### PR TITLE
Perf: Don't use HasFlag

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeGenerationOptions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeGenerationOptions.cs
@@ -63,10 +63,10 @@ public sealed partial class RazorCodeGenerationOptions
     }
 
     public bool DesignTime
-        => _flags.HasFlag(Flags.DesignTime);
+        => (_flags & Flags.DesignTime) == Flags.DesignTime;
 
     public bool IndentWithTabs
-        => _flags.HasFlag(Flags.IndentWithTabs);
+        => (_flags & Flags.IndentWithTabs) == Flags.IndentWithTabs;
 
     /// <summary>
     /// Gets a value that indicates whether to suppress the default <c>#pragma checksum</c> directive in the
@@ -78,7 +78,7 @@ public sealed partial class RazorCodeGenerationOptions
     /// purposes.
     /// </remarks>
     public bool SuppressChecksum
-        => _flags.HasFlag(Flags.SuppressChecksum);
+        => (_flags & Flags.SuppressChecksum) == Flags.SuppressChecksum;
 
     /// <summary>
     /// Gets a value that indicates whether to suppress the default metadata attributes in the generated
@@ -97,7 +97,7 @@ public sealed partial class RazorCodeGenerationOptions
     /// </para>
     /// </remarks>
     public bool SuppressMetadataAttributes
-        => _flags.HasFlag(Flags.SuppressMetadataAttributes);
+        => (_flags & Flags.SuppressMetadataAttributes) == Flags.SuppressMetadataAttributes;
 
     /// <summary>
     /// Gets a value that indicates whether to suppress the <c>RazorSourceChecksumAttribute</c>.
@@ -107,49 +107,49 @@ public sealed partial class RazorCodeGenerationOptions
     /// </para>
     /// </summary>
     public bool SuppressMetadataSourceChecksumAttributes
-        => _flags.HasFlag(Flags.SuppressMetadataSourceChecksumAttributes);
+        => (_flags & Flags.SuppressMetadataSourceChecksumAttributes) == Flags.SuppressMetadataSourceChecksumAttributes;
 
     /// <summary>
     /// Gets or sets a value that determines if an empty body is generated for the primary method.
     /// </summary>
     public bool SuppressPrimaryMethodBody
-        => _flags.HasFlag(Flags.SuppressPrimaryMethodBody);
+        => (_flags & Flags.SuppressPrimaryMethodBody) == Flags.SuppressPrimaryMethodBody;
 
     /// <summary>
     /// Gets a value that determines if nullability type enforcement should be suppressed for user code.
     /// </summary>
     public bool SuppressNullabilityEnforcement
-        => _flags.HasFlag(Flags.SuppressNullabilityEnforcement);
+        => (_flags & Flags.SuppressNullabilityEnforcement) == Flags.SuppressNullabilityEnforcement;
 
     /// <summary>
     /// Gets a value that determines if the components code writer may omit values for minimized attributes.
     /// </summary>
     public bool OmitMinimizedComponentAttributeValues
-        => _flags.HasFlag(Flags.OmitMinimizedComponentAttributeValues);
+        => (_flags & Flags.OmitMinimizedComponentAttributeValues) == Flags.OmitMinimizedComponentAttributeValues;
 
     /// <summary>
     /// Gets a value that determines if localized component names are to be supported.
     /// </summary>
     public bool SupportLocalizedComponentNames
-        => _flags.HasFlag(Flags.SupportLocalizedComponentNames);
+        => (_flags & Flags.SupportLocalizedComponentNames) == Flags.SupportLocalizedComponentNames;
 
     /// <summary>
     /// Gets a value that determines if enhanced line pragmas are to be utilized.
     /// </summary>
     public bool UseEnhancedLinePragma
-        => _flags.HasFlag(Flags.UseEnhancedLinePragma);
+        => (_flags & Flags.UseEnhancedLinePragma) == Flags.UseEnhancedLinePragma;
 
     /// <summary>
     /// Determines whether RenderTreeBuilder.AddComponentParameter should not be used.
     /// </summary>
     public bool SuppressAddComponentParameter
-        => _flags.HasFlag(Flags.SuppressAddComponentParameter);
+        => (_flags & Flags.SuppressAddComponentParameter) == Flags.SuppressAddComponentParameter;
 
     /// <summary>
     /// Determines if the file paths emitted as part of line pragmas should be mapped back to a valid path on windows.
     /// </summary>
     public bool RemapLinePragmaPathsOnWindows
-        => _flags.HasFlag(Flags.RemapLinePragmaPathsOnWindows);
+        => (_flags & Flags.RemapLinePragmaPathsOnWindows) == Flags.RemapLinePragmaPathsOnWindows;
 
     public RazorCodeGenerationOptions WithIndentSize(int value)
         => IndentSize == value


### PR DESCRIPTION
Instead do the bitwise operations explicitly, as this is *much* fast and less alloc-y on net fx.

The speedometer profile I'm looking at shows 39 MB of allocations due to this.
![image](https://github.com/user-attachments/assets/8f6203d6-5a47-4eda-b95b-dfd00bd1f526)