### PR TITLE
Reduce allocations in calls to WithAnnotationsGreen

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/InternalSyntax/MarkupEndTagSyntax.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/InternalSyntax/MarkupEndTagSyntax.cs
@@ -22,14 +22,5 @@ internal sealed partial class MarkupEndTagSyntax
     }
 
     public MarkupEndTagSyntax AsMarkupTransition()
-    {
-        var annotations = new List<SyntaxAnnotation>(GetAnnotations())
-            {
-                new SyntaxAnnotation(MarkupTransitionKey, new object())
-            };
-
-        var newGreen = this.WithAnnotationsGreen(annotations.ToArray());
-
-        return newGreen;
-    }
+        =>  this.WithAnnotationsGreen([.. GetAnnotations(), new(MarkupTransitionKey, new object())]);
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/InternalSyntax/MarkupStartTagSyntax.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/InternalSyntax/MarkupStartTagSyntax.cs
@@ -22,14 +22,5 @@ internal sealed partial class MarkupStartTagSyntax
     }
 
     public MarkupStartTagSyntax AsMarkupTransition()
-    {
-        var annotations = new List<SyntaxAnnotation>(GetAnnotations())
-            {
-                new SyntaxAnnotation(MarkupTransitionKey, new object())
-            };
-
-        var newGreen = this.WithAnnotationsGreen(annotations.ToArray());
-
-        return newGreen;
-    }
+        => this.WithAnnotationsGreen([.. GetAnnotations(), new(MarkupTransitionKey, new object())]);
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/InternalSyntax/RazorDirectiveSyntax.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/InternalSyntax/RazorDirectiveSyntax.cs
@@ -22,14 +22,5 @@ internal sealed partial class RazorDirectiveSyntax
     }
 
     public RazorDirectiveSyntax WithDirectiveDescriptor(DirectiveDescriptor descriptor)
-    {
-        var annotations = new List<SyntaxAnnotation>(GetAnnotations())
-            {
-                new SyntaxAnnotation(DirectiveDescriptorKey, descriptor)
-            };
-
-        var newGreen = this.WithAnnotationsGreen(annotations.ToArray());
-
-        return newGreen;
-    }
+        => this.WithAnnotationsGreen([.. GetAnnotations(), new(DirectiveDescriptorKey, descriptor)]);
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/MarkupMinimizedTagHelperAttributeSyntax.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/MarkupMinimizedTagHelperAttributeSyntax.cs
@@ -3,8 +3,6 @@
 
 #nullable disable
 
-using System.Collections.Generic;
-
 namespace Microsoft.AspNetCore.Razor.Language.Syntax;
 
 internal sealed partial class MarkupMinimizedTagHelperAttributeSyntax

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/MarkupMinimizedTagHelperAttributeSyntax.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/MarkupMinimizedTagHelperAttributeSyntax.cs
@@ -22,12 +22,7 @@ internal sealed partial class MarkupMinimizedTagHelperAttributeSyntax
 
     public MarkupMinimizedTagHelperAttributeSyntax WithTagHelperAttributeInfo(TagHelperAttributeInfo info)
     {
-        var annotations = new List<SyntaxAnnotation>(GetAnnotations())
-            {
-                new SyntaxAnnotation(TagHelperAttributeInfoKey, info)
-            };
-
-        var newGreen = Green.WithAnnotationsGreen(annotations.ToArray());
+        var newGreen = Green.WithAnnotationsGreen([.. GetAnnotations(), new(TagHelperAttributeInfoKey, info)]);
 
         return (MarkupMinimizedTagHelperAttributeSyntax)newGreen.CreateRed(Parent, Position);
     }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/MarkupMinimizedTagHelperDirectiveAttributeSyntax.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/MarkupMinimizedTagHelperDirectiveAttributeSyntax.cs
@@ -35,12 +35,7 @@ internal sealed partial class MarkupMinimizedTagHelperDirectiveAttributeSyntax
 
     public MarkupMinimizedTagHelperDirectiveAttributeSyntax WithTagHelperAttributeInfo(TagHelperAttributeInfo info)
     {
-        var annotations = new List<SyntaxAnnotation>(GetAnnotations())
-            {
-                new SyntaxAnnotation(TagHelperAttributeInfoKey, info)
-            };
-
-        var newGreen = Green.WithAnnotationsGreen(annotations.ToArray());
+        var newGreen = Green.WithAnnotationsGreen([.. GetAnnotations(), new(TagHelperAttributeInfoKey, info)]);
 
         return (MarkupMinimizedTagHelperDirectiveAttributeSyntax)newGreen.CreateRed(Parent, Position);
     }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/MarkupMinimizedTagHelperDirectiveAttributeSyntax.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/MarkupMinimizedTagHelperDirectiveAttributeSyntax.cs
