### PR TITLE
Fixes one of the cases in directive attribute completion

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/AbstractRazorCompletionFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/AbstractRazorCompletionFactsService.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.VisualStudio.Editor.Razor;
 
@@ -76,6 +77,16 @@ internal abstract class AbstractRazorCompletionFactsService(ImmutableArray<IRazo
         {
             Debug.Assert(previousToken2.Span.End == requestIndex);
             return previousToken2.Parent;
+        }
+
+        // If we have @ transition right in front of an existing equals and caret is after @, e.g.
+        // <button @|="OnClick"></button>
+        // we get entire attribute from FindInnermostNode. We always want the attribute name as the context in such cases,
+        // so we adjust it to be the attrbute name node.
+        if (originalNode is MarkupAttributeBlockSyntax markupAttribute
+            && markupAttribute.EqualsToken.SpanStart == requestIndex)
+        {
+            return markupAttribute.Name;
         }
 
         return originalNode;

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/CompletionIntegrationTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/CompletionIntegrationTests.cs
@@ -143,6 +143,29 @@ public class CompletionIntegrationTests(ITestOutputHelper testOutputHelper) : Ab
     }
 
     [IdeFact]
+    public async Task CompletionCommit_BlazorDirectiveAttribute()
+    {
+        await VerifyTypeAndCommitCompletionAsync(
+            input: """
+                @page "/test"
+
+                <PageTitle>Test</PageTitle>
+
+                <select @=""></select>
+                """,
+            output: """
+                @page "/test"
+                
+                <PageTitle>Test</PageTitle>
+
+                <select @onactivate=""></select>
+                """,
+            search: "<select @",
+            stringsToType: ["o", "n", "a", "c"],
+            expectedSelectedItemLabel: "@onactivate");
+    }
+
+    [IdeFact]
     public async Task CompletionCommit_HtmlTag()
     {
         await VerifyTypeAndCommitCompletionAsync(


### PR DESCRIPTION
When we have @ symbol in front of existing = symbol in an attribute, we weren't getting directive attributes in the completion. We are adding one more case to check to AdjustSyntaxNodeForWordBoundary to fix this.

﻿### Summary of the changes

-This is another case where replacing Locate with FindInnermostNode caused an issue in one of the edge cases. If you already have an existing @="" attribute and you tried typing after @, you didn't get any of the directive attributes, e.g. @onclick. This PR adds anothe adjustment to account for this case.

Fixes:
https://github.com/dotnet/razor/issues/11890