### PR TITLE
Create a specialized pool for arrays of ClassifiedSpanInternal

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/ClassifiedSpanVisitor.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/ClassifiedSpanVisitor.cs
@@ -6,11 +6,14 @@ using System.Collections.Immutable;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.Extensions.ObjectPool;
 
 namespace Microsoft.AspNetCore.Razor.Language;
 
 internal class ClassifiedSpanVisitor : SyntaxWalker
 {
+    private static readonly ObjectPool<ImmutableArray<ClassifiedSpanInternal>.Builder> Pool = DefaultPool.Create(Policy.Instance, size: 5);
+
     private readonly RazorSourceDocument _source;
     private readonly ImmutableArray<ClassifiedSpanInternal>.Builder _spans;
 
@@ -51,7 +54,7 @@ internal class ClassifiedSpanVisitor : SyntaxWalker
 
     public static ImmutableArray<ClassifiedSpanInternal> VisitRoot(RazorSyntaxTree syntaxTree)
     {
-        using var _ = ArrayBuilderPool<ClassifiedSpanInternal>.GetPooledObject(out var builder);
+        using var _ = Pool.GetPooledObject(out var builder);
 
         var visitor = new ClassifiedSpanVisitor(syntaxTree.Source, builder);
         visitor.Visit(syntaxTree.Root);
@@ -362,5 +365,33 @@ internal class ClassifiedSpanVisitor : SyntaxWalker
 
         var span = new ClassifiedSpanInternal(spanSource, blockSource, kind, _currentBlockKind, acceptedCharacters.Value);
         _spans.Add(span);
+    }
+
+    private class Policy : IPooledObjectPolicy<ImmutableArray<ClassifiedSpanInternal>.Builder>
+    {
+        public static readonly Policy Instance = new();
+
+        // Significantly larger than DefaultPool.MaximumObjectSize as there shouldn't be much concurrency
+        // of these arrays (we limit the number of pooled items to 5) and they are commonly large
+        public const int MaximumObjectSize = DefaultPool.MaximumObjectSize * 32;
+
+        private Policy()
+        {
+        }
+
+        public ImmutableArray<ClassifiedSpanInternal>.Builder Create() => ImmutableArray.CreateBuilder<ClassifiedSpanInternal>();
+
+        public bool Return(ImmutableArray<ClassifiedSpanInternal>.Builder builder)
+        {
+            builder.Clear();
+
+            if (builder.Capacity > MaximumObjectSize)
+            {
+                // Differs from ArrayBuilderPool.Policy's behavior as we allow our array to grow significantly larger
+                builder.Capacity = 0;
+            }
+
+            return true;
+        }
     }
 }


### PR DESCRIPTION
Create a specialized pool for arrays of ClassifiedSpanInternal

These arrays show up as a fairly large allocation in the typing scenario of the razor speedometer test. There are 150 MB (2.1%)of allocations of ClassifiedSpanInternal[] in the profile, but only 2.1 MB of ImmutableArray<ClassifiedSpanInternal>. This should be partly addressed by the earlier switch from DrainToImmutable use ToImmutableAndClear. However, this is also indicative that the 512 entry threshold for ArrayBuilderPool isn't sufficient for ClassifiedSpanInternal array counts. Roslyn has experienced this too and utilizes separate array pools for classification/tagging performance. The new pool has a threshold of 16K, much larger than the 512 entry limit. I tested this against a 60 KB razor file and was hitting about 7K entries, so this seemed like a pretty reasonable value. To ensure this doesn't add to total memory usage, the pool is limited to only 5 entries, as cconcurrent execution of classification isn't common.

![image](https://github.com/user-attachments/assets/0fa28ed4-816e-480e-8fa3-bd8871e0e986)
...
![image](https://github.com/user-attachments/assets/45cffb1a-e93b-43e3-9768-2a478c46cda7)