@@ -3,8 +3,6 @@
 
 #nullable disable
 
-using System.Collections.Generic;
-
 namespace Microsoft.AspNetCore.Razor.Language.Syntax;
 
 internal sealed partial class MarkupMinimizedTagHelperDirectiveAttributeSyntax

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/MarkupTagHelperAttributeSyntax.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/MarkupTagHelperAttributeSyntax.cs
@@ -22,12 +22,7 @@ internal sealed partial class MarkupTagHelperAttributeSyntax
 
     public MarkupTagHelperAttributeSyntax WithTagHelperAttributeInfo(TagHelperAttributeInfo info)
     {
-        var annotations = new List<SyntaxAnnotation>(GetAnnotations())
-            {
-                new SyntaxAnnotation(TagHelperAttributeInfoKey, info)
-            };
-
-        var newGreen = Green.WithAnnotationsGreen(annotations.ToArray());
+        var newGreen = Green.WithAnnotationsGreen([.. GetAnnotations(), new(TagHelperAttributeInfoKey, info)]);
 
         return (MarkupTagHelperAttributeSyntax)newGreen.CreateRed(Parent, Position);
     }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/MarkupTagHelperAttributeSyntax.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/MarkupTagHelperAttributeSyntax.cs
@@ -3,8 +3,6 @@
 
 #nullable disable
 
-using System.Collections.Generic;
-
 namespace Microsoft.AspNetCore.Razor.Language.Syntax;
 
 internal sealed partial class MarkupTagHelperAttributeSyntax

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/MarkupTagHelperDirectiveAttributeSyntax.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/MarkupTagHelperDirectiveAttributeSyntax.cs
@@ -35,12 +35,7 @@ internal sealed partial class MarkupTagHelperDirectiveAttributeSyntax
 
     public MarkupTagHelperDirectiveAttributeSyntax WithTagHelperAttributeInfo(TagHelperAttributeInfo info)
     {
-        var annotations = new List<SyntaxAnnotation>(GetAnnotations())
-            {
-                new SyntaxAnnotation(TagHelperAttributeInfoKey, info)
-            };
-
-        var newGreen = Green.WithAnnotationsGreen(annotations.ToArray());
+        var newGreen = Green.WithAnnotationsGreen([.. GetAnnotations(), new(TagHelperAttributeInfoKey, info)]);
 
         return (MarkupTagHelperDirectiveAttributeSyntax)newGreen.CreateRed(Parent, Position);
     }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/MarkupTagHelperDirectiveAttributeSyntax.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/MarkupTagHelperDirectiveAttributeSyntax.cs
@@ -3,8 +3,6 @@
 
 #nullable disable
 
-using System.Collections.Generic;
-
 namespace Microsoft.AspNetCore.Razor.Language.Syntax;
 
 internal sealed partial class MarkupTagHelperDirectiveAttributeSyntax

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/RazorDirectiveSyntax.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/RazorDirectiveSyntax.cs
@@ -22,12 +22,7 @@ internal sealed partial class RazorDirectiveSyntax
 
     public RazorDirectiveSyntax WithDirectiveDescriptor(DirectiveDescriptor descriptor)
     {
-        var annotations = new List<SyntaxAnnotation>(GetAnnotations())
-            {
-                new SyntaxAnnotation(DirectiveDescriptorKey, descriptor)
-            };
-
-        var newGreen = Green.WithAnnotationsGreen(annotations.ToArray());
+        var newGreen = Green.WithAnnotationsGreen([.. GetAnnotations(), new(DirectiveDescriptorKey, descriptor)]);
 
         return (RazorDirectiveSyntax)newGreen.CreateRed(Parent, Position);
     }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/RazorDirectiveSyntax.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/RazorDirectiveSyntax.cs
@@ -3,8 +3,6 @@
 
 #nullable disable
 
-using System.Collections.Generic;
-
 namespace Microsoft.AspNetCore.Razor.Language.Syntax;
 
 internal sealed partial class RazorDirectiveSyntax


### PR DESCRIPTION
Each caller changed was allocating more than necessary:

1) List object created
2) If GetAnnotations isn't empty, there was an array allocated in the list 
3) The Add calls would always allocate (even when constructed with a non-empty GetAnnotations result) 
4) ToArray allocation

Instead, there is just a single array allocation.

I don't expect this to have a huge effect, but there are 35 MB of List/array of SyntaxAnnotations allocated in the speedometer trace I'm looking at during the typing scenario (about 0.5% of allocations)

![image](https://github.com/user-attachments/assets/8554dec3-31be-4a95-92c7-c69b75768789)
...
![image](https://github.com/user-attachments/assets/02f659ee-1374-4ba8-a3df-b33c6b62c30e)