### PR TITLE
Handle when Roslyn removes newlines while formatting

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/TextLineExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/TextLineExtensions.cs
@@ -7,6 +7,23 @@ namespace Microsoft.CodeAnalysis.Text;
 
 internal static class TextLineExtensions
 {
+    public static char CharAt(this TextLine line, int offset)
+    {
+        if (offset < 0 || offset >= line.SpanIncludingLineBreak.Length)
+        {
+            return ThrowHelper.ThrowArgumentOutOfRangeException<char>(nameof(offset), SR.Invalid_Offset);
+        }
+
+        var text = line.Text.AssumeNotNull();
+        var index = line.Start + offset;
+        if (index >= text.Length)
+        {
+            return ThrowHelper.ThrowArgumentOutOfRangeException<char>(nameof(offset), index, SR.FormatPositionCharacter_Outside_Range(offset, "character", line.Span.Length));
+        }
+
+        return text[index];
+    }
+
     public static string GetLeadingWhitespace(this TextLine line)
     {
         return line.GetFirstNonWhitespaceOffset() is int offset

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/TextLineExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/TextLineExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using Microsoft.AspNetCore.Razor;
 
 namespace Microsoft.CodeAnalysis.Text;
@@ -9,17 +10,12 @@ internal static class TextLineExtensions
 {
     public static char CharAt(this TextLine line, int offset)
     {
-        if (offset < 0 || offset >= line.SpanIncludingLineBreak.Length)
-        {
-            return ThrowHelper.ThrowArgumentOutOfRangeException<char>(nameof(offset), SR.Invalid_Offset);
-        }
+        ArgHelper.ThrowIfNegative(offset);
+        ArgHelper.ThrowIfGreaterThanOrEqual(offset, line.SpanIncludingLineBreak.Length);
 
         var text = line.Text.AssumeNotNull();
         var index = line.Start + offset;
-        if (index >= text.Length)
-        {
-            return ThrowHelper.ThrowArgumentOutOfRangeException<char>(nameof(offset), index, SR.FormatPositionCharacter_Outside_Range(offset, "character", line.Span.Length));
-        }
+        Debug.Assert(index < text.Length, "This should be impossible as we validated offset against the line length above.");
 
         return text[index];
     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/New/CSharpFormattingPass.CSharpDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/New/CSharpFormattingPass.CSharpDocumentGenerator.cs
@@ -650,7 +650,8 @@ internal partial class CSharpFormattingPass
                     _builder.AppendLine("class F");
                     _builder.AppendLine("{");
 
-                    return CreateLineInfo(skipNextLine: true);
+                    // Roslyn might move our brace to the previous line, so we might _not_ need to skip it 🤦‍
+                    return CreateLineInfo(skipNextLineIfBrace: true);
                 }
 
                 // If the braces are on different lines, then we can do nothing, unless its an @code or @functions
@@ -735,6 +736,7 @@ internal partial class CSharpFormattingPass
                 bool checkForNewLines = false,
                 bool skipPreviousLine = false,
                 bool skipNextLine = false,
+                bool skipNextLineIfBrace = false,
                 int htmlIndentLevel = 0,
                 int originOffset = 0,
                 int formattedLength = 0,
@@ -761,6 +763,7 @@ internal partial class CSharpFormattingPass
                     CheckForNewLines: checkForNewLines,
                     SkipPreviousLine: skipPreviousLine,
                     SkipNextLine: skipNextLine,
+                    SkipNextLineIfBrace: skipNextLineIfBrace,
                     HtmlIndentLevel: htmlIndentLevel,
                     OriginOffset: originOffset,
                     FormattedLength: formattedLength,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/New/CSharpFormattingPass.LineInfo.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/New/CSharpFormattingPass.LineInfo.cs
@@ -13,6 +13,7 @@ internal partial class CSharpFormattingPass
     /// <param name="CheckForNewLines">Whether the origin document text could have overflowed to multiple lines in the formatted document</param>
     /// <param name="SkipPreviousLine">Whether to skip the previous line in the formatted document, since it doesn't represent anything in the origin document</param>
     /// <param name="SkipNextLine">Whether to skip the next line in the formatted document, since it doesn't represent anything in the origin document</param>
+    /// <param name="SkipNextLineIfBrace">Whether to skip the next line in the formatted document, like <see cref="SkipNextLine" />, but only skips if the next line is a brace</param>
     /// <param name="HtmlIndentLevel">The indent level that the Html formatter applied to this line</param>
     /// <param name="OriginOffset">How many characters after the first non-whitespace character of the origin line should be skipped before applying formatting</param>
     /// <param name="FormattedLength">How many characters of the origin line the formatted line represents</param>
@@ -25,6 +26,7 @@ internal partial class CSharpFormattingPass
         bool CheckForNewLines,
         bool SkipPreviousLine,
         bool SkipNextLine,
+        bool SkipNextLineIfBrace,
         int HtmlIndentLevel,
         int OriginOffset,
         int FormattedLength,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/New/CSharpFormattingPass.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/New/CSharpFormattingPass.cs
@@ -147,7 +147,8 @@ internal sealed partial class CSharpFormattingPass(IHostServicesProvider hostSer
                 // If the next line is a brace, we skip it, otherwise we don't. This is used to skip the opening brace of a class
                 // that we insert, but Roslyn settings might place on the same like as the class declaration.
                 if (iFormatted + 1 < formattedCSharpText.Lines.Count &&
-                    formattedCSharpText.Lines[iFormatted + 1].CharAt(0) == '{')
+                    formattedCSharpText.Lines[iFormatted + 1] is { Span.Length: > 0 } nextLine &&
+                    nextLine.CharAt(0) == '{')
                 {
                     iFormatted++;
                 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/New/CSharpFormattingPass.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/New/CSharpFormattingPass.cs
@@ -21,6 +21,8 @@ internal sealed partial class CSharpFormattingPass(IHostServicesProvider hostSer
     private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<CSharpFormattingPass>();
     private readonly IHostServicesProvider _hostServicesProvider = hostServicesProvider;
 
+    private Func<SourceText, SourceText>? _formattedCSharpDocumentModifierFunc = null;
+
     public async Task<ImmutableArray<TextChange>> ExecuteAsync(FormattingContext context, ImmutableArray<TextChange> changes, CancellationToken cancellationToken)
     {
         // Process changes from previous passes
@@ -35,6 +37,12 @@ internal sealed partial class CSharpFormattingPass(IHostServicesProvider hostSer
         _logger.LogTestOnly($"Generated C# document:\r\n{generatedCSharpText}");
         var formattedCSharpText = await FormatCSharpAsync(generatedCSharpText, context.Options.ToIndentationOptions(), cancellationToken).ConfigureAwait(false);
         _logger.LogTestOnly($"Formatted generated C# document:\r\n{formattedCSharpText}");
+
+        if (_formattedCSharpDocumentModifierFunc is { } func)
+        {
+            formattedCSharpText = func(formattedCSharpText);
+            _logger.LogTestOnly($"Formatted generated C# document (after func):\r\n{formattedCSharpText}");
+        }
 
         // We now have a formatted C# document, and an original document, but we can't just apply the changes to the original
         // document as they come from very different places. What we want to do is go through each line of the generated document,
@@ -94,16 +102,37 @@ internal sealed partial class CSharpFormattingPass(IHostServicesProvider hostSer
                         // making it run over two lines, or even "string Prop { get" and making it span three lines.
                         // Since we assume Roslyn won't change anything non-whitespace, we just keep inserting the formatted lines
                         // of C# until we match the original line contents.
+                        // Of course, Roslyn could just as easily remove whitespace, eg making a "class Goo {" into "class Goo\n{",
+                        // so whilst the same theory applies, instead of inserting formatted lines, we eat the original lines.
                         while (!changedText.NonWhitespaceContentEquals(formattedCSharpText, originalStart, originalLine.End, formattedStart, formattedLine.End))
                         {
-                            // Sanity check: Because we're looking ahead through lines until the original line content is fully matches, we could loop forever if there is a bug somewhere
-                            Debug.Assert(
-                                FormattingUtilities.CountNonWhitespaceChars(changedText, originalStart, originalLine.End) >= FormattingUtilities.CountNonWhitespaceChars(formattedCSharpText, formattedStart, formattedLine.End),
-                                "Infinite loop in formatting! A bug in our visitor, or has Roslyn changed a non-whitespace char?");
+                            // If there are more non-whitespace chars in the original line, then its something like "if (true) {" to "if (true)", so keep inserting formatted lines until we're past the brace.
+                            if (FormattingUtilities.CountNonWhitespaceChars(changedText, originalStart, originalLine.End) >= FormattingUtilities.CountNonWhitespaceChars(formattedCSharpText, formattedStart, formattedLine.End))
+                            {
+                                iFormatted++;
+                                if (iFormatted >= formattedCSharpText.Lines.Count)
+                                {
+                                    _logger.LogError($"Ran out of formatted lines while trying to process formatted changes after {iOriginal} lines. Abandoning further formatting to not corrupt the source file, please report this issue.");
+                                    break;
+                                }
 
-                            iFormatted++;
-                            formattedLine = formattedCSharpText.Lines[iFormatted];
-                            formattingChanges.Add(new TextChange(new(originalLine.EndIncludingLineBreak, 0), htmlIndentString + formattedCSharpText.ToString(formattedLine.SpanIncludingLineBreak)));
+                                formattedLine = formattedCSharpText.Lines[iFormatted];
+                                formattingChanges.Add(new TextChange(new(originalLine.EndIncludingLineBreak, 0), htmlIndentString + formattedCSharpText.ToString(formattedLine.SpanIncludingLineBreak)));
+                            }
+                            else
+                            {
+                                // Otherwise, there are more whitespace chars in the formatted line, so "if (true)" to "if (true) {", so we need to remove the original lines until we're past the brace.
+                                var oldEnd = originalLine.End;
+                                iOriginal++;
+                                if (iOriginal >= changedText.Lines.Count)
+                                {
+                                    _logger.LogError("Ran out of lines while trying to process formatted changes. Abandoning further formatting to not corrupt the source file, please report this issue.");
+                                    break;
+                                }
+
+                                originalLine = changedText.Lines[iOriginal];
+                                formattingChanges.Add(new TextChange(TextSpan.FromBounds(oldEnd, originalLine.End), ""));
+                            }
                         }
                     }
                 }
@@ -112,6 +141,16 @@ internal sealed partial class CSharpFormattingPass(IHostServicesProvider hostSer
             if (lineInfo.SkipNextLine)
             {
                 iFormatted++;
+            }
+            else if (lineInfo.SkipNextLineIfBrace)
+            {
+                // If the next line is a brace, we skip it, otherwise we don't. This is used to skip the opening brace of a class
+                // that we insert, but Roslyn settings might place on the same like as the class declaration.
+                if (iFormatted + 1 < formattedCSharpText.Lines.Count &&
+                    formattedCSharpText.Lines[iFormatted + 1].CharAt(0) == '{')
+                {
+                    iFormatted++;
+                }
             }
         }
 
@@ -182,4 +221,14 @@ internal sealed partial class CSharpFormattingPass(IHostServicesProvider hostSer
     [Obsolete("Only for the syntax visualizer, do not call")]
     internal static string GetFormattingDocumentContentsForSyntaxVisualizer(RazorCodeDocument codeDocument)
         => CSharpDocumentGenerator.Generate(codeDocument, new()).SourceText.ToString();
+
+    internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+
+    internal readonly struct TestAccessor(CSharpFormattingPass instance)
+    {
+        public void SetFormattedCSharpDocumentModifierFunc(Func<SourceText, SourceText> func)
+        {
+            instance._formattedCSharpDocumentModifierFunc = func;
+        }
+    }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/RazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/RazorFormattingService.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -386,6 +387,15 @@ internal class RazorFormattingService : IRazorFormattingService
         {
             var contentValidationPass = service._validationPasses.OfType<FormattingContentValidationPass>().Single();
             contentValidationPass.DebugAssertsEnabled = debugAssertsEnabled;
+        }
+
+        public void SetFormattedCSharpDocumentModifierFunc(Func<SourceText, SourceText> func)
+        {
+            // This is only valid for the new formatting engine, so a test that sets it for the old formatter is probably written incorrectly.
+            Debug.Assert(service._languageServerFeatureOptions.UseNewFormattingEngine);
+
+            var pass = service._documentFormattingPasses.OfType<New.CSharpFormattingPass>().Single();
+            pass.GetTestAccessor().SetFormattedCSharpDocumentModifierFunc(func);
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingTestBase.cs
@@ -65,13 +65,14 @@ public abstract class FormattingTestBase : RazorToolingIntegrationTestBase
         bool allowDiagnostics = false,
         bool codeBlockBraceOnNextLine = false,
         bool inGlobalNamespace = false,
-        bool debugAssertsEnabled = true)
+        bool debugAssertsEnabled = true,
+        Func<SourceText, SourceText>? csharpModifierFunc = null)
     {
         (input, expected) = ProcessFormattingContext(input, expected);
 
         var razorLSPOptions = RazorLSPOptions.Default with { CodeBlockBraceOnNextLine = codeBlockBraceOnNextLine };
 
-        await RunFormattingTestInternalAsync(input, expected, tabSize, insertSpaces, fileKind, tagHelpers, allowDiagnostics, razorLSPOptions, inGlobalNamespace, debugAssertsEnabled);
+        await RunFormattingTestInternalAsync(input, expected, tabSize, insertSpaces, fileKind, tagHelpers, allowDiagnostics, razorLSPOptions, inGlobalNamespace, debugAssertsEnabled, csharpModifierFunc);
     }
 
     private async Task RunFormattingTestInternalAsync(
@@ -84,7 +85,8 @@ public abstract class FormattingTestBase : RazorToolingIntegrationTestBase
         bool allowDiagnostics,
         RazorLSPOptions? razorLSPOptions,
         bool inGlobalNamespace,
-        bool debugAssertsEnabled)
+        bool debugAssertsEnabled,
+        Func<SourceText, SourceText>? csharpModifierFunc)
     {
         // Arrange
         var fileKindValue = fileKind ?? RazorFileKind.Component;
@@ -111,7 +113,7 @@ public abstract class FormattingTestBase : RazorToolingIntegrationTestBase
 
         var languageServerFeatureOptions = new TestLanguageServerFeatureOptions(useNewFormattingEngine: _context.UseNewFormattingEngine);
 
-        var formattingService = await TestRazorFormattingService.CreateWithFullSupportAsync(LoggerFactory, codeDocument, razorLSPOptions, languageServerFeatureOptions, debugAssertsEnabled);
+        var formattingService = await TestRazorFormattingService.CreateWithFullSupportAsync(LoggerFactory, codeDocument, razorLSPOptions, languageServerFeatureOptions, debugAssertsEnabled, csharpModifierFunc);
         var documentContext = new DocumentContext(uri, documentSnapshot, projectContext: null);
 
         var client = new FormattingLanguageServerClient(_htmlFormattingService, LoggerFactory);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/TestRazorFormattingService.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/TestRazorFormattingService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
@@ -10,6 +11,7 @@ using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.CodeAnalysis.Razor.Formatting;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.CodeAnalysis.Text;
 using Moq;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
@@ -21,7 +23,8 @@ internal static class TestRazorFormattingService
         RazorCodeDocument? codeDocument = null,
         RazorLSPOptions? razorLSPOptions = null,
         LanguageServerFeatureOptions? languageServerFeatureOptions = null,
-        bool debugAssertsEnabled = false)
+        bool debugAssertsEnabled = false,
+        Func<SourceText, SourceText>? csharpModifierFunc = null)
     {
         codeDocument ??= TestRazorCodeDocument.CreateEmpty();
 
@@ -45,7 +48,13 @@ internal static class TestRazorFormattingService
         var hostServicesProvider = new DefaultHostServicesProvider();
 
         var service = new RazorFormattingService(mappingService, hostServicesProvider, languageServerFeatureOptions, loggerFactory);
-        service.GetTestAccessor().SetDebugAssertsEnabled(debugAssertsEnabled);
+        var accessor = service.GetTestAccessor();
+        accessor.SetDebugAssertsEnabled(debugAssertsEnabled);
+        if (csharpModifierFunc is not null)
+        {
+            accessor.SetFormattedCSharpDocumentModifierFunc(csharpModifierFunc);
+        }
+
         return service;
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/FormattingTestBase.cs
@@ -44,7 +44,8 @@ public abstract class FormattingTestBase : CohostEndpointTestBase
         bool insertSpaces = true,
         int tabSize = 4,
         bool allowDiagnostics = false,
-        bool debugAssertsEnabled = true)
+        bool debugAssertsEnabled = true,
+        Func<SourceText, SourceText>? csharpModifierFunc = null)
     {
         (input, expected) = ProcessFormattingContext(input, expected);
 
@@ -62,7 +63,12 @@ public abstract class FormattingTestBase : CohostEndpointTestBase
         }
 
         var formattingService = (RazorFormattingService)OOPExportProvider.GetExportedValue<IRazorFormattingService>();
-        formattingService.GetTestAccessor().SetDebugAssertsEnabled(debugAssertsEnabled);
+        var accessor = formattingService.GetTestAccessor();
+        accessor.SetDebugAssertsEnabled(debugAssertsEnabled);
+        if (csharpModifierFunc is not null)
+        {
+            accessor.SetFormattedCSharpDocumentModifierFunc(csharpModifierFunc);
+        }
 
         var generatedHtml = await RemoteServiceInvoker.TryInvokeAsync<IRemoteHtmlDocumentService, string?>(document.Project.Solution,
             (service, solutionInfo, ct) => service.GetHtmlDocumentTextAsync(solutionInfo, document.Id, ct),


### PR DESCRIPTION
Fixes the other reported issue in [developercommunity.visualstudio.com/t/Format-Document-in-Razor-pages-no-longer/10903159](https://developercommunity.visualstudio.com/t/Format-Document-in-Razor-pages-no-longer/10903159)
Fixes [devdiv.visualstudio.com/DevDiv/_workitems/edit/2471065](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2471065)

Allows users to have Roslyn configured for K&R style braces (ie, on the same line), even though its ugly 😛