### PR TITLE
Tiny allocation improvement in TagHelperParseTreeRewriter.Rewriter.CurrentTagHelperTracker

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/TagHelperParseTreeRewriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/TagHelperParseTreeRewriter.cs
@@ -80,7 +80,21 @@ internal static class TagHelperParseTreeRewriter
 
         private bool CurrentParentIsTagHelper => CurrentTracker?.IsTagHelper ?? false;
 
-        private TagHelperTracker? CurrentTagHelperTracker => _trackerStack.Count > 0 ? _trackerStack.Peek() as TagHelperTracker : null;
+        private TagHelperTracker? CurrentTagHelperTracker
+        {
+            get
+            {
+                foreach (var tracker in _trackerStack)
+                {
+                    if (tracker.IsTagHelper)
+                    {
+                        return tracker as TagHelperTracker;
+                    }
+                }
+
+                return null;
+            }
+        }
 
         public override SyntaxNode VisitMarkupElement(MarkupElementSyntax node)
         {

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/TagHelperParseTreeRewriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/TagHelperParseTreeRewriter.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 
@@ -81,7 +80,7 @@ internal static class TagHelperParseTreeRewriter
 
         private bool CurrentParentIsTagHelper => CurrentTracker?.IsTagHelper ?? false;
 
-        private TagHelperTracker? CurrentTagHelperTracker => _trackerStack.FirstOrDefault(t => t.IsTagHelper) as TagHelperTracker;
+        private TagHelperTracker? CurrentTagHelperTracker => _trackerStack.Count > 0 ? _trackerStack.Peek() as TagHelperTracker : null;
 
         public override SyntaxNode VisitMarkupElement(MarkupElementSyntax node)
         {


### PR DESCRIPTION
Tiny allocation improvement in TagHelperParseTreeRewriter.Rewriter.CurrentTagHelperTracker

The FirstOrDefault Linq usage was shown to be allocating about 9 MB (0.1%) in the typing scenario in the razor speedometer test. Small win for a small fix.

![image](https://github.com/user-attachments/assets/7cf3e12d-5498-48fe-b3ae-80b7a559a49c)