### PR TITLE
HtmlTokenizer: Cache tokens with well-known text

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/HtmlTokenizer.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/HtmlTokenizer.cs
@@ -1,7 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable disable
 
 using System.Diagnostics;
 using Microsoft.AspNetCore.Razor.Language.Syntax.InternalSyntax;
@@ -196,7 +194,7 @@ internal class HtmlTokenizer : Tokenizer
         return Transition(HtmlTokenizerState.Data, EndToken(SyntaxKind.Text));
     }
 
-    private SyntaxToken Token()
+    private SyntaxToken? Token()
     {
         Debug.Assert(AtToken());
         var sym = CurrentCharacter;
@@ -233,7 +231,7 @@ internal class HtmlTokenizer : Tokenizer
         }
     }
 
-    private SyntaxToken Whitespace()
+    private SyntaxToken? Whitespace()
     {
         while (SyntaxFacts.IsWhitespace(CurrentCharacter))
         {
@@ -242,7 +240,7 @@ internal class HtmlTokenizer : Tokenizer
         return EndToken(SyntaxKind.Whitespace);
     }
 
-    private SyntaxToken Newline()
+    private SyntaxToken? Newline()
     {
         Debug.Assert(SyntaxFacts.IsNewLine(CurrentCharacter));
         // CSharp Spec §2.3.1
@@ -283,7 +281,7 @@ internal class HtmlTokenizer : Tokenizer
         return Transition((int)state, result: null);
     }
 
-    private StateResult Transition(HtmlTokenizerState state, SyntaxToken result)
+    private StateResult Transition(HtmlTokenizerState state, SyntaxToken? result)
     {
         return Transition((int)state, result);
     }


### PR DESCRIPTION
Razor only caches a limited number of green SyntaxTokens--specifically those that have different text, such as identifiers. However, it doesn't cache green SyntaxTokens will well-known text, even though those can always be shared if they don't have any diagnostics. This PR introduces a cache for SyntaxKind to SyntaxToken to the HTML tokenizer for tokens with well-known text.

Note: This only addresses the HTML tokenizer and C# will be handled separately. Because some SyntaxKind values are shared across HTML and C# but have different text (like SyntaxKind.Equals -- "=" in HTML and "==" in C#), it'll take a more significant change to solve this in a unified way.

----
CI Build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2724900&view=results
Toolset Run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2724901&view=results