### PR TITLE
Compiler: Optimize SyntaxList<TNode>, SyntaxTokenList and PooledArrayBuilder<T> operations

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Syntax/SyntaxListTests.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Syntax/SyntaxListTests.cs
@@ -1,0 +1,1169 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.PooledObjects;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Language.Syntax;
+
+public class SyntaxListTests
+{
+    private static MarkupTextLiteralSyntax CreateMarkupTextLiteral(params ReadOnlySpan<SyntaxToken> tokens)
+    {
+        using var builder = new PooledArrayBuilder<SyntaxToken>(tokens.Length);
+        builder.AddRange(tokens);
+
+        return SyntaxFactory.MarkupTextLiteral(builder.ToList(), chunkGenerator: null);
+    }
+
+    private static readonly SyntaxToken s_openAngle = SyntaxFactory.Token(SyntaxKind.OpenAngle, "<");
+    private static readonly SyntaxToken s_closeAngle = SyntaxFactory.Token(SyntaxKind.CloseAngle, ">");
+    private static readonly SyntaxToken s_leftBrace = SyntaxFactory.Token(SyntaxKind.LeftBrace, "{");
+    private static readonly SyntaxToken s_rightBrace = SyntaxFactory.Token(SyntaxKind.RightBrace, "}");
+    private static readonly SyntaxToken s_forwardSlash = SyntaxFactory.Token(SyntaxKind.ForwardSlash, "/");
+
+    [Fact]
+    public void Add_WhenListIsEmpty_AddsNodeAtEnd()
+    {
+        // Arrange
+        var emptyList = new SyntaxList<SyntaxNode>();
+        var node = CreateMarkupTextLiteral(s_openAngle);
+
+        // Act
+        var newList = emptyList.Add(node);
+
+        // Assert
+        Assert.Empty(emptyList);
+        Assert.Single(newList);
+        Assert.True(node.IsEquivalentTo(newList[0]));
+    }
+
+    [Fact]
+    public void Add_WhenListHasNodes_AddsNodeAtEnd()
+    {
+        // Arrange
+        var existingNode = CreateMarkupTextLiteral(s_openAngle);
+        var originalList = new SyntaxList<SyntaxNode>(existingNode);
+        var nodeToAdd = CreateMarkupTextLiteral(s_closeAngle);
+
+        // Act
+        var newList = originalList.Add(nodeToAdd);
+
+        // Assert
+        Assert.Single(originalList);
+        Assert.Equal(2, newList.Count);
+        Assert.True(existingNode.IsEquivalentTo(newList[0]));
+        Assert.True(nodeToAdd.IsEquivalentTo(newList[1]));
+    }
+
+    [Fact]
+    public void Add_WithMultipleNodes_AddsNodesInOrder()
+    {
+        // Arrange
+        var node1 = CreateMarkupTextLiteral(s_openAngle);
+        var node2 = CreateMarkupTextLiteral(s_closeAngle);
+        var node3 = CreateMarkupTextLiteral(s_leftBrace);
+
+        // Act
+        var list = new SyntaxList<SyntaxNode>();
+        var list1 = list.Add(node1);
+        var list2 = list1.Add(node2);
+        var list3 = list2.Add(node3);
+
+        // Assert
+        Assert.Empty(list);
+        Assert.Single(list1);
+        Assert.Equal(2, list2.Count);
+        Assert.Equal(3, list3.Count);
+
+        Assert.True(node1.IsEquivalentTo(list1[0]));
+        Assert.True(node1.IsEquivalentTo(list2[0]));
+        Assert.True(node2.IsEquivalentTo(list2[1]));
+        Assert.True(node1.IsEquivalentTo(list3[0]));
+        Assert.True(node2.IsEquivalentTo(list3[1]));
+        Assert.True(node3.IsEquivalentTo(list3[2]));
+    }
+
+    [Fact]
+    public void Add_ImplementsImmutability_DoesNotModifyOriginalList()
+    {
+        // Arrange
+        var node1 = CreateMarkupTextLiteral(s_openAngle);
+        var node2 = CreateMarkupTextLiteral(s_closeAngle);
+        var originalList = new SyntaxList<SyntaxNode>(node1);
+
+        // Act
+        var newList = originalList.Add(node2);
+
+        // Assert
+        Assert.Single(originalList);
+        Assert.True(node1.IsEquivalentTo(originalList[0]));
+        Assert.Equal(2, newList.Count);
+    }
+
+    [Fact]
+    public void Add_DelegatesToInsert_WithCorrectIndex()
+    {
+        // Arrange
+        var node1 = CreateMarkupTextLiteral(s_openAngle);
+        var node2 = CreateMarkupTextLiteral(s_closeAngle);
+        var originalList = new SyntaxList<SyntaxNode>(node1);
+
+        // Act
+        var addResult = originalList.Add(node2);
+        var insertResult = originalList.Insert(originalList.Count, node2);
+
+        // Assert
+        Assert.Equal(addResult.Count, insertResult.Count);
+
+        for (var i = 0; i < addResult.Count; i++)
+        {
+            Assert.True(addResult[i].IsEquivalentTo(insertResult[i]));
+        }
+    }
+
+    [Fact]
+    public void Add_ThrowsArgumentNullException_WhenNodeIsNull()
+    {
+        // Arrange
+        var list = new SyntaxList<SyntaxNode>();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => list.Add(null!));
+    }
+
+    [Fact]
+    public void AddRange_WhenListIsEmpty_AddsAllNodes()
+    {
+        // Arrange
+        var emptyList = new SyntaxList<SyntaxNode>();
+        SyntaxNode[] nodesToAdd = [
+            CreateMarkupTextLiteral(s_openAngle),
+            CreateMarkupTextLiteral(s_forwardSlash),
+            CreateMarkupTextLiteral(s_closeAngle)
+        ];
+
+        // Act
+        var newList = emptyList.AddRange(nodesToAdd);
+
+        // Assert
+        Assert.Empty(emptyList);
+        Assert.Equal(nodesToAdd.Length, newList.Count);
+
+        for (var i = 0; i < nodesToAdd.Length; i++)
+        {
+            Assert.True(nodesToAdd[i].IsEquivalentTo(newList[i]));
+        }
+    }
+
+    [Fact]
+    public void AddRange_WhenListHasNodes_AddsNodesToEnd()
+    {
+        // Arrange
+        var existingNode = CreateMarkupTextLiteral(s_openAngle);
+        var originalList = new SyntaxList<SyntaxNode>(existingNode);
+
+        SyntaxNode[] nodesToAdd = [
+            CreateMarkupTextLiteral(s_forwardSlash),
+            CreateMarkupTextLiteral(s_closeAngle)
+        ];
+
+        // Act
+        var newList = originalList.AddRange(nodesToAdd);
+
+        // Assert
+        Assert.Single(originalList);
+        Assert.Equal(1 + nodesToAdd.Length, newList.Count);
+
+        Assert.True(existingNode.IsEquivalentTo(newList[0]));
+        Assert.True(nodesToAdd[0].IsEquivalentTo(newList[1]));
+        Assert.True(nodesToAdd[1].IsEquivalentTo(newList[2]));
+    }
+
+    [Fact]
+    public void AddRange_WithEmptyCollection_ReturnsSameList()
+    {
+        // Arrange
+        var node = CreateMarkupTextLiteral(s_openAngle);
+        var originalList = new SyntaxList<SyntaxNode>(node);
+        var emptyNodes = Array.Empty<SyntaxNode>();
+
+        // Act
+        var newList = originalList.AddRange(emptyNodes);
+
+        // Assert
+        Assert.Equal(originalList.Count, newList.Count);
+        Assert.True(originalList[0].IsEquivalentTo(newList[0]));
+    }
+
+    [Fact]
+    public void AddRange_ImplementsImmutability_DoesNotModifyOriginalList()
+    {
+        // Arrange
+        var existingNode = CreateMarkupTextLiteral(s_openAngle);
+        var originalList = new SyntaxList<SyntaxNode>(existingNode);
+
+        SyntaxNode[] nodesToAdd = [
+            CreateMarkupTextLiteral(s_forwardSlash),
+            CreateMarkupTextLiteral(s_closeAngle)
+        ];
+
+        // Act
+        var newList = originalList.AddRange(nodesToAdd);
+
+        // Assert
+        Assert.Single(originalList);
+        Assert.True(existingNode.IsEquivalentTo(originalList[0]));
+        Assert.Equal(3, newList.Count);
+    }
+
+    [Fact]
+    public void AddRange_DelegatesToInsertRange_WithCorrectIndex()
+    {
+        // Arrange
+        var existingNode = CreateMarkupTextLiteral(s_openAngle);
+        var originalList = new SyntaxList<SyntaxNode>(existingNode);
+
+        SyntaxNode[] nodesToAdd = [
+            CreateMarkupTextLiteral(s_forwardSlash),
+            CreateMarkupTextLiteral(s_closeAngle)
+        ];
+
+        // Act
+        var addResult = originalList.AddRange(nodesToAdd);
+        var insertResult = originalList.InsertRange(originalList.Count, nodesToAdd);
+
+        // Assert
+        Assert.Equal(addResult.Count, insertResult.Count);
+        for (var i = 0; i < addResult.Count; i++)
+        {
+            Assert.True(addResult[i].IsEquivalentTo(insertResult[i]));
+        }
+    }
+
+    [Fact]
+    public void AddRange_ThrowsArgumentNullException_WhenNodesIsNull()
+    {
+        // Arrange
+        var list = new SyntaxList<SyntaxNode>();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => list.AddRange(null!));
+    }
+
+    [Fact]
+    public void AddRange_WithDifferentNodeTypes_AddsAllNodes()
+    {
+        // Arrange
+        var emptyList = new SyntaxList<SyntaxNode>();
+
+        // Create different types of syntax nodes
+        SyntaxNode[] mixedNodes = [
+            CreateMarkupTextLiteral(s_openAngle),
+            SyntaxFactory.MarkupBlock(),
+            SyntaxFactory.MarkupTagHelperAttributeValue()
+        ];
+
+        // Act
+        var newList = emptyList.AddRange(mixedNodes);
+
+        // Assert
+        Assert.Equal(mixedNodes.Length, newList.Count);
+
+        for (var i = 0; i < mixedNodes.Length; i++)
+        {
+            Assert.True(mixedNodes[i].IsEquivalentTo(newList[i]));
+            Assert.Equal(mixedNodes[i].Kind, newList[i].Kind);
+        }
+    }
+
+    [Fact]
+    public void AddRange_WithListAsSource_AddsAllNodes()
+    {
+        // Arrange
+        var emptyList = new SyntaxList<SyntaxNode>();
+        List<SyntaxNode> nodesList = [
+            CreateMarkupTextLiteral(s_openAngle),
+            CreateMarkupTextLiteral(s_forwardSlash),
+            CreateMarkupTextLiteral(s_closeAngle)
+        ];
+
+        // Act
+        var newList = emptyList.AddRange(nodesList);
+
+        // Assert
+        Assert.Equal(nodesList.Count, newList.Count);
+
+        for (var i = 0; i < nodesList.Count; i++)
+        {
+            Assert.True(nodesList[i].IsEquivalentTo(newList[i]));
+        }
+    }
+
+    [Fact]
+    public void AddRange_WithIEnumerableAsSource_AddsAllNodes()
+    {
+        // Arrange
+        var emptyList = new SyntaxList<SyntaxNode>();
+
+        IEnumerable<SyntaxNode> nodes = [
+            CreateMarkupTextLiteral(s_openAngle),
+            CreateMarkupTextLiteral(s_forwardSlash),
+            CreateMarkupTextLiteral(s_closeAngle)
+        ];
+
+        // Act
+        var newList = emptyList.AddRange(nodes);
+
+        // Assert
+        Assert.Equal(3, newList.Count);
+
+        var index = 0;
+        foreach (var node in nodes)
+        {
+            Assert.True(node.IsEquivalentTo(newList[index++]));
+        }
+    }
+
+    [Fact]
+    public void Insert_AtBeginning_InsertsNodeAtStart()
+    {
+        // Arrange
+        var node1 = CreateMarkupTextLiteral(s_closeAngle);
+        var node2 = CreateMarkupTextLiteral(s_rightBrace);
+        var originalList = new SyntaxList<SyntaxNode>(node1).Add(node2);
+        var nodeToInsert = CreateMarkupTextLiteral(s_openAngle);
+
+        // Act
+        var newList = originalList.Insert(0, nodeToInsert);
+
+        // Assert
+        Assert.Equal(2, originalList.Count);
+        Assert.Equal(3, newList.Count);
+        Assert.True(nodeToInsert.IsEquivalentTo(newList[0]));
+        Assert.True(node1.IsEquivalentTo(newList[1]));
+        Assert.True(node2.IsEquivalentTo(newList[2]));
+    }
+
+    [Fact]
+    public void Insert_AtMiddle_InsertsNodeAtCorrectPosition()
+    {
+        // Arrange
+        var node1 = CreateMarkupTextLiteral(s_openAngle);
+        var node2 = CreateMarkupTextLiteral(s_closeAngle);
+        var originalList = new SyntaxList<SyntaxNode>(node1).Add(node2);
+        var nodeToInsert = CreateMarkupTextLiteral(s_forwardSlash);
+
+        // Act
+        var newList = originalList.Insert(1, nodeToInsert);
+
+        // Assert
+        Assert.Equal(2, originalList.Count);
+        Assert.Equal(3, newList.Count);
+        Assert.True(node1.IsEquivalentTo(newList[0]));
+        Assert.True(nodeToInsert.IsEquivalentTo(newList[1]));
+        Assert.True(node2.IsEquivalentTo(newList[2]));
+    }
+
+    [Fact]
+    public void Insert_AtEnd_SameAsAdd()
+    {
+        // Arrange
+        var node1 = CreateMarkupTextLiteral(s_openAngle);
+        var node2 = CreateMarkupTextLiteral(s_forwardSlash);
+        var originalList = new SyntaxList<SyntaxNode>(node1).Add(node2);
+        var nodeToInsert = CreateMarkupTextLiteral(s_closeAngle);
+
+        // Act
+        var insertResult = originalList.Insert(originalList.Count, nodeToInsert);
+        var addResult = originalList.Add(nodeToInsert);
+
+        // Assert
+        Assert.Equal(addResult.Count, insertResult.Count);
+        for (var i = 0; i < addResult.Count; i++)
+        {
+            Assert.True(addResult[i].IsEquivalentTo(insertResult[i]));
+        }
+    }
+
+    [Fact]
+    public void Insert_IntoEmptyList_CreatesSingleItemList()
+    {
+        // Arrange
+        var emptyList = new SyntaxList<SyntaxNode>();
+        var node = CreateMarkupTextLiteral(s_openAngle);
+
+        // Act
+        var newList = emptyList.Insert(0, node);
+
+        // Assert
+        Assert.Empty(emptyList);
+        Assert.Single(newList);
+        Assert.True(node.IsEquivalentTo(newList[0]));
+    }
+
+    [Fact]
+    public void Insert_ImplementsImmutability_DoesNotModifyOriginalList()
+    {
+        // Arrange
+        var node1 = CreateMarkupTextLiteral(s_openAngle);
+        var originalList = new SyntaxList<SyntaxNode>(node1);
+        var nodeToInsert = CreateMarkupTextLiteral(s_forwardSlash);
+
+        // Act
+        var newList = originalList.Insert(0, nodeToInsert);
+
+        // Assert
+        Assert.Single(originalList);
+        Assert.True(node1.IsEquivalentTo(originalList[0]));
+        Assert.Equal(2, newList.Count);
+    }
+
+    [Fact]
+    public void Insert_ThrowsArgumentNullException_WhenNodeIsNull()
+    {
+        // Arrange
+        var list = new SyntaxList<SyntaxNode>(CreateMarkupTextLiteral(s_openAngle));
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => list.Insert(0, null!));
+    }
+
+    [Fact]
+    public void Insert_ThrowsArgumentOutOfRangeException_WhenIndexIsNegative()
+    {
+        // Arrange
+        var list = new SyntaxList<SyntaxNode>(CreateMarkupTextLiteral(s_openAngle));
+        var node = CreateMarkupTextLiteral(s_closeAngle);
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.Insert(-1, node));
+    }
+
+    [Fact]
+    public void Insert_ThrowsArgumentOutOfRangeException_WhenIndexExceedsCount()
+    {
+        // Arrange
+        var list = new SyntaxList<SyntaxNode>(CreateMarkupTextLiteral(s_openAngle));
+        var node = CreateMarkupTextLiteral(s_closeAngle);
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.Insert(list.Count + 1, node));
+    }
+
+    [Fact]
+    public void InsertRange_AtBeginning_InsertsNodesAtStart()
+    {
+        // Arrange
+        var existingNode = CreateMarkupTextLiteral(s_closeAngle);
+        var originalList = new SyntaxList<SyntaxNode>(existingNode);
+
+        SyntaxNode[] nodesToInsert = [
+            CreateMarkupTextLiteral(s_openAngle),
+            CreateMarkupTextLiteral(s_forwardSlash)
+        ];
+
+        // Act
+        var newList = originalList.InsertRange(0, nodesToInsert);
+
+        // Assert
+        Assert.Single(originalList);
+        Assert.Equal(nodesToInsert.Length + 1, newList.Count);
+        Assert.True(nodesToInsert[0].IsEquivalentTo(newList[0]));
+        Assert.True(nodesToInsert[1].IsEquivalentTo(newList[1]));
+        Assert.True(existingNode.IsEquivalentTo(newList[2]));
+    }
+
+    [Fact]
+    public void InsertRange_AtMiddle_InsertsNodesAtCorrectPosition()
+    {
+        // Arrange
+        var node1 = CreateMarkupTextLiteral(s_openAngle);
+        var node2 = CreateMarkupTextLiteral(s_closeAngle);
+        var originalList = new SyntaxList<SyntaxNode>(node1).Add(node2);
+
+        SyntaxNode[] nodesToInsert = [
+            CreateMarkupTextLiteral(s_forwardSlash),
+            CreateMarkupTextLiteral(s_rightBrace)
+        ];
+
+        // Act
+        var newList = originalList.InsertRange(1, nodesToInsert);
+
+        // Assert
+        Assert.Equal(2, originalList.Count);
+        Assert.Equal(originalList.Count + nodesToInsert.Length, newList.Count);
+        Assert.True(node1.IsEquivalentTo(newList[0]));
+        Assert.True(nodesToInsert[0].IsEquivalentTo(newList[1]));
+        Assert.True(nodesToInsert[1].IsEquivalentTo(newList[2]));
+        Assert.True(node2.IsEquivalentTo(newList[3]));
+    }
+
+    [Fact]
+    public void InsertRange_AtEnd_SameAsAddRange()
+    {
+        // Arrange
+        var node1 = CreateMarkupTextLiteral(s_openAngle);
+        var originalList = new SyntaxList<SyntaxNode>(node1);
+
+        SyntaxNode[] nodesToInsert = [
+            CreateMarkupTextLiteral(s_forwardSlash),
+            CreateMarkupTextLiteral(s_closeAngle)
+        ];
+
+        // Act
+        var insertResult = originalList.InsertRange(originalList.Count, nodesToInsert);
+        var addResult = originalList.AddRange(nodesToInsert);
+
+        // Assert
+        Assert.Equal(addResult.Count, insertResult.Count);
+        for (var i = 0; i < addResult.Count; i++)
+        {
+            Assert.True(addResult[i].IsEquivalentTo(insertResult[i]));
+        }
+    }
+
+    [Fact]
+    public void InsertRange_WithEmptyCollection_ReturnsSameList()
+    {
+        // Arrange
+        var node = CreateMarkupTextLiteral(s_openAngle);
+        var originalList = new SyntaxList<SyntaxNode>(node);
+        var emptyNodes = Array.Empty<SyntaxNode>();
+
+        // Act
+        var newList = originalList.InsertRange(0, emptyNodes);
+
+        // Assert
+        Assert.Equal(originalList.Count, newList.Count);
+        Assert.True(originalList[0].IsEquivalentTo(newList[0]));
+    }
+
+    [Fact]
+    public void InsertRange_IntoEmptyList_CreatesListWithAllNodes()
+    {
+        // Arrange
+        var emptyList = new SyntaxList<SyntaxNode>();
+        
+        SyntaxNode[] nodesToInsert = [
+            CreateMarkupTextLiteral(s_openAngle),
+            CreateMarkupTextLiteral(s_forwardSlash),
+            CreateMarkupTextLiteral(s_closeAngle)
+        ];
+
+        // Act
+        var newList = emptyList.InsertRange(0, nodesToInsert);
+
+        // Assert
+        Assert.Empty(emptyList);
+        Assert.Equal(nodesToInsert.Length, newList.Count);
+        
+        for (var i = 0; i < nodesToInsert.Length; i++)
+        {
+            Assert.True(nodesToInsert[i].IsEquivalentTo(newList[i]));
+        }
+    }
+
+    [Fact]
+    public void InsertRange_ImplementsImmutability_DoesNotModifyOriginalList()
+    {
+        // Arrange
+        var existingNode = CreateMarkupTextLiteral(s_openAngle);
+        var originalList = new SyntaxList<SyntaxNode>(existingNode);
+
+        SyntaxNode[] nodesToInsert = [
+            CreateMarkupTextLiteral(s_forwardSlash),
+            CreateMarkupTextLiteral(s_closeAngle)
+        ];
+
+        // Act
+        var newList = originalList.InsertRange(0, nodesToInsert);
+
+        // Assert
+        Assert.Single(originalList);
+        Assert.True(existingNode.IsEquivalentTo(originalList[0]));
+        Assert.Equal(3, newList.Count);
+    }
+
+    [Fact]
+    public void InsertRange_ThrowsArgumentNullException_WhenNodesIsNull()
+    {
+        // Arrange
+        var list = new SyntaxList<SyntaxNode>(CreateMarkupTextLiteral(s_openAngle));
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => list.InsertRange(0, null!));
+    }
+
+    [Fact]
+    public void InsertRange_ThrowsArgumentOutOfRangeException_WhenIndexIsNegative()
+    {
+        // Arrange
+        var list = new SyntaxList<SyntaxNode>(CreateMarkupTextLiteral(s_openAngle));
+        var nodes = new[] { CreateMarkupTextLiteral(s_closeAngle) };
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.InsertRange(-1, nodes));
+    }
+
+    [Fact]
+    public void InsertRange_ThrowsArgumentOutOfRangeException_WhenIndexExceedsCount()
+    {
+        // Arrange
+        var list = new SyntaxList<SyntaxNode>(CreateMarkupTextLiteral(s_openAngle));
+        var nodes = new[] { CreateMarkupTextLiteral(s_closeAngle) };
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.InsertRange(list.Count + 1, nodes));
+    }
+
+    [Fact]
+    public void InsertRange_WithListAsSource_InsertsAllNodes()
+    {
+        // Arrange
+        var existingNode = CreateMarkupTextLiteral(s_openAngle);
+        var originalList = new SyntaxList<SyntaxNode>(existingNode);
+
+        List<SyntaxNode> nodesToInsert = [
+            CreateMarkupTextLiteral(s_forwardSlash),
+            CreateMarkupTextLiteral(s_closeAngle)
+        ];
+
+        // Act
+        var newList = originalList.InsertRange(0, nodesToInsert);
+
+        // Assert
+        Assert.Single(originalList);
+        Assert.Equal(nodesToInsert.Count + 1, newList.Count);
+        
+        for (var i = 0; i < nodesToInsert.Count; i++)
+        {
+            Assert.True(nodesToInsert[i].IsEquivalentTo(newList[i]));
+        }
+        Assert.True(existingNode.IsEquivalentTo(newList[^1]));
+    }
+
+    [Fact]
+    public void InsertRange_WithIEnumerableAsSource_InsertsAllNodes()
+    {
+        // Arrange
+        var existingNode = CreateMarkupTextLiteral(s_closeAngle);
+        var originalList = new SyntaxList<SyntaxNode>(existingNode);
+
+        IEnumerable<SyntaxNode> nodesToInsert = [
+            CreateMarkupTextLiteral(s_openAngle),
+            CreateMarkupTextLiteral(s_forwardSlash)
+        ];
+
+        // Act
+        var newList = originalList.InsertRange(0, nodesToInsert);
+
+        // Assert
+        Assert.Single(originalList);
+        Assert.Equal(3, newList.Count);
+        
+        var index = 0;
+        foreach (var node in nodesToInsert)
+        {
+            Assert.True(node.IsEquivalentTo(newList[index++]));
+        }
+        Assert.True(existingNode.IsEquivalentTo(newList[^1]));
+    }
+
+    [Fact]
+    public void RemoveAt_SingleElementList_ReturnsEmptyList()
+    {
+        // Arrange
+        var node = CreateMarkupTextLiteral(s_openAngle);
+        var originalList = new SyntaxList<SyntaxNode>(node);
+
+        // Act
+        var newList = originalList.RemoveAt(0);
+
+        // Assert
+        Assert.Single(originalList);
+        Assert.Empty(newList);
+    }
+
+    [Fact]
+    public void RemoveAt_FromBeginning_RemovesCorrectNode()
+    {
+        // Arrange
+        var node1 = CreateMarkupTextLiteral(s_openAngle);
+        var node2 = CreateMarkupTextLiteral(s_forwardSlash);
+        var node3 = CreateMarkupTextLiteral(s_closeAngle);
+        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2, node3]);
+
+        // Act
+        var newList = originalList.RemoveAt(0);
+
+        // Assert
+        Assert.Equal(3, originalList.Count);
+        Assert.Equal(2, newList.Count);
+        Assert.True(node2.IsEquivalentTo(newList[0]));
+        Assert.True(node3.IsEquivalentTo(newList[1]));
+    }
+
+    [Fact]
+    public void RemoveAt_FromMiddle_RemovesCorrectNode()
+    {
+        // Arrange
+        var node1 = CreateMarkupTextLiteral(s_openAngle);
+        var node2 = CreateMarkupTextLiteral(s_forwardSlash);
+        var node3 = CreateMarkupTextLiteral(s_closeAngle);
+        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2, node3]);
+
+        // Act
+        var newList = originalList.RemoveAt(1);
+
+        // Assert
+        Assert.Equal(3, originalList.Count);
+        Assert.Equal(2, newList.Count);
+        Assert.True(node1.IsEquivalentTo(newList[0]));
+        Assert.True(node3.IsEquivalentTo(newList[1]));
+    }
+
+    [Fact]
+    public void RemoveAt_FromEnd_RemovesCorrectNode()
+    {
+        // Arrange
+        var node1 = CreateMarkupTextLiteral(s_openAngle);
+        var node2 = CreateMarkupTextLiteral(s_forwardSlash);
+        var node3 = CreateMarkupTextLiteral(s_closeAngle);
+        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2, node3]);
+
+        // Act
+        var newList = originalList.RemoveAt(2);
+
+        // Assert
+        Assert.Equal(3, originalList.Count);
+        Assert.Equal(2, newList.Count);
+        Assert.True(node1.IsEquivalentTo(newList[0]));
+        Assert.True(node2.IsEquivalentTo(newList[1]));
+    }
+
+    [Fact]
+    public void RemoveAt_ThrowsArgumentOutOfRangeException_WhenIndexIsNegative()
+    {
+        // Arrange
+        var node = CreateMarkupTextLiteral(s_openAngle);
+        var list = new SyntaxList<SyntaxNode>(node);
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.RemoveAt(-1));
+    }
+
+    [Fact]
+    public void RemoveAt_ThrowsArgumentOutOfRangeException_WhenIndexExceedsOrEqualsCount()
+    {
+        // Arrange
+        var node = CreateMarkupTextLiteral(s_openAngle);
+        var list = new SyntaxList<SyntaxNode>(node);
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.RemoveAt(list.Count));
+    }
+
+    [Fact]
+    public void RemoveAt_ImplementsImmutability_DoesNotModifyOriginalList()
+    {
+        // Arrange
+        var node1 = CreateMarkupTextLiteral(s_openAngle);
+        var node2 = CreateMarkupTextLiteral(s_forwardSlash);
+        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2]);
+
+        // Act
+        var newList = originalList.RemoveAt(0);
+
+        // Assert
+        Assert.Equal(2, originalList.Count);
+        Assert.True(node1.IsEquivalentTo(originalList[0]));
+        Assert.True(node2.IsEquivalentTo(originalList[1]));
+        Assert.Single(newList);
+    }
+
+    [Fact]
+    public void RemoveAt_DelegatesToRemove_WithCorrectNode()
+    {
+        // Arrange
+        var node1 = CreateMarkupTextLiteral(s_openAngle);
+        var node2 = CreateMarkupTextLiteral(s_forwardSlash);
+        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2]);
+
+        // Act
+        var removeAtResult = originalList.RemoveAt(0);
+        var removeResult = originalList.Remove(originalList[0]);
+
+        // Assert
+        Assert.Equal(removeResult.Count, removeAtResult.Count);
+        for (var i = 0; i < removeResult.Count; i++)
+        {
+            Assert.True(removeResult[i].IsEquivalentTo(removeAtResult[i]));
+        }
+    }
+
+    [Fact]
+    public void Remove_SingleElementList_ReturnsEmptyList()
+    {
+        // Arrange
+        var node = CreateMarkupTextLiteral(s_openAngle);
+        var originalList = new SyntaxList<SyntaxNode>(node);
+
+        // Act
+        var newList = originalList.Remove(node);
+
+        // Assert
+        Assert.Single(originalList);
+        Assert.Empty(newList);
+    }
+
+    [Fact]
+    public void Remove_FromList_RemovesMatchingNode()
+    {
+        // Arrange
+        var node1 = CreateMarkupTextLiteral(s_openAngle);
+        var node2 = CreateMarkupTextLiteral(s_forwardSlash);
+        var node3 = CreateMarkupTextLiteral(s_closeAngle);
+        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2, node3]);
+
+        // Act
+        var newList = originalList.Remove(originalList[1]);
+
+        // Assert
+        Assert.Equal(3, originalList.Count);
+        Assert.Equal(2, newList.Count);
+        Assert.True(node1.IsEquivalentTo(newList[0]));
+        Assert.True(node3.IsEquivalentTo(newList[1]));
+    }
+
+    [Fact]
+    public void Remove_NodeNotInList_ReturnsSameList()
+    {
+        // Arrange
+        var node1 = CreateMarkupTextLiteral(s_openAngle);
+        var node2 = CreateMarkupTextLiteral(s_forwardSlash);
+        var nodeNotInList = CreateMarkupTextLiteral(s_closeAngle);
+        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2]);
+
+        // Act
+        var newList = originalList.Remove(nodeNotInList);
+
+        // Assert
+        Assert.Equal(2, originalList.Count);
+        Assert.Equal(2, newList.Count);
+        Assert.True(node1.IsEquivalentTo(newList[0]));
+        Assert.True(node2.IsEquivalentTo(newList[1]));
+    }
+
+    [Fact]
+    public void Remove_ImplementsImmutability_DoesNotModifyOriginalList()
+    {
+        // Arrange
+        var node1 = CreateMarkupTextLiteral(s_openAngle);
+        var node2 = CreateMarkupTextLiteral(s_forwardSlash);
+        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2]);
+
+        // Act
+        var newList = originalList.Remove(originalList[0]);
+
+        // Assert
+        Assert.Equal(2, originalList.Count);
+        Assert.True(node1.IsEquivalentTo(originalList[0]));
+        Assert.True(node2.IsEquivalentTo(originalList[1]));
+        Assert.Single(newList);
+    }
+
+    [Fact]
+    public void Remove_FromEmptyList_ReturnsEmptyList()
+    {
+        // Arrange
+        var emptyList = new SyntaxList<SyntaxNode>();
+        var node = CreateMarkupTextLiteral(s_openAngle);
+
+        // Act
+        var newList = emptyList.Remove(node);
+
+        // Assert
+        Assert.Empty(emptyList);
+        Assert.Empty(newList);
+    }
+
+    [Fact]
+    public void Replace_SingleNodeList_ReplacesNode()
+    {
+        // Arrange
+        var original = CreateMarkupTextLiteral(s_openAngle);
+        var replacement = CreateMarkupTextLiteral(s_closeAngle);
+        var originalList = new SyntaxList<SyntaxNode>(original);
+
+        // Act
+        var newList = originalList.Replace(original, replacement);
+
+        // Assert
+        Assert.Single(originalList);
+        Assert.Single(newList);
+        Assert.True(original.IsEquivalentTo(originalList[0]));
+        Assert.True(replacement.IsEquivalentTo(newList[0]));
+    }
+
+    [Fact]
+    public void Replace_MultiNodeList_ReplacesCorrectNode()
+    {
+        // Arrange
+        var node1 = CreateMarkupTextLiteral(s_openAngle);
+        var node2 = CreateMarkupTextLiteral(s_forwardSlash);
+        var node3 = CreateMarkupTextLiteral(s_closeAngle);
+        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2, node3]);
+        var replacement = CreateMarkupTextLiteral(s_leftBrace);
+
+        // Act
+        var newList = originalList.Replace(originalList[1], replacement);
+
+        // Assert
+        Assert.Equal(3, originalList.Count);
+        Assert.Equal(3, newList.Count);
+        Assert.True(node1.IsEquivalentTo(newList[0]));
+        Assert.True(replacement.IsEquivalentTo(newList[1]));
+        Assert.True(node3.IsEquivalentTo(newList[2]));
+    }
+
+    [Fact]
+    public void Replace_ImplementsImmutability_DoesNotModifyOriginalList()
+    {
+        // Arrange
+        var node1 = CreateMarkupTextLiteral(s_openAngle);
+        var node2 = CreateMarkupTextLiteral(s_forwardSlash);
+        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2]);
+        var replacement = CreateMarkupTextLiteral(s_closeAngle);
+
+        // Act
+        var newList = originalList.Replace(originalList[0], replacement);
+
+        // Assert
+        Assert.Equal(2, originalList.Count);
+        Assert.True(node1.IsEquivalentTo(originalList[0]));
+        Assert.True(node2.IsEquivalentTo(originalList[1]));
+        Assert.Equal(2, newList.Count);
+    }
+
+    [Fact]
+    public void Replace_ThrowsArgumentNullException_WhenNodeInListIsNull()
+    {
+        // Arrange
+        var node = CreateMarkupTextLiteral(s_openAngle);
+        var list = new SyntaxList<SyntaxNode>(node);
+        var replacement = CreateMarkupTextLiteral(s_closeAngle);
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => list.Replace(null!, replacement));
+    }
+
+    [Fact]
+    public void Replace_ThrowsArgumentNullException_WhenNewNodeIsNull()
+    {
+        // Arrange
+        var node = CreateMarkupTextLiteral(s_openAngle);
+        var list = new SyntaxList<SyntaxNode>(node);
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => list.Replace(list[0], null!));
+    }
+
+    [Fact]
+    public void Replace_ThrowsArgumentOutOfRangeException_WhenNodeNotInList()
+    {
+        // Arrange
+        var node = CreateMarkupTextLiteral(s_openAngle);
+        var nodeNotInList = CreateMarkupTextLiteral(s_forwardSlash);
+        var replacement = CreateMarkupTextLiteral(s_closeAngle);
+        var list = new SyntaxList<SyntaxNode>(node);
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.Replace(nodeNotInList, replacement));
+    }
+
+    [Fact]
+    public void Replace_DelegatesToReplaceRange_WithSingleElementArray()
+    {
+        // Arrange
+        var node1 = CreateMarkupTextLiteral(s_openAngle);
+        var node2 = CreateMarkupTextLiteral(s_forwardSlash);
+        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2]);
+        var replacement = CreateMarkupTextLiteral(s_closeAngle);
+
+        // Act
+        var replaceResult = originalList.Replace(originalList[0], replacement);
+        var replaceRangeResult = originalList.ReplaceRange(originalList[0], [replacement]);
+
+        // Assert
+        Assert.Equal(replaceResult.Count, replaceRangeResult.Count);
+        for (var i = 0; i < replaceResult.Count; i++)
+        {
+            Assert.True(replaceResult[i].IsEquivalentTo(replaceRangeResult[i]));
+        }
+    }
+
+    [Fact]
+    public void ReplaceRange_SingleNodeList_ReplacesNodeWithMultipleNodes()
+    {
+        // Arrange
+        var original = CreateMarkupTextLiteral(s_openAngle);
+        var replacement1 = CreateMarkupTextLiteral(s_forwardSlash);
+        var replacement2 = CreateMarkupTextLiteral(s_closeAngle);
+        var originalList = new SyntaxList<SyntaxNode>(original);
+
+        // Act
+        var newList = originalList.ReplaceRange(original, [replacement1, replacement2]);
+
+        // Assert
+        Assert.Single(originalList);
+        Assert.Equal(2, newList.Count);
+        Assert.True(replacement1.IsEquivalentTo(newList[0]));
+        Assert.True(replacement2.IsEquivalentTo(newList[1]));
+    }
+
+    [Fact]
+    public void ReplaceRange_MultiNodeList_ReplacesCorrectNodeWithMultipleNodes()
+    {
+        // Arrange
+        var node1 = CreateMarkupTextLiteral(s_openAngle);
+        var node2 = CreateMarkupTextLiteral(s_forwardSlash);
+        var node3 = CreateMarkupTextLiteral(s_closeAngle);
+        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2, node3]);
+        var replacement1 = CreateMarkupTextLiteral(s_leftBrace);
+        var replacement2 = CreateMarkupTextLiteral(s_rightBrace);
+
+        // Act
+        var newList = originalList.ReplaceRange(originalList[1], [replacement1, replacement2]);
+
+        // Assert
+        Assert.Equal(3, originalList.Count);
+        Assert.Equal(4, newList.Count);
+        Assert.True(node1.IsEquivalentTo(newList[0]));
+        Assert.True(replacement1.IsEquivalentTo(newList[1]));
+        Assert.True(replacement2.IsEquivalentTo(newList[2]));
+        Assert.True(node3.IsEquivalentTo(newList[3]));
+    }
+
+    [Fact]
+    public void ReplaceRange_MultiNodeList_ReplacesNodeWithEmptyList()
+    {
+        // Arrange
+        var node1 = CreateMarkupTextLiteral(s_openAngle);
+        var node2 = CreateMarkupTextLiteral(s_forwardSlash);
+        var node3 = CreateMarkupTextLiteral(s_closeAngle);
+        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2, node3]);
+
+        // Act
+        var newList = originalList.ReplaceRange(originalList[1], []);
+
+        // Assert
+        Assert.Equal(3, originalList.Count);
+        Assert.Equal(2, newList.Count);
+        Assert.True(node1.IsEquivalentTo(newList[0]));
+        Assert.True(node3.IsEquivalentTo(newList[1]));
+    }
+
+    [Fact]
+    public void ReplaceRange_ImplementsImmutability_DoesNotModifyOriginalList()
+    {
+        // Arrange
+        var node1 = CreateMarkupTextLiteral(s_openAngle);
+        var node2 = CreateMarkupTextLiteral(s_forwardSlash);
+        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2]);
+        var replacement1 = CreateMarkupTextLiteral(s_leftBrace);
+        var replacement2 = CreateMarkupTextLiteral(s_rightBrace);
+
+        // Act
+        var newList = originalList.ReplaceRange(originalList[0], [replacement1, replacement2]);
+
+        // Assert
+        Assert.Equal(2, originalList.Count);
+        Assert.True(node1.IsEquivalentTo(originalList[0]));
+        Assert.True(node2.IsEquivalentTo(originalList[1]));
+        Assert.Equal(3, newList.Count);
+    }
+
+    [Fact]
+    public void ReplaceRange_ThrowsArgumentNullException_WhenNodeInListIsNull()
+    {
+        // Arrange
+        var node = CreateMarkupTextLiteral(s_openAngle);
+        var list = new SyntaxList<SyntaxNode>(node);
+        var replacements = new[] { CreateMarkupTextLiteral(s_closeAngle) };
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => list.ReplaceRange(null!, replacements));
+    }
+
+    [Fact]
+    public void ReplaceRange_ThrowsArgumentNullException_WhenNewNodesIsNull()
+    {
+        // Arrange
+        var node = CreateMarkupTextLiteral(s_openAngle);
+        var list = new SyntaxList<SyntaxNode>(node);
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => list.ReplaceRange(node, null!));
+    }
+
+    [Fact]
+    public void ReplaceRange_ThrowsArgumentOutOfRangeException_WhenNodeNotInList()
+    {
+        // Arrange
+        var node = CreateMarkupTextLiteral(s_openAngle);
+        var nodeNotInList = CreateMarkupTextLiteral(s_forwardSlash);
+        var replacements = new[] { CreateMarkupTextLiteral(s_closeAngle) };
+        var list = new SyntaxList<SyntaxNode>(node);
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.ReplaceRange(nodeNotInList, replacements));
+    }
+
+    [Fact]
+    public void ReplaceRange_WithListAsSource_ReplacesNodeCorrectly()
+    {
+        // Arrange
+        var node = CreateMarkupTextLiteral(s_openAngle);
+        var list = new SyntaxList<SyntaxNode>(node);
+        List<SyntaxNode> replacements = [
+            CreateMarkupTextLiteral(s_forwardSlash),
+            CreateMarkupTextLiteral(s_closeAngle)
+        ];
+
+        // Act
+        var newList = list.ReplaceRange(node, replacements);
+
+        // Assert
+        Assert.Equal(replacements.Count, newList.Count);
+        for (var i = 0; i < replacements.Count; i++)
+        {
+            Assert.True(replacements[i].IsEquivalentTo(newList[i]));
+        }
+    }
+
+    [Fact]
+    public void ReplaceRange_WithIEnumerableAsSource_ReplacesNodeCorrectly()
+    {
+        // Arrange
+        var node = CreateMarkupTextLiteral(s_openAngle);
+        var list = new SyntaxList<SyntaxNode>(node);
+        IEnumerable<SyntaxNode> replacements = [
+            CreateMarkupTextLiteral(s_forwardSlash),
+            CreateMarkupTextLiteral(s_closeAngle)
+        ];
+
+        // Act
+        var newList = list.ReplaceRange(node, replacements);
+
+        // Assert
+        Assert.Equal(2, newList.Count);
+        var index = 0;
+        foreach (var replacement in replacements)
+        {
+            Assert.True(replacement.IsEquivalentTo(newList[index++]));
+        }
+    }
+}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Syntax/SyntaxListTests.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Syntax/SyntaxListTests.cs
@@ -28,7 +28,7 @@ public class SyntaxListTests
     public void Add_WhenListIsEmpty_AddsNodeAtEnd()
     {
         // Arrange
-        var emptyList = new SyntaxList<SyntaxNode>();
+        var emptyList = SyntaxList<SyntaxNode>.Empty;
         var node = CreateMarkupTextLiteral(s_openAngle);
 
         // Act
@@ -45,7 +45,7 @@ public class SyntaxListTests
     {
         // Arrange
         var existingNode = CreateMarkupTextLiteral(s_openAngle);
-        var originalList = new SyntaxList<SyntaxNode>(existingNode);
+        SyntaxList<SyntaxNode> originalList = [existingNode];
         var nodeToAdd = CreateMarkupTextLiteral(s_closeAngle);
 
         // Act
@@ -67,7 +67,7 @@ public class SyntaxListTests
         var node3 = CreateMarkupTextLiteral(s_leftBrace);
 
         // Act
-        var list = new SyntaxList<SyntaxNode>();
+        var list = SyntaxList<SyntaxNode>.Empty;
         var list1 = list.Add(node1);
         var list2 = list1.Add(node2);
         var list3 = list2.Add(node3);
@@ -92,7 +92,7 @@ public class SyntaxListTests
         // Arrange
         var node1 = CreateMarkupTextLiteral(s_openAngle);
         var node2 = CreateMarkupTextLiteral(s_closeAngle);
-        var originalList = new SyntaxList<SyntaxNode>(node1);
+        SyntaxList<SyntaxNode> originalList = [node1];
 
         // Act
         var newList = originalList.Add(node2);
@@ -109,7 +109,7 @@ public class SyntaxListTests
         // Arrange
         var node1 = CreateMarkupTextLiteral(s_openAngle);
         var node2 = CreateMarkupTextLiteral(s_closeAngle);
-        var originalList = new SyntaxList<SyntaxNode>(node1);
+        SyntaxList<SyntaxNode> originalList = [node1];
 
         // Act
         var addResult = originalList.Add(node2);
@@ -128,7 +128,7 @@ public class SyntaxListTests
     public void Add_ThrowsArgumentNullException_WhenNodeIsNull()
     {
         // Arrange
-        var list = new SyntaxList<SyntaxNode>();
+        var list = SyntaxList<SyntaxNode>.Empty;
 
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() => list.Add(null!));
@@ -138,7 +138,7 @@ public class SyntaxListTests
     public void AddRange_WhenListIsEmpty_AddsAllNodes()
     {
         // Arrange
-        var emptyList = new SyntaxList<SyntaxNode>();
+        var emptyList = SyntaxList<SyntaxNode>.Empty;
         SyntaxNode[] nodesToAdd = [
             CreateMarkupTextLiteral(s_openAngle),
             CreateMarkupTextLiteral(s_forwardSlash),
@@ -163,7 +163,7 @@ public class SyntaxListTests
     {
         // Arrange
         var existingNode = CreateMarkupTextLiteral(s_openAngle);
-        var originalList = new SyntaxList<SyntaxNode>(existingNode);
+        SyntaxList<SyntaxNode> originalList = [existingNode];
 
         SyntaxNode[] nodesToAdd = [
             CreateMarkupTextLiteral(s_forwardSlash),
@@ -187,7 +187,7 @@ public class SyntaxListTests
     {
         // Arrange
         var node = CreateMarkupTextLiteral(s_openAngle);
-        var originalList = new SyntaxList<SyntaxNode>(node);
+        SyntaxList<SyntaxNode> originalList = [node];
         var emptyNodes = Array.Empty<SyntaxNode>();
 
         // Act
@@ -203,7 +203,7 @@ public class SyntaxListTests
     {
         // Arrange
         var existingNode = CreateMarkupTextLiteral(s_openAngle);
-        var originalList = new SyntaxList<SyntaxNode>(existingNode);
+        SyntaxList<SyntaxNode> originalList = [existingNode];
 
         SyntaxNode[] nodesToAdd = [
             CreateMarkupTextLiteral(s_forwardSlash),
@@ -224,7 +224,7 @@ public class SyntaxListTests
     {
         // Arrange
         var existingNode = CreateMarkupTextLiteral(s_openAngle);
-        var originalList = new SyntaxList<SyntaxNode>(existingNode);
+        SyntaxList<SyntaxNode> originalList = [existingNode];
 
         SyntaxNode[] nodesToAdd = [
             CreateMarkupTextLiteral(s_forwardSlash),
@@ -247,7 +247,7 @@ public class SyntaxListTests
     public void AddRange_ThrowsArgumentNullException_WhenNodesIsNull()
     {
         // Arrange
-        var list = new SyntaxList<SyntaxNode>();
+        var list = SyntaxList<SyntaxNode>.Empty;
 
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() => list.AddRange(null!));
@@ -257,7 +257,7 @@ public class SyntaxListTests
     public void AddRange_WithDifferentNodeTypes_AddsAllNodes()
     {
         // Arrange
-        var emptyList = new SyntaxList<SyntaxNode>();
+        var emptyList = SyntaxList<SyntaxNode>.Empty;
 
         // Create different types of syntax nodes
         SyntaxNode[] mixedNodes = [
@@ -283,7 +283,7 @@ public class SyntaxListTests
     public void AddRange_WithListAsSource_AddsAllNodes()
     {
         // Arrange
-        var emptyList = new SyntaxList<SyntaxNode>();
+        var emptyList = SyntaxList<SyntaxNode>.Empty;
         List<SyntaxNode> nodesList = [
             CreateMarkupTextLiteral(s_openAngle),
             CreateMarkupTextLiteral(s_forwardSlash),
@@ -306,7 +306,7 @@ public class SyntaxListTests
     public void AddRange_WithIEnumerableAsSource_AddsAllNodes()
     {
         // Arrange
-        var emptyList = new SyntaxList<SyntaxNode>();
+        var emptyList = SyntaxList<SyntaxNode>.Empty;
 
         IEnumerable<SyntaxNode> nodes = [
             CreateMarkupTextLiteral(s_openAngle),
@@ -333,7 +333,7 @@ public class SyntaxListTests
         // Arrange
         var node1 = CreateMarkupTextLiteral(s_closeAngle);
         var node2 = CreateMarkupTextLiteral(s_rightBrace);
-        var originalList = new SyntaxList<SyntaxNode>(node1).Add(node2);
+        SyntaxList<SyntaxNode> originalList = [node1, node2];
         var nodeToInsert = CreateMarkupTextLiteral(s_openAngle);
 
         // Act
@@ -353,7 +353,7 @@ public class SyntaxListTests
         // Arrange
         var node1 = CreateMarkupTextLiteral(s_openAngle);
         var node2 = CreateMarkupTextLiteral(s_closeAngle);
-        var originalList = new SyntaxList<SyntaxNode>(node1).Add(node2);
+        SyntaxList<SyntaxNode> originalList = [node1, node2];
         var nodeToInsert = CreateMarkupTextLiteral(s_forwardSlash);
 
         // Act
@@ -373,7 +373,7 @@ public class SyntaxListTests
         // Arrange
         var node1 = CreateMarkupTextLiteral(s_openAngle);
         var node2 = CreateMarkupTextLiteral(s_forwardSlash);
-        var originalList = new SyntaxList<SyntaxNode>(node1).Add(node2);
+        SyntaxList<SyntaxNode> originalList = [node1, node2];
         var nodeToInsert = CreateMarkupTextLiteral(s_closeAngle);
 
         // Act
@@ -392,7 +392,7 @@ public class SyntaxListTests
     public void Insert_IntoEmptyList_CreatesSingleItemList()
     {
         // Arrange
-        var emptyList = new SyntaxList<SyntaxNode>();
+        var emptyList = SyntaxList<SyntaxNode>.Empty;
         var node = CreateMarkupTextLiteral(s_openAngle);
 
         // Act
@@ -409,7 +409,7 @@ public class SyntaxListTests
     {
         // Arrange
         var node1 = CreateMarkupTextLiteral(s_openAngle);
-        var originalList = new SyntaxList<SyntaxNode>(node1);
+        SyntaxList<SyntaxNode> originalList = [node1];
         var nodeToInsert = CreateMarkupTextLiteral(s_forwardSlash);
 
         // Act
@@ -425,7 +425,7 @@ public class SyntaxListTests
     public void Insert_ThrowsArgumentNullException_WhenNodeIsNull()
     {
         // Arrange
-        var list = new SyntaxList<SyntaxNode>(CreateMarkupTextLiteral(s_openAngle));
+        SyntaxList<SyntaxNode> list = [CreateMarkupTextLiteral(s_openAngle)];
 
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() => list.Insert(0, null!));
@@ -435,7 +435,7 @@ public class SyntaxListTests
     public void Insert_ThrowsArgumentOutOfRangeException_WhenIndexIsNegative()
     {
         // Arrange
-        var list = new SyntaxList<SyntaxNode>(CreateMarkupTextLiteral(s_openAngle));
+        SyntaxList<SyntaxNode> list = [CreateMarkupTextLiteral(s_openAngle)];
         var node = CreateMarkupTextLiteral(s_closeAngle);
 
         // Act & Assert
@@ -446,7 +446,7 @@ public class SyntaxListTests
     public void Insert_ThrowsArgumentOutOfRangeException_WhenIndexExceedsCount()
     {
         // Arrange
-        var list = new SyntaxList<SyntaxNode>(CreateMarkupTextLiteral(s_openAngle));
+        SyntaxList<SyntaxNode> list = [CreateMarkupTextLiteral(s_openAngle)];
         var node = CreateMarkupTextLiteral(s_closeAngle);
 
         // Act & Assert
@@ -458,7 +458,7 @@ public class SyntaxListTests
     {
         // Arrange
         var existingNode = CreateMarkupTextLiteral(s_closeAngle);
-        var originalList = new SyntaxList<SyntaxNode>(existingNode);
+        SyntaxList<SyntaxNode> originalList = [existingNode];
 
         SyntaxNode[] nodesToInsert = [
             CreateMarkupTextLiteral(s_openAngle),
@@ -482,7 +482,7 @@ public class SyntaxListTests
         // Arrange
         var node1 = CreateMarkupTextLiteral(s_openAngle);
         var node2 = CreateMarkupTextLiteral(s_closeAngle);
-        var originalList = new SyntaxList<SyntaxNode>(node1).Add(node2);
+        SyntaxList<SyntaxNode> originalList = [node1, node2];
 
         SyntaxNode[] nodesToInsert = [
             CreateMarkupTextLiteral(s_forwardSlash),
@@ -506,7 +506,7 @@ public class SyntaxListTests
     {
         // Arrange
         var node1 = CreateMarkupTextLiteral(s_openAngle);
-        var originalList = new SyntaxList<SyntaxNode>(node1);
+        SyntaxList<SyntaxNode> originalList = [node1];
 
         SyntaxNode[] nodesToInsert = [
             CreateMarkupTextLiteral(s_forwardSlash),
@@ -530,7 +530,7 @@ public class SyntaxListTests
     {
         // Arrange
         var node = CreateMarkupTextLiteral(s_openAngle);
-        var originalList = new SyntaxList<SyntaxNode>(node);
+        SyntaxList<SyntaxNode> originalList = [node];
         var emptyNodes = Array.Empty<SyntaxNode>();
 
         // Act
@@ -545,7 +545,7 @@ public class SyntaxListTests
     public void InsertRange_IntoEmptyList_CreatesListWithAllNodes()
     {
         // Arrange
-        var emptyList = new SyntaxList<SyntaxNode>();
+        var emptyList = SyntaxList<SyntaxNode>.Empty;
         
         SyntaxNode[] nodesToInsert = [
             CreateMarkupTextLiteral(s_openAngle),
@@ -571,7 +571,7 @@ public class SyntaxListTests
     {
         // Arrange
         var existingNode = CreateMarkupTextLiteral(s_openAngle);
-        var originalList = new SyntaxList<SyntaxNode>(existingNode);
+        SyntaxList<SyntaxNode> originalList = [existingNode];
 
         SyntaxNode[] nodesToInsert = [
             CreateMarkupTextLiteral(s_forwardSlash),
@@ -591,7 +591,7 @@ public class SyntaxListTests
     public void InsertRange_ThrowsArgumentNullException_WhenNodesIsNull()
     {
         // Arrange
-        var list = new SyntaxList<SyntaxNode>(CreateMarkupTextLiteral(s_openAngle));
+        SyntaxList<SyntaxNode> list = [CreateMarkupTextLiteral(s_openAngle)];
 
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() => list.InsertRange(0, null!));
@@ -601,7 +601,7 @@ public class SyntaxListTests
     public void InsertRange_ThrowsArgumentOutOfRangeException_WhenIndexIsNegative()
     {
         // Arrange
-        var list = new SyntaxList<SyntaxNode>(CreateMarkupTextLiteral(s_openAngle));
+        SyntaxList<SyntaxNode> list = [CreateMarkupTextLiteral(s_openAngle)];
         var nodes = new[] { CreateMarkupTextLiteral(s_closeAngle) };
 
         // Act & Assert
@@ -612,7 +612,7 @@ public class SyntaxListTests
     public void InsertRange_ThrowsArgumentOutOfRangeException_WhenIndexExceedsCount()
     {
         // Arrange
-        var list = new SyntaxList<SyntaxNode>(CreateMarkupTextLiteral(s_openAngle));
+        SyntaxList<SyntaxNode> list = [CreateMarkupTextLiteral(s_openAngle)];
         var nodes = new[] { CreateMarkupTextLiteral(s_closeAngle) };
 
         // Act & Assert
@@ -624,7 +624,7 @@ public class SyntaxListTests
     {
         // Arrange
         var existingNode = CreateMarkupTextLiteral(s_openAngle);
-        var originalList = new SyntaxList<SyntaxNode>(existingNode);
+        SyntaxList<SyntaxNode> originalList = [existingNode];
 
         List<SyntaxNode> nodesToInsert = [
             CreateMarkupTextLiteral(s_forwardSlash),
@@ -650,7 +650,7 @@ public class SyntaxListTests
     {
         // Arrange
         var existingNode = CreateMarkupTextLiteral(s_closeAngle);
-        var originalList = new SyntaxList<SyntaxNode>(existingNode);
+        SyntaxList<SyntaxNode> originalList = [existingNode];
 
         IEnumerable<SyntaxNode> nodesToInsert = [
             CreateMarkupTextLiteral(s_openAngle),
@@ -677,7 +677,7 @@ public class SyntaxListTests
     {
         // Arrange
         var node = CreateMarkupTextLiteral(s_openAngle);
-        var originalList = new SyntaxList<SyntaxNode>(node);
+        SyntaxList<SyntaxNode> originalList = [node];
 
         // Act
         var newList = originalList.RemoveAt(0);
@@ -694,7 +694,7 @@ public class SyntaxListTests
         var node1 = CreateMarkupTextLiteral(s_openAngle);
         var node2 = CreateMarkupTextLiteral(s_forwardSlash);
         var node3 = CreateMarkupTextLiteral(s_closeAngle);
-        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2, node3]);
+        SyntaxList<SyntaxNode> originalList = [node1, node2, node3];
 
         // Act
         var newList = originalList.RemoveAt(0);
@@ -713,7 +713,7 @@ public class SyntaxListTests
         var node1 = CreateMarkupTextLiteral(s_openAngle);
         var node2 = CreateMarkupTextLiteral(s_forwardSlash);
         var node3 = CreateMarkupTextLiteral(s_closeAngle);
-        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2, node3]);
+        SyntaxList<SyntaxNode> originalList = [node1, node2, node3];
 
         // Act
         var newList = originalList.RemoveAt(1);
@@ -732,7 +732,7 @@ public class SyntaxListTests
         var node1 = CreateMarkupTextLiteral(s_openAngle);
         var node2 = CreateMarkupTextLiteral(s_forwardSlash);
         var node3 = CreateMarkupTextLiteral(s_closeAngle);
-        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2, node3]);
+        SyntaxList<SyntaxNode> originalList = [node1, node2, node3];
 
         // Act
         var newList = originalList.RemoveAt(2);
@@ -749,7 +749,7 @@ public class SyntaxListTests
     {
         // Arrange
         var node = CreateMarkupTextLiteral(s_openAngle);
-        var list = new SyntaxList<SyntaxNode>(node);
+        SyntaxList<SyntaxNode> list = [node];
 
         // Act & Assert
         Assert.Throws<ArgumentOutOfRangeException>(() => list.RemoveAt(-1));
@@ -760,7 +760,7 @@ public class SyntaxListTests
     {
         // Arrange
         var node = CreateMarkupTextLiteral(s_openAngle);
-        var list = new SyntaxList<SyntaxNode>(node);
+        SyntaxList<SyntaxNode> list = [node];
 
         // Act & Assert
         Assert.Throws<ArgumentOutOfRangeException>(() => list.RemoveAt(list.Count));
@@ -772,7 +772,7 @@ public class SyntaxListTests
         // Arrange
         var node1 = CreateMarkupTextLiteral(s_openAngle);
         var node2 = CreateMarkupTextLiteral(s_forwardSlash);
-        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2]);
+        SyntaxList<SyntaxNode> originalList = [node1, node2];
 
         // Act
         var newList = originalList.RemoveAt(0);
@@ -790,7 +790,7 @@ public class SyntaxListTests
         // Arrange
         var node1 = CreateMarkupTextLiteral(s_openAngle);
         var node2 = CreateMarkupTextLiteral(s_forwardSlash);
-        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2]);
+        SyntaxList<SyntaxNode> originalList = [node1, node2];
 
         // Act
         var removeAtResult = originalList.RemoveAt(0);
@@ -809,10 +809,10 @@ public class SyntaxListTests
     {
         // Arrange
         var node = CreateMarkupTextLiteral(s_openAngle);
-        var originalList = new SyntaxList<SyntaxNode>(node);
+        SyntaxList<SyntaxNode> originalList = [node];
 
         // Act
-        var newList = originalList.Remove(node);
+        var newList = originalList.Remove(originalList[0]);
 
         // Assert
         Assert.Single(originalList);
@@ -826,7 +826,7 @@ public class SyntaxListTests
         var node1 = CreateMarkupTextLiteral(s_openAngle);
         var node2 = CreateMarkupTextLiteral(s_forwardSlash);
         var node3 = CreateMarkupTextLiteral(s_closeAngle);
-        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2, node3]);
+        SyntaxList<SyntaxNode> originalList = [node1, node2, node3];
 
         // Act
         var newList = originalList.Remove(originalList[1]);
@@ -845,7 +845,7 @@ public class SyntaxListTests
         var node1 = CreateMarkupTextLiteral(s_openAngle);
         var node2 = CreateMarkupTextLiteral(s_forwardSlash);
         var nodeNotInList = CreateMarkupTextLiteral(s_closeAngle);
-        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2]);
+        SyntaxList<SyntaxNode> originalList = [node1, node2];
 
         // Act
         var newList = originalList.Remove(nodeNotInList);
@@ -863,7 +863,7 @@ public class SyntaxListTests
         // Arrange
         var node1 = CreateMarkupTextLiteral(s_openAngle);
         var node2 = CreateMarkupTextLiteral(s_forwardSlash);
-        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2]);
+        SyntaxList<SyntaxNode> originalList = [node1, node2];
 
         // Act
         var newList = originalList.Remove(originalList[0]);
@@ -879,7 +879,7 @@ public class SyntaxListTests
     public void Remove_FromEmptyList_ReturnsEmptyList()
     {
         // Arrange
-        var emptyList = new SyntaxList<SyntaxNode>();
+        var emptyList = SyntaxList<SyntaxNode>.Empty;
         var node = CreateMarkupTextLiteral(s_openAngle);
 
         // Act
@@ -896,10 +896,10 @@ public class SyntaxListTests
         // Arrange
         var original = CreateMarkupTextLiteral(s_openAngle);
         var replacement = CreateMarkupTextLiteral(s_closeAngle);
-        var originalList = new SyntaxList<SyntaxNode>(original);
+        SyntaxList<SyntaxNode> originalList = [original];
 
         // Act
-        var newList = originalList.Replace(original, replacement);
+        var newList = originalList.Replace(originalList[0], replacement);
 
         // Assert
         Assert.Single(originalList);
@@ -915,7 +915,7 @@ public class SyntaxListTests
         var node1 = CreateMarkupTextLiteral(s_openAngle);
         var node2 = CreateMarkupTextLiteral(s_forwardSlash);
         var node3 = CreateMarkupTextLiteral(s_closeAngle);
-        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2, node3]);
+        SyntaxList<SyntaxNode> originalList = [node1, node2, node3];
         var replacement = CreateMarkupTextLiteral(s_leftBrace);
 
         // Act
@@ -935,7 +935,7 @@ public class SyntaxListTests
         // Arrange
         var node1 = CreateMarkupTextLiteral(s_openAngle);
         var node2 = CreateMarkupTextLiteral(s_forwardSlash);
-        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2]);
+        SyntaxList<SyntaxNode> originalList = [node1, node2];
         var replacement = CreateMarkupTextLiteral(s_closeAngle);
 
         // Act
@@ -953,7 +953,7 @@ public class SyntaxListTests
     {
         // Arrange
         var node = CreateMarkupTextLiteral(s_openAngle);
-        var list = new SyntaxList<SyntaxNode>(node);
+        SyntaxList<SyntaxNode> list = [node];
         var replacement = CreateMarkupTextLiteral(s_closeAngle);
 
         // Act & Assert
@@ -965,7 +965,7 @@ public class SyntaxListTests
     {
         // Arrange
         var node = CreateMarkupTextLiteral(s_openAngle);
-        var list = new SyntaxList<SyntaxNode>(node);
+        SyntaxList<SyntaxNode> list = [node];
 
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() => list.Replace(list[0], null!));
@@ -978,7 +978,7 @@ public class SyntaxListTests
         var node = CreateMarkupTextLiteral(s_openAngle);
         var nodeNotInList = CreateMarkupTextLiteral(s_forwardSlash);
         var replacement = CreateMarkupTextLiteral(s_closeAngle);
-        var list = new SyntaxList<SyntaxNode>(node);
+        SyntaxList<SyntaxNode> list = [node];
 
         // Act & Assert
         Assert.Throws<ArgumentOutOfRangeException>(() => list.Replace(nodeNotInList, replacement));
@@ -990,7 +990,7 @@ public class SyntaxListTests
         // Arrange
         var node1 = CreateMarkupTextLiteral(s_openAngle);
         var node2 = CreateMarkupTextLiteral(s_forwardSlash);
-        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2]);
+        SyntaxList<SyntaxNode> originalList = [node1, node2];
         var replacement = CreateMarkupTextLiteral(s_closeAngle);
 
         // Act
@@ -1012,10 +1012,10 @@ public class SyntaxListTests
         var original = CreateMarkupTextLiteral(s_openAngle);
         var replacement1 = CreateMarkupTextLiteral(s_forwardSlash);
         var replacement2 = CreateMarkupTextLiteral(s_closeAngle);
-        var originalList = new SyntaxList<SyntaxNode>(original);
+        SyntaxList<SyntaxNode> originalList = [original];
 
         // Act
-        var newList = originalList.ReplaceRange(original, [replacement1, replacement2]);
+        var newList = originalList.ReplaceRange(originalList[0], [replacement1, replacement2]);
 
         // Assert
         Assert.Single(originalList);
@@ -1031,7 +1031,7 @@ public class SyntaxListTests
         var node1 = CreateMarkupTextLiteral(s_openAngle);
         var node2 = CreateMarkupTextLiteral(s_forwardSlash);
         var node3 = CreateMarkupTextLiteral(s_closeAngle);
-        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2, node3]);
+        SyntaxList<SyntaxNode> originalList = [node1, node2, node3];
         var replacement1 = CreateMarkupTextLiteral(s_leftBrace);
         var replacement2 = CreateMarkupTextLiteral(s_rightBrace);
 
@@ -1054,7 +1054,7 @@ public class SyntaxListTests
         var node1 = CreateMarkupTextLiteral(s_openAngle);
         var node2 = CreateMarkupTextLiteral(s_forwardSlash);
         var node3 = CreateMarkupTextLiteral(s_closeAngle);
-        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2, node3]);
+        SyntaxList<SyntaxNode> originalList = [node1, node2, node3];
 
         // Act
         var newList = originalList.ReplaceRange(originalList[1], []);
@@ -1072,7 +1072,7 @@ public class SyntaxListTests
         // Arrange
         var node1 = CreateMarkupTextLiteral(s_openAngle);
         var node2 = CreateMarkupTextLiteral(s_forwardSlash);
-        var originalList = new SyntaxList<SyntaxNode>().AddRange([node1, node2]);
+        SyntaxList<SyntaxNode> originalList = [node1, node2];
         var replacement1 = CreateMarkupTextLiteral(s_leftBrace);
         var replacement2 = CreateMarkupTextLiteral(s_rightBrace);
 
@@ -1091,7 +1091,7 @@ public class SyntaxListTests
     {
         // Arrange
         var node = CreateMarkupTextLiteral(s_openAngle);
-        var list = new SyntaxList<SyntaxNode>(node);
+        SyntaxList<SyntaxNode> list = [node];
         var replacements = new[] { CreateMarkupTextLiteral(s_closeAngle) };
 
         // Act & Assert
@@ -1103,7 +1103,7 @@ public class SyntaxListTests
     {
         // Arrange
         var node = CreateMarkupTextLiteral(s_openAngle);
-        var list = new SyntaxList<SyntaxNode>(node);
+        SyntaxList<SyntaxNode> list = [node];
 
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() => list.ReplaceRange(node, null!));
@@ -1116,7 +1116,7 @@ public class SyntaxListTests
         var node = CreateMarkupTextLiteral(s_openAngle);
         var nodeNotInList = CreateMarkupTextLiteral(s_forwardSlash);
         var replacements = new[] { CreateMarkupTextLiteral(s_closeAngle) };
-        var list = new SyntaxList<SyntaxNode>(node);
+        SyntaxList<SyntaxNode> list = [node];
 
         // Act & Assert
         Assert.Throws<ArgumentOutOfRangeException>(() => list.ReplaceRange(nodeNotInList, replacements));
@@ -1127,14 +1127,14 @@ public class SyntaxListTests
     {
         // Arrange
         var node = CreateMarkupTextLiteral(s_openAngle);
-        var list = new SyntaxList<SyntaxNode>(node);
+        SyntaxList<SyntaxNode> list = [node];
         List<SyntaxNode> replacements = [
             CreateMarkupTextLiteral(s_forwardSlash),
             CreateMarkupTextLiteral(s_closeAngle)
         ];
 
         // Act
-        var newList = list.ReplaceRange(node, replacements);
+        var newList = list.ReplaceRange(list[0], replacements);
 
         // Assert
         Assert.Equal(replacements.Count, newList.Count);
@@ -1149,14 +1149,14 @@ public class SyntaxListTests
     {
         // Arrange
         var node = CreateMarkupTextLiteral(s_openAngle);
-        var list = new SyntaxList<SyntaxNode>(node);
+        SyntaxList<SyntaxNode> list = [node];
         IEnumerable<SyntaxNode> replacements = [
             CreateMarkupTextLiteral(s_forwardSlash),
             CreateMarkupTextLiteral(s_closeAngle)
         ];
 
         // Act
-        var newList = list.ReplaceRange(node, replacements);
+        var newList = list.ReplaceRange(list[0], replacements);
 
         // Assert
         Assert.Equal(2, newList.Count);

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/TagHelperBlockRewriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/TagHelperBlockRewriter.cs
@@ -561,11 +561,11 @@ internal static class TagHelperBlockRewriter
                     tokens = tokens.RemoveAt(0);
                     var children = createExpressionLiteral(tokens);
                     return SyntaxFactory.MarkupBlock(
-                        new SyntaxList<RazorSyntaxNode>(SyntaxFactory.CSharpCodeBlock(
-                            new SyntaxList<RazorSyntaxNode>(SyntaxFactory.CSharpImplicitExpression(
+                        [SyntaxFactory.CSharpCodeBlock(
+                            [SyntaxFactory.CSharpImplicitExpression(
                                 SyntaxFactory.CSharpTransition(transition, chunkGenerator: null),
                                 SyntaxFactory.CSharpImplicitExpressionBody(
-                                    SyntaxFactory.CSharpCodeBlock(children)))))));
+                                    SyntaxFactory.CSharpCodeBlock(children)))])]);
                 }
 
                 return node.Update(createExpressionLiteral(tokens));
@@ -577,7 +577,7 @@ internal static class TagHelperBlockRewriter
             {
                 var expression = SyntaxFactory.CSharpExpressionLiteral(tokens, chunkGenerator: null);
                 var rewrittenExpression = (CSharpExpressionLiteralSyntax)VisitCSharpExpressionLiteral(expression);
-                return new SyntaxList<RazorSyntaxNode>(rewrittenExpression);
+                return [rewrittenExpression];
             }
         }
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/GreenNode.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/GreenNode.cs
@@ -4,11 +4,9 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 
@@ -342,37 +340,6 @@ internal abstract class GreenNode
     #endregion
 
     #region Factories
-    public virtual GreenNode CreateList(IEnumerable<GreenNode> nodes, bool alwaysCreateListNode = false)
-    {
-        if (nodes == null)
-        {
-            return null;
-        }
-
-        var list = nodes.ToArray();
-
-        switch (list.Length)
-        {
-            case 0:
-                return null;
-            case 1:
-                if (alwaysCreateListNode)
-                {
-                    goto default;
-                }
-                else
-                {
-                    return list[0];
-                }
-            case 2:
-                return InternalSyntax.SyntaxList.List(list[0], list[1]);
-            case 3:
-                return InternalSyntax.SyntaxList.List(list[0], list[1], list[2]);
-            default:
-                return InternalSyntax.SyntaxList.List(list);
-        }
-    }
-
     public SyntaxNode CreateRed()
     {
         return CreateRed(null, 0);

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxFactory.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxFactory.cs
@@ -24,6 +24,22 @@ internal static partial class SyntaxFactory
         return new SyntaxToken(parent: null, InternalSyntax.SyntaxFactory.MissingToken(kind, diagnostics), position: 0, index: 0);
     }
 
+    public static SyntaxList<TNode> List<TNode>()
+        where TNode : SyntaxNode
+        => default;
+
+    public static SyntaxList<TNode> List<TNode>(TNode node)
+        where TNode : SyntaxNode
+        => new(node);
+
+    public static SyntaxList<TNode> List<TNode>(params ReadOnlySpan<TNode> nodes)
+        where TNode : SyntaxNode
+        => SyntaxList.Create(nodes);
+
+    public static SyntaxList<TNode> List<TNode>(IEnumerable<TNode> nodes)
+        where TNode : SyntaxNode
+        => SyntaxList.Create(nodes);
+
     public static SyntaxTokenList TokenList()
         => default;
 
@@ -31,10 +47,10 @@ internal static partial class SyntaxFactory
         => new(token);
 
     public static SyntaxTokenList TokenList(params ReadOnlySpan<SyntaxToken> tokens)
-        => new(tokens);
+        => SyntaxList.Create(tokens);
 
     public static SyntaxTokenList TokenList(IEnumerable<SyntaxToken> tokens)
-        => new(tokens);
+        => SyntaxList.Create(tokens);
 
     public static MarkupTextLiteralSyntax MarkupTextLiteral(SyntaxToken token, ISpanChunkGenerator? chunkGenerator)
         => MarkupTextLiteral(new SyntaxTokenList(token), chunkGenerator);

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxList.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxList.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.PooledObjects;
 
 namespace Microsoft.AspNetCore.Razor.Language.Syntax;
 
@@ -13,6 +14,20 @@ internal abstract class SyntaxList : SyntaxNode
     {
     }
 
+
+    public static SyntaxList<TNode> Create<TNode>(ReadOnlySpan<TNode> nodes)
+        where TNode : SyntaxNode
+    {
+        if (nodes.Length == 0)
+        {
+            return default;
+        }
+
+        using var builder = new PooledArrayBuilder<TNode>(nodes.Length);
+        builder.AddRange(nodes);
+
+        return builder.ToList();
+    }
 
     // For debugging
 #pragma warning disable IDE0051 // Remove unused private members

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxList.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxList.cs
@@ -7,15 +7,9 @@ using Microsoft.AspNetCore.Razor.PooledObjects;
 
 namespace Microsoft.AspNetCore.Razor.Language.Syntax;
 
-internal abstract class SyntaxList : SyntaxNode
+internal abstract class SyntaxList(InternalSyntax.SyntaxList green, SyntaxNode parent, int position) : SyntaxNode(green, parent, position)
 {
-    protected SyntaxList(InternalSyntax.SyntaxList green, SyntaxNode parent, int position)
-        : base(green, parent, position)
-    {
-    }
-
-
-    public static SyntaxList<TNode> Create<TNode>(ReadOnlySpan<TNode> nodes)
+    public static SyntaxList<TNode> Create<TNode>(params ReadOnlySpan<TNode> nodes)
         where TNode : SyntaxNode
     {
         if (nodes.Length == 0)
@@ -25,6 +19,36 @@ internal abstract class SyntaxList : SyntaxNode
 
         using var builder = new PooledArrayBuilder<TNode>(nodes.Length);
         builder.AddRange(nodes);
+
+        return builder.ToList();
+    }
+
+    public static SyntaxList<TNode> Create<TNode>(IEnumerable<TNode> nodes)
+        where TNode : SyntaxNode
+    {
+        using var builder = new PooledArrayBuilder<TNode>();
+        builder.AddRange(nodes);
+
+        return builder.ToList();
+    }
+
+    public static SyntaxTokenList Create(params ReadOnlySpan<SyntaxToken> tokens)
+    {
+        if (tokens.Length == 0)
+        {
+            return default;
+        }
+
+        using var builder = new PooledArrayBuilder<SyntaxToken>(tokens.Length);
+        builder.AddRange(tokens);
+
+        return builder.ToList();
+    }
+
+    public static SyntaxTokenList Create(IEnumerable<SyntaxToken> tokens)
+    {
+        using var builder = new PooledArrayBuilder<SyntaxToken>();
+        builder.AddRange(tokens);
 
         return builder.ToList();
     }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxListOfT.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxListOfT.cs
@@ -29,33 +29,6 @@ internal readonly struct SyntaxList<TNode>(SyntaxNode? node) : IReadOnlyList<TNo
     }
 
     /// <summary>
-    /// Creates a list of syntax nodes.
-    /// </summary>
-    /// <param name="nodes">A sequence of element nodes.</param>
-    public SyntaxList(SyntaxList<TNode> nodes)
-        : this(CreateNode(nodes))
-    {
-    }
-
-    private static SyntaxNode? CreateNode(SyntaxList<TNode> nodes)
-    {
-        using var builder = new PooledArrayBuilder<TNode>(nodes.Count);
-        builder.AddRange(nodes);
-
-        return builder.ToList().Node;
-    }
-
-    public static SyntaxList<TNode> Create(SyntaxNode node, SyntaxNode parent, int position)
-    {
-        return new SyntaxList<TNode>(node.Green.CreateRed(parent, position));
-    }
-
-    public static SyntaxList<TNode> Create(SyntaxNode node, SyntaxNode parent)
-    {
-        return new SyntaxList<TNode>(node.Green.CreateRed(parent, parent.Position));
-    }
-
-    /// <summary>
     /// The number of nodes in the list.
     /// </summary>
     public int Count
@@ -94,7 +67,7 @@ internal readonly struct SyntaxList<TNode>(SyntaxNode? node) : IReadOnlyList<TNo
         }
     }
 
-    internal SyntaxNode? ItemInternal(int index)
+    private SyntaxNode? ItemInternal(int index)
     {
         if (Node?.IsList is true)
         {
@@ -361,21 +334,6 @@ internal readonly struct SyntaxList<TNode>(SyntaxNode? node) : IReadOnlyList<TNo
     {
         Debug.Assert(Node == null || Count != 0);
         return Node != null;
-    }
-
-    public SyntaxList<TNode> Where(Func<TNode, bool> predicate)
-    {
-        using var builder = new PooledArrayBuilder<TNode>(Count);
-
-        foreach (var node in this)
-        {
-            if (predicate(node))
-            {
-                builder.Add(node);
-            }
-        }
-
-        return builder.ToList();
     }
 
     // for debugging

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxListOfT.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxListOfT.cs
@@ -28,6 +28,37 @@ internal readonly struct SyntaxList<TNode>(SyntaxNode? node) : IReadOnlyList<TNo
     {
     }
 
+    public SyntaxList(params ReadOnlySpan<TNode> nodes)
+        : this(CreateRedListNode(nodes))
+    {
+    }
+
+    public SyntaxList(IEnumerable<TNode> nodes)
+        : this(CreateRedListNode(nodes))
+    {
+    }
+
+    private static SyntaxNode? CreateRedListNode(ReadOnlySpan<TNode> nodes)
+    {
+        if (nodes.Length == 0)
+        {
+            return null;
+        }
+
+        using var builder = new PooledArrayBuilder<TNode>(nodes.Length);
+        builder.AddRange(nodes);
+
+        return builder.ToListNode();
+    }
+
+    private static SyntaxNode? CreateRedListNode(IEnumerable<TNode> nodes)
+    {
+        using var builder = new PooledArrayBuilder<TNode>();
+        builder.AddRange(nodes);
+
+        return builder.ToListNode();
+    }
+
     /// <summary>
     /// The number of nodes in the list.
     /// </summary>

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxListOfT.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxListOfT.cs
@@ -144,10 +144,7 @@ internal readonly struct SyntaxList<TNode>(SyntaxNode? node) : IReadOnlyList<TNo
     /// <param name="node">The node to insert.</param>
     public SyntaxList<TNode> Insert(int index, TNode node)
     {
-        if (node == null)
-        {
-            throw new ArgumentNullException(nameof(node));
-        }
+        ArgHelper.ThrowIfNull(node);
 
         return InsertRange(index, new[] { node });
     }
@@ -159,15 +156,9 @@ internal readonly struct SyntaxList<TNode>(SyntaxNode? node) : IReadOnlyList<TNo
     /// <param name="nodes">The nodes to insert.</param>
     public SyntaxList<TNode> InsertRange(int index, IEnumerable<TNode> nodes)
     {
-        if (index < 0 || index > Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(index));
-        }
-
-        if (nodes == null)
-        {
-            throw new ArgumentNullException(nameof(nodes));
-        }
+        ArgHelper.ThrowIfNegative(index);
+        ArgHelper.ThrowIfGreaterThan(index, Count);
+        ArgHelper.ThrowIfNull(nodes);
 
         var list = this.ToList();
         list.InsertRange(index, nodes);
@@ -188,6 +179,8 @@ internal readonly struct SyntaxList<TNode>(SyntaxNode? node) : IReadOnlyList<TNo
     /// <param name="index">The index of the element to remove.</param>
     public SyntaxList<TNode> RemoveAt(int index)
     {
+        ArgHelper.ThrowIfNegative(index);
+        ArgHelper.ThrowIfGreaterThanOrEqual(index, Count);
         if (index < 0 || index > Count)
         {
             throw new ArgumentOutOfRangeException(nameof(index));
@@ -222,15 +215,8 @@ internal readonly struct SyntaxList<TNode>(SyntaxNode? node) : IReadOnlyList<TNo
     /// <param name="newNodes">The new nodes.</param>
     public SyntaxList<TNode> ReplaceRange(TNode nodeInList, IEnumerable<TNode> newNodes)
     {
-        if (nodeInList == null)
-        {
-            throw new ArgumentNullException(nameof(nodeInList));
-        }
-
-        if (newNodes == null)
-        {
-            throw new ArgumentNullException(nameof(newNodes));
-        }
+        ArgHelper.ThrowIfNull(nodeInList);
+        ArgHelper.ThrowIfNull(newNodes);
 
         var index = IndexOf(nodeInList);
         if (index >= 0 && index < Count)

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxListOfT.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxListOfT.cs
@@ -2,18 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
+using System.Linq;
+using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.AspNetCore.Razor.Language.Syntax;
 
+[CollectionBuilder(typeof(SyntaxList), methodName: "Create")]
 internal readonly struct SyntaxList<TNode>(SyntaxNode? node) : IReadOnlyList<TNode>, IEquatable<SyntaxList<TNode>>
     where TNode : SyntaxNode
 {
+    public static SyntaxList<TNode> Empty => default;
+
     internal SyntaxNode? Node { get; } = node;
 
     /// <summary>
@@ -195,6 +199,8 @@ internal readonly struct SyntaxList<TNode>(SyntaxNode? node) : IReadOnlyList<TNo
     /// <param name="node">The element to remove.</param>
     public SyntaxList<TNode> Remove(TNode node)
     {
+        ArgHelper.ThrowIfNull(node);
+
         return CreateList(this.Where(x => x != node).ToList());
     }
 
@@ -205,6 +211,8 @@ internal readonly struct SyntaxList<TNode>(SyntaxNode? node) : IReadOnlyList<TNo
     /// <param name="newNode">The new node.</param>
     public SyntaxList<TNode> Replace(TNode nodeInList, TNode newNode)
     {
+        ArgHelper.ThrowIfNull(newNode);
+
         return ReplaceRange(nodeInList, new[] { newNode });
     }
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxListOfT.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxListOfT.cs
@@ -63,12 +63,7 @@ internal readonly struct SyntaxList<TNode>(SyntaxNode? node) : IReadOnlyList<TNo
     /// The number of nodes in the list.
     /// </summary>
     public int Count
-    {
-        get
-        {
-            return Node == null ? 0 : (Node.IsList ? Node.SlotCount : 1);
-        }
-    }
+        => Node == null ? 0 : (Node.IsList ? Node.SlotCount : 1);
 
     /// <summary>
     /// Gets the node at the specified index.
@@ -415,22 +410,26 @@ internal readonly struct SyntaxList<TNode>(SyntaxNode? node) : IReadOnlyList<TNo
     /// <summary>
     /// The first node in the list.
     /// </summary>
-    public TNode First() => this[0];
+    public TNode First()
+        => this[0];
 
     /// <summary>
     /// The first node in the list or default if the list is empty.
     /// </summary>
-    public TNode? FirstOrDefault() => Any() ? this[0] : null;
+    public TNode? FirstOrDefault()
+        => Any() ? this[0] : null;
 
     /// <summary>
     /// The last node in the list.
     /// </summary>
-    public TNode Last() => this[^1];
+    public TNode Last()
+        => this[^1];
 
     /// <summary>
     /// The last node in the list or default if the list is empty.
     /// </summary>
-    public TNode? LastOrDefault() => Any() ? this[^1] : null;
+    public TNode? LastOrDefault()
+        => Any() ? this[^1] : null;
 
     /// <summary>
     /// True if the list has at least one node.
@@ -443,39 +442,24 @@ internal readonly struct SyntaxList<TNode>(SyntaxNode? node) : IReadOnlyList<TNo
 
     // for debugging
 #pragma warning disable IDE0051 // Remove unused private members
-    private TNode[] Nodes
+    private TNode[] Nodes => [.. this];
 #pragma warning restore IDE0051 // Remove unused private members
-    {
-        get { return this.ToArray(); }
-    }
 
     /// <summary>
     /// Get's the enumerator for this list.
     /// </summary>
     public Enumerator GetEnumerator()
-    {
-        return new Enumerator(in this);
-    }
+        => new(in this);
 
     IEnumerator<TNode> IEnumerable<TNode>.GetEnumerator()
-    {
-        if (Any())
-        {
-            return new EnumeratorImpl(this);
-        }
-
-        return SpecializedCollections.EmptyEnumerator<TNode>();
-    }
+        => Any()
+            ? new EnumeratorImpl(this)
+            : SpecializedCollections.EmptyEnumerator<TNode>();
 
     IEnumerator IEnumerable.GetEnumerator()
-    {
-        if (Any())
-        {
-            return new EnumeratorImpl(this);
-        }
-
-        return SpecializedCollections.EmptyEnumerator<TNode>();
-    }
+        => Any()
+            ? new EnumeratorImpl(this)
+            : (IEnumerator)SpecializedCollections.EmptyEnumerator<TNode>();
 
     public static bool operator ==(SyntaxList<TNode> left, SyntaxList<TNode> right)
         => left.Node == right.Node;
@@ -491,19 +475,13 @@ internal readonly struct SyntaxList<TNode>(SyntaxNode? node) : IReadOnlyList<TNo
            Equals(list);
 
     public override int GetHashCode()
-    {
-        return Node?.GetHashCode() ?? 0;
-    }
+        => Node?.GetHashCode() ?? 0;
 
     public static implicit operator SyntaxList<TNode>(SyntaxList<SyntaxNode> nodes)
-    {
-        return new SyntaxList<TNode>(nodes.Node);
-    }
+        => new(nodes.Node);
 
     public static implicit operator SyntaxList<SyntaxNode>(SyntaxList<TNode> nodes)
-    {
-        return new SyntaxList<SyntaxNode>(nodes.Node);
-    }
+        => new(nodes.Node);
 
     /// <summary>
     /// The index of the node in this list, or -1 if the node is not in the list.
@@ -511,9 +489,10 @@ internal readonly struct SyntaxList<TNode>(SyntaxNode? node) : IReadOnlyList<TNo
     public int IndexOf(TNode node)
     {
         var index = 0;
+
         foreach (var child in this)
         {
-            if (object.Equals(child, node))
+            if (Equals(child, node))
             {
                 return index;
             }
@@ -527,6 +506,7 @@ internal readonly struct SyntaxList<TNode>(SyntaxNode? node) : IReadOnlyList<TNo
     public int IndexOf(Func<TNode, bool> predicate)
     {
         var index = 0;
+
         foreach (var child in this)
         {
             if (predicate(child))
@@ -543,6 +523,7 @@ internal readonly struct SyntaxList<TNode>(SyntaxNode? node) : IReadOnlyList<TNo
     internal int IndexOf(SyntaxKind kind)
     {
         var index = 0;
+
         foreach (var child in this)
         {
             if (child.Kind == kind)
@@ -560,7 +541,7 @@ internal readonly struct SyntaxList<TNode>(SyntaxNode? node) : IReadOnlyList<TNo
     {
         for (var i = Count - 1; i >= 0; i--)
         {
-            if (object.Equals(this[i], node))
+            if (Equals(this[i], node))
             {
                 return i;
             }
@@ -605,67 +586,44 @@ internal readonly struct SyntaxList<TNode>(SyntaxNode? node) : IReadOnlyList<TNo
             return false;
         }
 
-        public TNode Current
-        {
-            get
-            {
-                return (TNode)_list.ItemInternal(_index)!;
-            }
-        }
+        public readonly TNode Current
+            => (TNode)_list.ItemInternal(_index)!;
 
         public void Reset()
         {
             _index = -1;
         }
 
-        public override bool Equals(object? obj)
-        {
-            throw new NotSupportedException();
-        }
+        public override readonly bool Equals(object? obj)
+            => throw new NotSupportedException();
 
-        public override int GetHashCode()
-        {
-            throw new NotSupportedException();
-        }
+        public override readonly int GetHashCode()
+            => throw new NotSupportedException();
     }
 
-    private class EnumeratorImpl : IEnumerator<TNode>
+    private sealed class EnumeratorImpl : IEnumerator<TNode>
     {
-        private Enumerator _e;
+        private Enumerator _enumerator;
 
         internal EnumeratorImpl(in SyntaxList<TNode> list)
         {
-            _e = new Enumerator(in list);
+            _enumerator = new Enumerator(in list);
         }
 
         public bool MoveNext()
-        {
-            return _e.MoveNext();
-        }
+            => _enumerator.MoveNext();
 
         public TNode Current
-        {
-            get
-            {
-                return _e.Current;
-            }
-        }
+            => _enumerator.Current;
 
         void IDisposable.Dispose()
         {
         }
 
         object IEnumerator.Current
-        {
-            get
-            {
-                return _e.Current;
-            }
-        }
+            => _enumerator.Current;
 
         void IEnumerator.Reset()
-        {
-            _e.Reset();
-        }
+            => _enumerator.Reset();
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxList`1.Enumerator.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxList`1.Enumerator.cs
@@ -1,0 +1,76 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.Language.Syntax;
+
+internal readonly partial struct SyntaxList<TNode>
+    where TNode : SyntaxNode
+{
+    public struct Enumerator
+    {
+        private readonly SyntaxList<TNode> _list;
+        private int _index;
+
+        internal Enumerator(in SyntaxList<TNode> list)
+        {
+            _list = list;
+            _index = -1;
+        }
+
+        public bool MoveNext()
+        {
+            var newIndex = _index + 1;
+            if (newIndex < _list.Count)
+            {
+                _index = newIndex;
+                return true;
+            }
+
+            return false;
+        }
+
+        public readonly TNode Current
+            => (TNode)_list.ItemInternal(_index)!;
+
+        public void Reset()
+        {
+            _index = -1;
+        }
+
+        public override readonly bool Equals(object? obj)
+            => throw new NotSupportedException();
+
+        public override readonly int GetHashCode()
+            => throw new NotSupportedException();
+    }
+
+    private sealed class EnumeratorImpl : IEnumerator<TNode>
+    {
+        private Enumerator _enumerator;
+
+        internal EnumeratorImpl(in SyntaxList<TNode> list)
+        {
+            _enumerator = new Enumerator(in list);
+        }
+
+        public bool MoveNext()
+            => _enumerator.MoveNext();
+
+        public TNode Current
+            => _enumerator.Current;
+
+        void IDisposable.Dispose()
+        {
+        }
+
+        object IEnumerator.Current
+            => _enumerator.Current;
+
+        void IEnumerator.Reset()
+            => _enumerator.Reset();
+    }
+}

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxList`1.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxList`1.cs
@@ -12,7 +12,7 @@ using Microsoft.CodeAnalysis.Text;
 namespace Microsoft.AspNetCore.Razor.Language.Syntax;
 
 [CollectionBuilder(typeof(SyntaxList), methodName: "Create")]
-internal readonly struct SyntaxList<TNode>(SyntaxNode? node) : IReadOnlyList<TNode>, IEquatable<SyntaxList<TNode>>
+internal readonly partial struct SyntaxList<TNode>(SyntaxNode? node) : IReadOnlyList<TNode>, IEquatable<SyntaxList<TNode>>
     where TNode : SyntaxNode
 {
     public static SyntaxList<TNode> Empty => default;
@@ -561,69 +561,5 @@ internal readonly struct SyntaxList<TNode>(SyntaxNode? node) : IReadOnlyList<TNo
         }
 
         return -1;
-    }
-
-    public struct Enumerator
-    {
-        private readonly SyntaxList<TNode> _list;
-        private int _index;
-
-        internal Enumerator(in SyntaxList<TNode> list)
-        {
-            _list = list;
-            _index = -1;
-        }
-
-        public bool MoveNext()
-        {
-            var newIndex = _index + 1;
-            if (newIndex < _list.Count)
-            {
-                _index = newIndex;
-                return true;
-            }
-
-            return false;
-        }
-
-        public readonly TNode Current
-            => (TNode)_list.ItemInternal(_index)!;
-
-        public void Reset()
-        {
-            _index = -1;
-        }
-
-        public override readonly bool Equals(object? obj)
-            => throw new NotSupportedException();
-
-        public override readonly int GetHashCode()
-            => throw new NotSupportedException();
-    }
-
-    private sealed class EnumeratorImpl : IEnumerator<TNode>
-    {
-        private Enumerator _enumerator;
-
-        internal EnumeratorImpl(in SyntaxList<TNode> list)
-        {
-            _enumerator = new Enumerator(in list);
-        }
-
-        public bool MoveNext()
-            => _enumerator.MoveNext();
-
-        public TNode Current
-            => _enumerator.Current;
-
-        void IDisposable.Dispose()
-        {
-        }
-
-        object IEnumerator.Current
-            => _enumerator.Current;
-
-        void IEnumerator.Reset()
-            => _enumerator.Reset();
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxRewriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxRewriter.cs
@@ -63,7 +63,7 @@ internal abstract partial class SyntaxRewriter : SyntaxVisitor<SyntaxNode>
                 // add the items we've seen so far.
                 builder.SetCapacityIfLarger(count);
 
-                builder.AddRange(list, index: 0, count: i);
+                builder.AddRange(list, startIndex: 0, count: i);
 
                 isUpdating = true;
             }
@@ -109,7 +109,7 @@ internal abstract partial class SyntaxRewriter : SyntaxVisitor<SyntaxNode>
                 // add the items we've seen so far.
                 builder.SetCapacityIfLarger(count);
 
-                builder.AddRange(list, index: 0, count: i);
+                builder.AddRange(list, startIndex: 0, count: i);
 
                 isUpdating = true;
             }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxTokenList.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxTokenList.cs
@@ -221,7 +221,7 @@ internal readonly partial struct SyntaxTokenList : IEquatable<SyntaxTokenList>, 
 
         Debug.Assert(builder.Count == count + tokens.Length);
 
-        return new(parent: null, builder.ToGreenListNode(), position: 0, index: 0);
+        return builder.ToList();
     }
 
     public SyntaxTokenList InsertRange(int index, IEnumerable<SyntaxToken> tokens)
@@ -257,7 +257,7 @@ internal readonly partial struct SyntaxTokenList : IEquatable<SyntaxTokenList>, 
         // Add remaining tokens starting from 'index'
         builder.AddRange(this, index, count - index);
 
-        return new(parent: null, builder.ToGreenListNode(), position: 0, index: 0);
+        return builder.ToList();
     }
 
     private SyntaxTokenList InsertRangeWithCount(int index, IEnumerable<SyntaxToken> tokens, int tokenCount)
@@ -282,7 +282,7 @@ internal readonly partial struct SyntaxTokenList : IEquatable<SyntaxTokenList>, 
 
         Debug.Assert(builder.Count == count + tokenCount);
 
-        return new(parent: null, builder.ToGreenListNode(), position: 0, index: 0);
+        return builder.ToList();
     }
 
     public SyntaxTokenList RemoveAt(int index)
@@ -303,7 +303,7 @@ internal readonly partial struct SyntaxTokenList : IEquatable<SyntaxTokenList>, 
         // Add remaining tokens starting *after* 'index'
         builder.AddRange(this, index + 1, newCount - index);
 
-        return new(parent: null, builder.ToGreenListNode(), position: 0, index: 0);
+        return builder.ToList();
     }
 
     public SyntaxTokenList Remove(SyntaxToken tokenInList)
@@ -350,7 +350,7 @@ internal readonly partial struct SyntaxTokenList : IEquatable<SyntaxTokenList>, 
         // Add remaining tokens starting *after* 'index'
         builder.AddRange(this, index + 1, newCount - index);
 
-        return new(parent: null, builder.ToGreenListNode(), position: 0, index: 0);
+        return builder.ToList();
     }
 
     public SyntaxTokenList ReplaceRange(SyntaxToken tokenInList, IEnumerable<SyntaxToken> tokens)
@@ -383,7 +383,7 @@ internal readonly partial struct SyntaxTokenList : IEquatable<SyntaxTokenList>, 
         // Add remaining tokens starting *after* 'index'
         builder.AddRange(this, index + 1, newCount - index);
 
-        return new(parent: null, builder.ToGreenListNode(), position: 0, index: 0);
+        return builder.ToList();
     }
 
     private SyntaxTokenList ReplaceRangeWithCount(int index, IEnumerable<SyntaxToken> tokens, int tokenCount)
@@ -411,7 +411,7 @@ internal readonly partial struct SyntaxTokenList : IEquatable<SyntaxTokenList>, 
 
         Debug.Assert(builder.Count == newCount + tokenCount);
 
-        return new(parent: null, builder.ToGreenListNode(), position: 0, index: 0);
+        return builder.ToList();
     }
 
     public override bool Equals([NotNullWhen(true)] object? obj)

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxUtilities.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxUtilities.cs
@@ -153,6 +153,6 @@ internal static class SyntaxUtilities
             markupTransition = markupTransition.WithEditHandler(editHandler);
         }
 
-        return SyntaxList<RazorSyntaxNode>.Create(markupTransition, parent: node);
+        return new(markupTransition);
     }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ImmutableArrayExtensionsTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ImmutableArrayExtensionsTests.cs
@@ -105,4 +105,131 @@ public class ImmutableArrayExtensionsTests
         var actual = enumerable.SelectAsArray(static (x, index) => x + index);
         Assert.Equal<int>(expected, actual);
     }
+
+    [Fact]
+    public void InsertRange_EmptySpan_DoesNotModifyBuilder()
+    {
+        // Arrange
+        var builder = ImmutableArray.CreateBuilder<int>();
+        builder.Add(1);
+        builder.Add(2);
+        var originalCount = builder.Count;
+        
+        // Act
+        builder.InsertRange(1, ReadOnlySpan<int>.Empty);
+        
+        // Assert
+        Assert.Equal(originalCount, builder.Count);
+        Assert.Equal(1, builder[0]);
+        Assert.Equal(2, builder[1]);
+    }
+    
+    [Fact]
+    public void InsertRange_AtEndOfBuilder_AppendsItems()
+    {
+        // Arrange
+        var builder = ImmutableArray.CreateBuilder<int>();
+        builder.Add(1);
+        builder.Add(2);
+        var itemsToInsert = new[] { 3, 4, 5 };
+        
+        // Act
+        builder.InsertRange(builder.Count, itemsToInsert.AsSpan());
+        
+        // Assert
+        Assert.Equal(5, builder.Count);
+        Assert.Equal([1, 2, 3, 4, 5], builder.ToArray());
+    }
+    
+    [Fact]
+    public void InsertRange_SingleItem_InsertsCorrectly()
+    {
+        // Arrange
+        var builder = ImmutableArray.CreateBuilder<int>();
+        builder.Add(1);
+        builder.Add(3);
+        var itemToInsert = new[] { 2 };
+        
+        // Act
+        builder.InsertRange(1, itemToInsert.AsSpan());
+        
+        // Assert
+        Assert.Equal(3, builder.Count);
+        Assert.Equal([1, 2, 3], builder.ToArray());
+    }
+    
+    [Fact]
+    public void InsertRange_MultipleItems_InsertsCorrectly()
+    {
+        // Arrange
+        var builder = ImmutableArray.CreateBuilder<int>();
+        builder.Add(1);
+        builder.Add(6);
+        var itemsToInsert = new[] { 2, 3, 4, 5 };
+        
+        // Act
+        builder.InsertRange(1, itemsToInsert.AsSpan());
+        
+        // Assert
+        Assert.Equal(6, builder.Count);
+        Assert.Equal([1, 2, 3, 4, 5, 6], builder.ToArray());
+    }
+    
+    [Fact]
+    public void InsertRange_AtBeginning_InsertsCorrectly()
+    {
+        // Arrange
+        var builder = ImmutableArray.CreateBuilder<int>();
+        builder.Add(3);
+        builder.Add(4);
+        var itemsToInsert = new[] { 1, 2 };
+        
+        // Act
+        builder.InsertRange(0, itemsToInsert.AsSpan());
+        
+        // Assert
+        Assert.Equal(4, builder.Count);
+        Assert.Equal([1, 2, 3, 4], builder.ToArray());
+    }
+    
+    [Fact]
+    public void InsertRange_NegativeIndex_ThrowsArgumentException()
+    {
+        // Arrange
+        var builder = ImmutableArray.CreateBuilder<int>();
+        builder.Add(1);
+        var itemsToInsert = new[] { 2, 3 };
+        
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => builder.InsertRange(-1, itemsToInsert.AsSpan()));
+    }
+    
+    [Fact]
+    public void InsertRange_IndexGreaterThanCount_ThrowsArgumentException()
+    {
+        // Arrange
+        var builder = ImmutableArray.CreateBuilder<int>();
+        builder.Add(1);
+        var itemsToInsert = new[] { 2, 3 };
+        
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => builder.InsertRange(builder.Count + 1, itemsToInsert.AsSpan()));
+    }
+
+    [Fact]
+    public void InsertRange_WithReferenceTypes_InsertsCorrectly()
+    {
+        // Arrange
+        var builder = ImmutableArray.CreateBuilder<string>();
+        builder.Add("apple");
+        builder.Add("banana");
+        var itemsToInsert = new[] { "cherry", "date" };
+        
+        // Act
+        builder.InsertRange(1, itemsToInsert.AsSpan());
+        
+        // Assert
+        Assert.Equal(4, builder.Count);
+        Assert.Equal(["apple", "cherry", "date", "banana"], builder.ToArray());
+    }
 }


### PR DESCRIPTION
I noticed that Razor's new `SyntaxTokenList` always creates a new array of `ArrayElement<GreenNode>` whenever a mutation method is called, even if there are few enough elements that an array is unnecessary. This pull request addresses that and brings the work done in `SyntaxTokenList` to `SyntaxList<TNode>`. Here is a summary of the changes:

- Introduce `ImmutableArray<T>.Builder.InsertRange(...)` extension method that takes a `ReadOnlySpan<T>`. For some reason, there's an `AddRange` overload for `ReadOnlySpan<T>` but no matching `InsertRange` overload.
- Add `PooledArrayBuilder<T>.InsertRange(...)` methods.
- Update `SyntaxTokenList` to use `PooledArrayBuilder<SyntaxToken>` for mutation operations. This should result in fewer `ArrayElement<GreenNode>[]` allocations.
- Bring `SyntaxList<TNode>` in line with `SyntaxTokenList` and use `PooledArrayBuilder<TNode>` for mutation operations rather than a `List<TNode>`.
- Loads of unit tests.

----
CI Build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2722495&view=results
Test Insertion: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/640753
Toolset Test Run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2722496&view=results