### PR TITLE
Reduce allocations during writing of the filepath in the CodeWriter

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/CodeGeneration/CSharpCodeWriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/CodeGeneration/CSharpCodeWriterTest.cs
@@ -292,7 +292,7 @@ public class CSharpCodeWriterTest
         var expected = $"#line 5 \"{filePath}\"" + writer.NewLine;
 
         // Act
-        writer.WriteLineNumberDirective(mappingLocation);
+        writer.WriteLineNumberDirective(mappingLocation, ensurePathBackslashes: false);
         var code = writer.GetText().ToString();
 
         // Assert

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriterExtensions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriterExtensions.cs
@@ -152,7 +152,7 @@ internal static class CodeWriterExtensions
         return writer;
     }
 
-    public static CodeWriter WriteEnhancedLineNumberDirective(this CodeWriter writer, SourceSpan span, int characterOffset = 0)
+    public static CodeWriter WriteEnhancedLineNumberDirective(this CodeWriter writer, SourceSpan span, int characterOffset, bool ensurePathBackslashes)
     {
         // All values here need to be offset by 1 since #line uses a 1-indexed numbering system.
         var lineNumberAsString = (span.LineIndex + 1).ToString(CultureInfo.InvariantCulture);
@@ -176,10 +176,10 @@ internal static class CodeWriterExtensions
             writer.Write(characterOffsetAsString).Write(" ");
         }
 
-        return writer.Write("\"").Write(span.FilePath).WriteLine("\"");
+        return writer.Write("\"").WriteFilePath(span.FilePath, ensurePathBackslashes).WriteLine("\"");
     }
 
-    public static CodeWriter WriteLineNumberDirective(this CodeWriter writer, SourceSpan span)
+    public static CodeWriter WriteLineNumberDirective(this CodeWriter writer, SourceSpan span, bool ensurePathBackslashes)
     {
         if (writer.Length >= writer.NewLine.Length && !IsAtBeginningOfLine(writer))
         {
@@ -187,7 +187,35 @@ internal static class CodeWriterExtensions
         }
 
         var lineNumberAsString = (span.LineIndex + 1).ToString(CultureInfo.InvariantCulture);
-        return writer.Write("#line ").Write(lineNumberAsString).Write(" \"").Write(span.FilePath).WriteLine("\"");
+        return writer.Write("#line ").Write(lineNumberAsString).Write(" \"").WriteFilePath(span.FilePath, ensurePathBackslashes).WriteLine("\"");
+    }
+
+    private static CodeWriter WriteFilePath(this CodeWriter writer, string filePath, bool ensurePathBackslashes)
+    {
+        if (!ensurePathBackslashes)
+        {
+            return writer.Write(filePath);
+        }
+
+        // ISSUE: https://github.com/dotnet/razor/issues/9108
+        // The razor tooling normalizes paths to be forward slash based, regardless of OS.
+        // If you try and use the line pragma in the design time docs to map back to the original file it will fail,
+        // as the path isn't actually valid on windows. As a workaround we apply a simple heuristic to switch the
+        // paths back when writing out the design time paths.
+        var filePathMemory = filePath.AsMemory();
+        var forwardSlashIndex = filePathMemory.Span.IndexOf('/');
+        while (forwardSlashIndex >= 0)
+        {
+            writer.Write(filePathMemory[..forwardSlashIndex]);
+            writer.Write("\\");
+
+            filePathMemory = filePathMemory[(forwardSlashIndex + 1)..];
+            forwardSlashIndex = filePathMemory.Span.IndexOf('/');
+        }
+
+        writer.Write(filePathMemory);
+
+        return writer;
     }
 
     public static CodeWriter WriteStartMethodInvocation(this CodeWriter writer, string methodName)
@@ -663,20 +691,6 @@ internal static class CodeWriterExtensions
         return new LinePragmaWriter(writer, span.Value, context, characterOffset, useEnhancedLinePragma: true, suppressLineDefaultAndHidden);
     }
 
-    private static SourceSpan RemapFilePathIfNecessary(SourceSpan sourceSpan, CodeRenderingContext context)
-    {
-        if (context.Options.RemapLinePragmaPathsOnWindows && PlatformInformation.IsWindows)
-        {
-            // ISSUE: https://github.com/dotnet/razor/issues/9108
-            // The razor tooling normalizes paths to be forward slash based, regardless of OS.
-            // If you try and use the line pragma in the design time docs to map back to the original file it will fail,
-            // as the path isn't actually valid on windows. As a workaround we apply a simple heuristic to switch the
-            // paths back when writing out the design time paths.
-            sourceSpan = new SourceSpan(sourceSpan.FilePath.Replace("/", "\\"), sourceSpan.AbsoluteIndex, sourceSpan.LineIndex, sourceSpan.CharacterIndex, sourceSpan.Length, sourceSpan.LineCount, sourceSpan.EndCharacterIndex);
-        }
-        return sourceSpan;
-    }
-
     private static void WriteVerbatimStringLiteral(CodeWriter writer, ReadOnlyMemory<char> literal)
     {
         writer.Write("@\"");
@@ -876,14 +890,14 @@ internal static class CodeWriterExtensions
                 _writer.WriteLine("#nullable restore");
             }
 
-            var sourceSpan = RemapFilePathIfNecessary(span, context);
+            var ensurePathBackslashes = context.Options.RemapLinePragmaPathsOnWindows && PlatformInformation.IsWindows;
             if (useEnhancedLinePragma && _context.Options.UseEnhancedLinePragma)
             {
-                WriteEnhancedLineNumberDirective(writer, sourceSpan, characterOffset);
+                WriteEnhancedLineNumberDirective(writer, span, characterOffset, ensurePathBackslashes);
             }
             else
             {
-                WriteLineNumberDirective(writer, sourceSpan);
+                WriteLineNumberDirective(writer, span, ensurePathBackslashes);
             }
 
             // Capture the line index after writing the #line directive.


### PR DESCRIPTION
Previously, the code would do a string.Replace on the filePath to allocate a new windows-friendly path. Instead, we can just separate the path into Spans and add those to the CodeWriter (separated by backslashes)

During the typing scenario in the razor editing speedometer test, the string.Replace accounts for about 0.4% of allocations.

![image](https://github.com/user-attachments/assets/471958ce-b793-4a8b-bc5d-089559d80b4e)