### PR TITLE
Convert CreateString helper to static extension method

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.cs
@@ -507,7 +507,7 @@ public sealed partial class CodeWriter : IDisposable
                 return string.Empty;
             }
 
-            var result = string.CreateString(_remainingLength, (_page, _chunkIndex, _charIndex), static (destination, state) =>
+            var result = string.Create(_remainingLength, (_page, _chunkIndex, _charIndex), static (destination, state) =>
             {
                 var (page, chunkIndex, charIndex) = state;
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultRazorProjectFileSystem.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultRazorProjectFileSystem.cs
@@ -127,7 +127,7 @@ internal class DefaultRazorProjectFileSystem : RazorProjectFileSystem
         var needsSlash = Root[^1] is not '/' && normalizedPath[0] is not '/';
         var length = Root.Length + normalizedPath.Length + (needsSlash ? 1 : 0);
 
-        return string.CreateString(
+        return string.Create(
             length,
             state: (Root, normalizedPath, needsSlash),
             static (span, state) =>

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorProjectFileSystem.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorProjectFileSystem.cs
@@ -120,7 +120,7 @@ public abstract partial class RazorProjectFileSystem
         {
             pathMemory = pathMemory[..(index + 1)];
 
-            var itemPath = string.CreateString(
+            var itemPath = string.Create(
                 length: pathMemory.Length + fileName.Length,
                 state: (pathMemory, fileName),
                 static (span, state) =>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Logging/LogMessageFormatter.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Logging/LogMessageFormatter.cs
@@ -22,7 +22,7 @@ internal static partial class LogMessageFormatter
                 ref messageLineRangeBuilder, ref exceptionLineRangeBuilder);
 
             // Create the final string.
-            return string.CreateString(state.Length, state, static (span, state) =>
+            return string.Create(state.Length, state, static (span, state) =>
             {
                 Write(state.CategoryNamePart, ref span);
 

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/StringExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/StringExtensions.cs
@@ -555,6 +555,7 @@ internal static class StringExtensions
 #endif
     }
 
+#if !NET
     /// <summary>
     ///  Encapsulates a method that receives a span of objects of type <typeparamref name="T"/>
     ///  and a state object of type <typeparamref name="TArg"/>.
@@ -598,27 +599,24 @@ internal static class StringExtensions
         ///  Therefore, it is the delegate's responsibility to ensure that every element of the span is assigned.
         ///  Otherwise, the resulting string could contain random characters.
         /// </remarks>
-        public unsafe static string CreateString<TState>(int length, TState state, SpanAction<char, TState> action)
+        public unsafe static string Create<TState>(int length, TState state, SpanAction<char, TState> action)
         {
-#if NET
-            return string.Create(length, (action, state), static (span, state) => state.action(span, state.state));
-#else
-        ArgHelper.ThrowIfNegative(length);
+            ArgHelper.ThrowIfNegative(length);
 
-        if (length == 0)
-        {
-            return string.Empty;
-        }
+            if (length == 0)
+            {
+                return string.Empty;
+            }
 
-        var result = new string('\0', length);
+            var result = new string('\0', length);
 
-        fixed (char* ptr = result)
-        {
-            action(new Span<char>(ptr, length), state);
-        }
+            fixed (char* ptr = result)
+            {
+                action(new Span<char>(ptr, length), state);
+            }
 
-        return result;
-#endif
+            return result;
         }
     }
+#endif
 }


### PR DESCRIPTION
To improve discoverability, transform Razor's StringExtensions.CreateString(...) helper to a static extension method on string.