### PR TITLE
Don't produce RazorSourceDocuments for imports with incorrect file paths

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/CompilationHelpers.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/CompilationHelpers.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
@@ -39,7 +39,7 @@ internal static class CompilationHelpers
         return generator.GenerateDesignTime(source, document.FileKind, importSources, tagHelpers, cancellationToken);
     }
 
-    private static async Task<ImmutableArray<RazorSourceDocument>> GetImportSourcesAsync(IDocumentSnapshot document, RazorProjectEngine projectEngine, CancellationToken cancellationToken)
+    internal static async Task<ImmutableArray<RazorSourceDocument>> GetImportSourcesAsync(IDocumentSnapshot document, RazorProjectEngine projectEngine, CancellationToken cancellationToken)
     {
         // We don't use document.FilePath when calling into GetItem(...) because
         // it could be rooted outside of the project root. document.TargetPath should

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/CompilationHelpers.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/CompilationHelpers.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
@@ -74,9 +74,7 @@ internal static class CompilationHelpers
             }
             else if (project.TryGetDocument(importProjectItem.PhysicalPath, out var importDocument))
             {
-                var text = await importDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
-                var properties = RazorSourceDocumentProperties.Create(importProjectItem.FilePath, importProjectItem.RelativePhysicalPath);
-                var importSource = RazorSourceDocument.Create(text, properties);
+                var importSource = await importDocument.GetSourceAsync(cancellationToken).ConfigureAwait(false);
 
                 importSources.Add(importSource);
             }


### PR DESCRIPTION
A bug introduced in https://github.com/dotnet/razor/commit/ac6e32a73fb93b3c699269fa432efac38fe4d5fe causes `RazorSourceDocuments` for imports to be created with the wrong file paths. Instead of a pointing to a physical file path on disk, they contain a relative path, which causes incorrect code generation. To fix this, call the GetSourceAsync(...) helper for the import. That populates the `RazorSourceDocument` with the correct paths.