### PR TITLE
Fix override completion in VS Code for Cohosting

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionItemResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionItemResolver.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.CodeAnalysis.Razor.Completion.Delegation;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.Formatting;
+using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Tooltip;
 
@@ -19,13 +20,15 @@ internal class DelegatedCompletionItemResolver(
     IRazorFormattingService formattingService,
     IDocumentMappingService documentMappingService,
     RazorLSPOptionsMonitor optionsMonitor,
-    IClientConnection clientConnection) : CompletionItemResolver
+    IClientConnection clientConnection,
+    ILoggerFactory loggerFactory) : CompletionItemResolver
 {
     private readonly IDocumentContextFactory _documentContextFactory = documentContextFactory;
     private readonly IRazorFormattingService _formattingService = formattingService;
     private readonly IDocumentMappingService _documentMappingService = documentMappingService;
     private readonly RazorLSPOptionsMonitor _optionsMonitor = optionsMonitor;
     private readonly IClientConnection _clientConnection = clientConnection;
+    private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<DelegatedCompletionItemResolver>();
 
     public override async Task<VSInternalCompletionItem?> ResolveAsync(
         VSInternalCompletionItem item,
@@ -100,6 +103,6 @@ internal class DelegatedCompletionItemResolver(
 
         var options = RazorFormattingOptions.From(formattingOptions, _optionsMonitor.CurrentValue.CodeBlockBraceOnNextLine);
 
-        return await DelegatedCompletionHelper.FormatCSharpCompletionItemAsync(resolvedCompletionItem, documentContext, options, _formattingService, _documentMappingService, cancellationToken).ConfigureAwait(false);
+        return await DelegatedCompletionHelper.FormatCSharpCompletionItemAsync(resolvedCompletionItem, documentContext, options, _formattingService, _documentMappingService, _logger, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionItemResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionItemResolver.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.CodeAnalysis.Razor.Completion.Delegation;
+using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.Formatting;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Tooltip;
@@ -16,11 +17,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation;
 internal class DelegatedCompletionItemResolver(
     IDocumentContextFactory documentContextFactory,
     IRazorFormattingService formattingService,
+    IDocumentMappingService documentMappingService,
     RazorLSPOptionsMonitor optionsMonitor,
     IClientConnection clientConnection) : CompletionItemResolver
 {
     private readonly IDocumentContextFactory _documentContextFactory = documentContextFactory;
     private readonly IRazorFormattingService _formattingService = formattingService;
+    private readonly IDocumentMappingService _documentMappingService = documentMappingService;
     private readonly RazorLSPOptionsMonitor _optionsMonitor = optionsMonitor;
     private readonly IClientConnection _clientConnection = clientConnection;
 
@@ -97,6 +100,6 @@ internal class DelegatedCompletionItemResolver(
 
         var options = RazorFormattingOptions.From(formattingOptions, _optionsMonitor.CurrentValue.CodeBlockBraceOnNextLine);
 
-        return await DelegatedCompletionHelper.FormatCSharpCompletionItemAsync(resolvedCompletionItem, documentContext, options, _formattingService, cancellationToken).ConfigureAwait(false);
+        return await DelegatedCompletionHelper.FormatCSharpCompletionItemAsync(resolvedCompletionItem, documentContext, options, _formattingService, _documentMappingService, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionListProvider.cs
@@ -117,7 +117,7 @@ internal class DelegatedCompletionListProvider(
             : DelegatedCompletionHelper.RewriteHtmlResponse(delegatedResponse, razorCompletionOptions);
 
         var completionCapability = clientCapabilities?.TextDocument?.Completion as VSInternalCompletionSetting;
-        var resolutionContext = new DelegatedCompletionResolutionContext(identifier, positionInfo.LanguageKind, rewrittenResponse.Data);
+        var resolutionContext = new DelegatedCompletionResolutionContext(identifier, positionInfo.LanguageKind, rewrittenResponse.Data ?? rewrittenResponse.ItemDefaults?.Data);
         var resultId = _completionListCache.Add(rewrittenResponse, resolutionContext);
         rewrittenResponse.SetResultId(resultId, completionCapability);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -94,7 +94,7 @@ internal class RazorCompletionEndpoint(
             }
 
             var completionCapability = _clientCapabilities?.TextDocument?.Completion as VSInternalCompletionSetting;
-            var supportsCompletionListData = completionCapability?.CompletionList?.Data ?? false;
+            var supportsCompletionListData = completionCapability.SupportsCompletionListData();
 
             RazorCompletionResolveData.Wrap(result, request.TextDocument, supportsCompletionListData: supportsCompletionListData);
             return result;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
@@ -212,7 +212,7 @@ internal sealed class CohostDocumentCompletionEndpoint(
         }
 
         var completionCapability = _clientCapabilitiesService.ClientCapabilities.TextDocument?.Completion as VSInternalCompletionSetting;
-        var supportsCompletionListData = completionCapability?.CompletionList?.Data ?? false;
+        var supportsCompletionListData = completionCapability.SupportsCompletionListData();
 
         RazorCompletionResolveData.Wrap(combinedCompletionList, originalTextDocumentIdentifier, supportsCompletionListData: supportsCompletionListData);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
@@ -69,7 +69,7 @@ internal sealed class CohostDocumentCompletionEndpoint(
                 Method = Methods.TextDocumentCompletionName,
                 RegisterOptions = new CompletionRegistrationOptions()
                 {
-                    ResolveProvider = false, // TODO - change to true when Resolve is implemented
+                    ResolveProvider = true,
                     TriggerCharacters = [.. _triggerAndCommitCharacters.AllTriggerCharacters],
                     AllCommitCharacters = [.. _triggerAndCommitCharacters.AllCommitCharacters]
                 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
@@ -239,7 +239,7 @@ internal sealed class CohostDocumentCompletionEndpoint(
         var completionCapability = _clientCapabilitiesService.ClientCapabilities.TextDocument?.Completion as VSInternalCompletionSetting;
 
         var razorDocumentIdentifier = new TextDocumentIdentifierAndVersion(request.TextDocument, Version: 0);
-        var resolutionContext = new DelegatedCompletionResolutionContext(razorDocumentIdentifier, RazorLanguageKind.Html, rewrittenResponse.Data);
+        var resolutionContext = new DelegatedCompletionResolutionContext(razorDocumentIdentifier, RazorLanguageKind.Html, rewrittenResponse.Data ?? rewrittenResponse.ItemDefaults?.Data);
         var resultId = _completionListCache.Add(rewrittenResponse, resolutionContext);
         rewrittenResponse.SetResultId(resultId, completionCapability);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionResolveEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionResolveEndpoint.cs
@@ -44,7 +44,7 @@ internal sealed class CohostDocumentCompletionResolveEndpoint(
     private readonly IRemoteServiceInvoker _remoteServiceInvoker = remoteServiceInvoker;
     private readonly IClientSettingsManager _clientSettingsManager = clientSettingsManager;
     private readonly IHtmlRequestInvoker _requestInvoker = requestInvoker;
-    private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<CohostDocumentCompletionEndpoint>();
+    private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<CohostDocumentCompletionResolveEndpoint>();
 
     protected override bool MutatesSolutionState => false;
 
@@ -103,7 +103,7 @@ internal sealed class CohostDocumentCompletionResolveEndpoint(
             Debug.Assert(_logger is not null);
             Debug.Assert(nameof(DelegatedCompletionHelper).Length > 0);
 
-            // We don't support completion resolve in VS Code
+            // We don't support Html completion resolve in VS Code
             return completionItem;
 #else
             completionItem.Data = DelegatedCompletionHelper.GetOriginalCompletionItemData(completionItem, completionList, delegatedContext.OriginalCompletionListData);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionListMerger.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionListMerger.cs
@@ -45,6 +45,7 @@ internal static class CompletionListMerger
         // We don't fully support merging continue characters currently. Razor doesn't currently use them so delegated completion lists always win.
         var mergedContinueWithCharacters = razorCompletionList.ContinueCharacters ?? delegatedCompletionList.ContinueCharacters;
 
+        var mergedItemDefaultsData = MergeData(razorCompletionList.ItemDefaults?.Data, delegatedCompletionList.ItemDefaults?.Data);
         // We don't fully support merging edit ranges currently. Razor doesn't currently use them so delegated completion lists always win.
         var mergedItemDefaultsEditRange = razorCompletionList.ItemDefaults?.EditRange ?? delegatedCompletionList.ItemDefaults?.EditRange;
 
@@ -58,6 +59,7 @@ internal static class CompletionListMerger
             ContinueCharacters = mergedContinueWithCharacters,
             ItemDefaults = new CompletionListItemDefaults()
             {
+                Data = mergedItemDefaultsData,
                 EditRange = mergedItemDefaultsEditRange,
             }
         };
@@ -152,14 +154,16 @@ internal static class CompletionListMerger
 
     private static void EnsureMergeableData(RazorVSInternalCompletionList completionListA, RazorVSInternalCompletionList completionListB)
     {
-        if (completionListA.Data != completionListB.Data &&
-            (completionListA.Data is null || completionListB.Data is null))
+        var completionListAData = completionListA.Data ?? completionListA.ItemDefaults?.Data;
+        var completionListBData = completionListB.Data ?? completionListB.ItemDefaults?.Data;
+        if (completionListAData != completionListBData &&
+            (completionListAData is null || completionListBData is null))
         {
             // One of the completion lists have data while the other does not, we need to ensure that any non-data centric items don't get incorrect data associated
 
             // The candidate completion list will be one where we populate empty data for any `null` specifying data given we'll be merging
             // two completion lists together we don't want incorrect data to be inherited down
-            var candidateCompletionList = completionListA.Data is null ? completionListA : completionListB;
+            var candidateCompletionList = completionListAData is null ? completionListA : completionListB;
             for (var i = 0; i < candidateCompletionList.Items.Length; i++)
             {
                 var item = candidateCompletionList.Items[i];

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionListMerger.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionListMerger.cs
@@ -210,11 +210,7 @@ internal static class CompletionListMerger
             }
 
             completionListToStopInheriting.CommitCharacters = null;
-
-            if (completionListToStopInheriting.ItemDefaults is not null)
-            {
-                completionListToStopInheriting.ItemDefaults.CommitCharacters = null;
-            }
+            completionListToStopInheriting.ItemDefaults?.CommitCharacters = null;
         }
     }
 
@@ -223,8 +219,7 @@ internal static class CompletionListMerger
         using var inheritableCompletions = new PooledArrayBuilder<VSInternalCompletionItem>();
         for (var i = 0; i < completionList.Items.Length; i++)
         {
-            var completionItem = completionList.Items[i] as VSInternalCompletionItem;
-            if (completionItem is null ||
+            if (completionList.Items[i] is not VSInternalCompletionItem completionItem ||
                 completionItem.CommitCharacters is not null ||
                 completionItem.VsCommitCharacters is not null)
             {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
@@ -70,6 +70,12 @@ internal class RazorCompletionListProvider(
 
         _logger.LogTrace($"Resolved {razorCompletionItems.Length} completion items.");
 
+        // No point caching or setting data for an empty completion list.
+        if (razorCompletionItems.Length == 0)
+        {
+            return null;
+        }
+
         var completionList = CreateLSPCompletionList(razorCompletionItems, clientCapabilities);
 
         var completionCapability = clientCapabilities?.TextDocument?.Completion as VSInternalCompletionSetting;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
@@ -115,10 +115,7 @@ internal class RazorCompletionListProvider(
         VSInternalClientCapabilities clientCapabilities,
         [NotNullWhen(true)] out VSInternalCompletionItem? completionItem)
     {
-        if (razorCompletionItem is null)
-        {
-            throw new ArgumentNullException(nameof(razorCompletionItem));
-        }
+        ArgHelper.ThrowIfNull(razorCompletionItem);
 
         var tagHelperCompletionItemKind = CompletionItemKind.TypeParameter;
         var supportedItemKinds = clientCapabilities.TextDocument?.Completion?.CompletionItemKind?.ValueSet ?? [];

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionResolveData.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionResolveData.cs
@@ -37,8 +37,17 @@ internal record RazorCompletionResolveData(
 
         if (supportsCompletionListData)
         {
-            // Can set data at the completion list level
-            completionList.Data = data with { OriginalData = completionList.Data };
+            if (completionList.Data is not null)
+            {
+                // Can set data at the completion list level
+                completionList.Data = data with { OriginalData = completionList.Data };
+            }
+
+            if (completionList.ItemDefaults?.Data is not null)
+            {
+                // Set data for the item defaults
+                completionList.ItemDefaults.Data = data with { OriginalData = completionList.ItemDefaults.Data };
+            }
 
             // Set data for items that won't inherit the default
             foreach (var completionItem in completionList.Items.Where(static c => c.Data is not null))

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionResolveData.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionResolveData.cs
@@ -22,8 +22,7 @@ internal record RazorCompletionResolveData(
             throw new InvalidOperationException($"Invalid completion item received'{completionItem.Label}'.");
         }
 
-        var context = paramsObj.Deserialize<RazorCompletionResolveData>();
-        if (context is null)
+        if (paramsObj.Deserialize<RazorCompletionResolveData>() is not { } context)
         {
             throw new InvalidOperationException($"completionItem.Data should be convertible to {nameof(RazorCompletionResolveData)}");
         }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/VSInternalCompletionItemExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/VSInternalCompletionItemExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.AspNetCore.Razor.PooledObjects;
@@ -10,17 +9,12 @@ namespace Microsoft.CodeAnalysis.Razor.Completion;
 
 internal static class VSInternalCompletionItemExtensions
 {
-    private const string ResultIdKey = "_resultId";
+    public const string ResultIdKey = "_resultId";
 
     private static readonly Dictionary<RazorCommitCharacter, VSInternalCommitCharacter> s_commitCharacterCache = [];
 
     public static bool TryGetCompletionListResultIds(this VSInternalCompletionItem completion, out ImmutableArray<int> resultIds)
     {
-        if (completion is null)
-        {
-            throw new ArgumentNullException(nameof(completion));
-        }
-
         if (!CompletionListMerger.TrySplit(completion.Data, out var splitData))
         {
             resultIds = default;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/VSInternalCompletionListExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/VSInternalCompletionListExtensions.cs
@@ -22,7 +22,7 @@ internal static class VSInternalCompletionListExtensions
             [ResultIdKey] = resultId,
         });
 
-        if (completionSetting?.CompletionList?.Data == true)
+        if (completionSetting.SupportsCompletionListData())
         {
             // Can set data at the completion list level
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/VSInternalCompletionListExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/VSInternalCompletionListExtensions.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Microsoft.AspNetCore.Razor;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion;
 
@@ -24,26 +25,31 @@ internal static class VSInternalCompletionListExtensions
 
         if (completionSetting.SupportsCompletionListData())
         {
-            // Can set data at the completion list level
+            // Ensure there is data at the completion list level, but only if ItemDefaults isn't set by the delegated server,
+            // or if they've set both.
+            var hasDefaultsData = completionList.ItemDefaults?.Data is not null;
+            if (completionList.Data is not null || !hasDefaultsData)
+            {
+                completionList.Data = CompletionListMerger.MergeData(data, completionList.Data);
+            }
 
-            var mergedData = CompletionListMerger.MergeData(data, completionList.Data);
-            completionList.Data = mergedData;
+            if (hasDefaultsData)
+            {
+                completionList.ItemDefaults.AssumeNotNull().Data = CompletionListMerger.MergeData(data, completionList.ItemDefaults.Data);
+            }
 
             // Merge data for items that won't inherit the default
             foreach (var completionItem in completionList.Items.Where(c => c.Data is not null))
             {
-                mergedData = CompletionListMerger.MergeData(data, completionItem.Data);
-                completionItem.Data = mergedData;
+                completionItem.Data = CompletionListMerger.MergeData(data, completionItem.Data);
             }
         }
         else
         {
             // No CompletionList.Data support
-
             foreach (var completionItem in completionList.Items)
             {
-                var mergedData = CompletionListMerger.MergeData(data, completionItem.Data);
-                completionItem.Data = mergedData;
+                completionItem.Data = CompletionListMerger.MergeData(data, completionItem.Data);
             }
         }
     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/VSInternalCompletionListExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/VSInternalCompletionListExtensions.cs
@@ -10,9 +10,6 @@ namespace Microsoft.CodeAnalysis.Razor.Completion;
 
 internal static class VSInternalCompletionListExtensions
 {
-    // This needs to match what's listed in VSInternalCompletionItemExtensions.ResultIdKey
-    private const string ResultIdKey = "_resultId";
-
     public static void SetResultId(
         this RazorVSInternalCompletionList completionList,
         int resultId,
@@ -20,7 +17,7 @@ internal static class VSInternalCompletionListExtensions
     {
         var data = JsonSerializer.SerializeToElement(new JsonObject()
         {
-            [ResultIdKey] = resultId,
+            [VSInternalCompletionItemExtensions.ResultIdKey] = resultId,
         });
 
         if (completionSetting.SupportsCompletionListData())

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/VSInternalCompletionSettingExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/VSInternalCompletionSettingExtensions.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion;
+
+internal static class VSInternalCompletionSettingExtensions
+{
+    public static bool SupportsCompletionListData(this VSInternalCompletionSetting? completionSetting)
+    {
+        return completionSetting?.CompletionList?.Data == true ||
+            completionSetting?.CompletionListSetting?.ItemDefaults?.Contains("data") == true;
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/RazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/RazorFormattingService.cs
@@ -194,7 +194,10 @@ internal class RazorFormattingService : IRazorFormattingService
             automaticallyAddUsings: false,
             validate: true,
             cancellationToken: cancellationToken).ConfigureAwait(false);
-        return razorChanges.SingleOrDefault();
+
+        return razorChanges is [{ } change]
+            ? change
+            : null;
     }
 
     public async Task<TextChange?> TryGetCSharpCodeActionEditAsync(DocumentContext documentContext, ImmutableArray<TextChange> csharpChanges, RazorFormattingOptions options, CancellationToken cancellationToken)
@@ -215,7 +218,10 @@ internal class RazorFormattingService : IRazorFormattingService
             automaticallyAddUsings: true,
             validate: false,
             cancellationToken: cancellationToken).ConfigureAwait(false);
-        return razorChanges.SingleOrDefault();
+
+        return razorChanges is [{ } change]
+            ? change
+            : null;
     }
 
     public async Task<TextChange?> TryGetCSharpSnippetFormattingEditAsync(DocumentContext documentContext, ImmutableArray<TextChange> csharpChanges, RazorFormattingOptions options, CancellationToken cancellationToken)
@@ -241,7 +247,9 @@ internal class RazorFormattingService : IRazorFormattingService
 
         razorChanges = UnwrapCSharpSnippets(razorChanges);
 
-        return razorChanges.SingleOrDefault();
+        return razorChanges is [{ } change]
+            ? change
+            : null;
     }
 
     public bool TryGetOnTypeFormattingTriggerKind(RazorCodeDocument codeDocument, int hostDocumentIndex, string triggerCharacter, out RazorLanguageKind triggerCharacterKind)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
@@ -236,7 +236,7 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
 
         var completionCapability = clientCapabilities?.TextDocument?.Completion as VSInternalCompletionSetting;
 
-        var resolutionContext = new DelegatedCompletionResolutionContext(identifier, RazorLanguageKind.CSharp, rewrittenResponse.Data);
+        var resolutionContext = new DelegatedCompletionResolutionContext(identifier, RazorLanguageKind.CSharp, rewrittenResponse.Data ?? rewrittenResponse.ItemDefaults?.Data);
         var resultId = _completionListCache.Add(rewrittenResponse, resolutionContext);
         rewrittenResponse.SetResultId(resultId, completionCapability);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
@@ -351,6 +351,7 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
                 formattingOptions,
                 _formattingService,
                 _documentMappingService,
+                Logger,
                 cancellationToken).ConfigureAwait(false);
 
             return item;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.CodeAnalysis.Razor.Completion.Delegation;
+using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.Formatting;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.Protocol;
@@ -38,6 +39,7 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
     private readonly IClientCapabilitiesService _clientCapabilitiesService = args.ExportProvider.GetExportedValue<IClientCapabilitiesService>();
     private readonly CompletionTriggerAndCommitCharacters _triggerAndCommitCharacters = args.ExportProvider.GetExportedValue<CompletionTriggerAndCommitCharacters>();
     private readonly IRazorFormattingService _formattingService = args.ExportProvider.GetExportedValue<IRazorFormattingService>();
+    private readonly IDocumentMappingService _documentMappingService = args.ExportProvider.GetExportedValue<IDocumentMappingService>();
     private readonly ITelemetryReporter _telemetryReporter = args.ExportProvider.GetExportedValue<ITelemetryReporter>();
 
     public ValueTask<CompletionPositionInfo?> GetPositionInfoAsync(
@@ -311,48 +313,51 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
 
     private async ValueTask<VSInternalCompletionItem> ResolveCSharpCompletionItemAsync(RemoteDocumentContext context, VSInternalCompletionItem request, VSInternalCompletionList containingCompletionList, DelegatedCompletionResolutionContext resolutionContext, RazorFormattingOptions formattingOptions, CancellationToken cancellationToken)
     {
-        request.Data = DelegatedCompletionHelper.GetOriginalCompletionItemData(request, containingCompletionList, resolutionContext.OriginalCompletionListData);
-
-        // Roslyn expects data to be JsonElement because we're calling into their LSP handler, but we cache their data as its underlying object, so lets
-        // make sure to serialize if we need to.
-        if (request.Data is not JsonElement)
+        var oldData = request.Data;
+        try
         {
-            request.Data = JsonSerializer.SerializeToElement(request.Data, JsonHelpers.JsonSerializerOptions);
-        }
+            request.Data = DelegatedCompletionHelper.GetOriginalCompletionItemData(request, containingCompletionList, resolutionContext.OriginalCompletionListData);
 
-        var documentSnapshot = context.Snapshot;
-        var generatedDocument = await documentSnapshot.GetGeneratedDocumentAsync(cancellationToken).ConfigureAwait(false);
+            // Roslyn expects data to be JsonElement because we're calling into their LSP handler, but we cache their data as its underlying object, so lets
+            // make sure to serialize if we need to.
+            if (request.Data is not JsonElement)
+            {
+                request.Data = JsonSerializer.SerializeToElement(request.Data, JsonHelpers.JsonSerializerOptions);
+            }
 
-        var clientCapabilities = _clientCapabilitiesService.ClientCapabilities;
-        var completionListSetting = clientCapabilities.TextDocument?.Completion;
-        var result = await ExternalAccess.Razor.Cohost.Handlers.Completion.ResolveCompletionItemAsync(
-            request,
-            generatedDocument,
-            clientCapabilities.SupportsVisualStudioExtensions,
-            completionListSetting ?? new(),
-            cancellationToken).ConfigureAwait(false);
+            var documentSnapshot = context.Snapshot;
+            var generatedDocument = await documentSnapshot.GetGeneratedDocumentAsync(cancellationToken).ConfigureAwait(false);
 
-        var item = JsonHelpers.Convert<CompletionItem, VSInternalCompletionItem>(result).AssumeNotNull();
+            var clientCapabilities = _clientCapabilitiesService.ClientCapabilities;
+            var completionListSetting = clientCapabilities.TextDocument?.Completion;
+            var result = await ExternalAccess.Razor.Cohost.Handlers.Completion.ResolveCompletionItemAsync(
+                request,
+                generatedDocument,
+                clientCapabilities.SupportsVisualStudioExtensions,
+                completionListSetting ?? new(),
+                cancellationToken).ConfigureAwait(false);
 
-        if (!item.VsResolveTextEditOnCommit)
-        {
-            // Resolve doesn't typically handle text edit resolution; however, in VS cases it does.
+            var item = JsonHelpers.Convert<CompletionItem, VSInternalCompletionItem>(result).AssumeNotNull();
+
+            if (clientCapabilities.SupportsVisualStudioExtensions && !item.VsResolveTextEditOnCommit)
+            {
+                // Resolve doesn't typically handle text edit resolution; however, in VS cases it does.
+                return item;
+            }
+
+            item = await DelegatedCompletionHelper.FormatCSharpCompletionItemAsync(
+                item,
+                context,
+                formattingOptions,
+                _formattingService,
+                _documentMappingService,
+                cancellationToken).ConfigureAwait(false);
+
             return item;
         }
-
-        if (item.TextEdit is null && item.AdditionalTextEdits is null)
+        finally
         {
-            // Only post-processing work we have to do is formatting text edits on resolution.
-            return item;
+            request.Data = oldData; // Restore original data to avoid side effects, as it may have come from the cache
         }
-
-        item = await DelegatedCompletionHelper.FormatCSharpCompletionItemAsync(
-            item,
-            context,
-            formattingOptions,
-            _formattingService,
-            cancellationToken).ConfigureAwait(false);
-
-        return item;
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.NetFx.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.NetFx.cs
@@ -86,7 +86,7 @@ public class DelegatedCompletionItemResolverTest : CompletionTestBase
         var clientConnection = CreateClientConnectionForResolve(response: null);
         var optionsMonitor = TestRazorLSPOptionsMonitor.Create();
         var formattingService = await _lazyFormattingService.GetValueAsync(DisposalToken);
-        var resolver = new DelegatedCompletionItemResolver(DocumentContextFactory, formattingService, optionsMonitor, clientConnection);
+        var resolver = new DelegatedCompletionItemResolver(DocumentContextFactory, formattingService, DocumentMappingService, optionsMonitor, clientConnection);
         var item = new VSInternalCompletionItem();
         var notContainingCompletionList = new RazorVSInternalCompletionList() { Items = [] };
         var originalRequestContext = StrictMock.Of<ICompletionResolveContext>();
@@ -106,7 +106,7 @@ public class DelegatedCompletionItemResolverTest : CompletionTestBase
         var clientConnection = CreateClientConnectionForResolve(response: null);
         var optionsMonitor = TestRazorLSPOptionsMonitor.Create();
         var formattingService = await _lazyFormattingService.GetValueAsync(DisposalToken);
-        var resolver = new DelegatedCompletionItemResolver(DocumentContextFactory, formattingService, optionsMonitor, clientConnection);
+        var resolver = new DelegatedCompletionItemResolver(DocumentContextFactory, formattingService, DocumentMappingService, optionsMonitor, clientConnection);
         var item = new VSInternalCompletionItem();
         var containingCompletionList = new RazorVSInternalCompletionList() { Items = [item] };
         var originalRequestContext = StrictMock.Of<ICompletionResolveContext>();
@@ -127,7 +127,7 @@ public class DelegatedCompletionItemResolverTest : CompletionTestBase
         var clientConnection = CreateClientConnectionForResolve(response: null, ValidateResolveParams);
         var optionsMonitor = TestRazorLSPOptionsMonitor.Create();
         var formattingService = await _lazyFormattingService.GetValueAsync(DisposalToken);
-        var resolver = new DelegatedCompletionItemResolver(DocumentContextFactory, formattingService, optionsMonitor, clientConnection);
+        var resolver = new DelegatedCompletionItemResolver(DocumentContextFactory, formattingService, DocumentMappingService, optionsMonitor, clientConnection);
         var item = new VSInternalCompletionItem()
         {
             Data = expectedData,
@@ -155,7 +155,7 @@ public class DelegatedCompletionItemResolverTest : CompletionTestBase
 
         var optionsMonitor = TestRazorLSPOptionsMonitor.Create();
         var formattingService = await _lazyFormattingService.GetValueAsync(DisposalToken);
-        var resolver = new DelegatedCompletionItemResolver(DocumentContextFactory, formattingService, optionsMonitor, clientConnection);
+        var resolver = new DelegatedCompletionItemResolver(DocumentContextFactory, formattingService, DocumentMappingService, optionsMonitor, clientConnection);
         var item = new VSInternalCompletionItem();
         var containingCompletionList = new RazorVSInternalCompletionList() { Items = [item], Data = new object() };
         var originalRequestContext = new DelegatedCompletionResolutionContext(_csharpCompletionParams.Identifier, _csharpCompletionParams.ProjectedKind, expectedData);
@@ -223,7 +223,7 @@ public class DelegatedCompletionItemResolverTest : CompletionTestBase
 
         var optionsMonitor = TestRazorLSPOptionsMonitor.Create();
         var formattingService = await _lazyFormattingService.GetValueAsync(DisposalToken);
-        var resolver = new DelegatedCompletionItemResolver(DocumentContextFactory, formattingService, optionsMonitor, clientConnection);
+        var resolver = new DelegatedCompletionItemResolver(DocumentContextFactory, formattingService, DocumentMappingService, optionsMonitor, clientConnection);
         var item = new VSInternalCompletionItem();
         var containingCompletionList = new RazorVSInternalCompletionList() { Items = [item] };
         var originalRequestContext = new DelegatedCompletionResolutionContext(_htmlCompletionParams.Identifier, _htmlCompletionParams.ProjectedKind, new object());
@@ -252,7 +252,7 @@ public class DelegatedCompletionItemResolverTest : CompletionTestBase
         var documentContextFactory = new TestDocumentContextFactory("C:/path/to/file.razor", codeDocument);
         var optionsMonitor = TestRazorLSPOptionsMonitor.Create();
         var formattingService = await _lazyFormattingService.GetValueAsync(DisposalToken);
-        var resolver = new DelegatedCompletionItemResolver(documentContextFactory, formattingService, optionsMonitor, clientConnection);
+        var resolver = new DelegatedCompletionItemResolver(documentContextFactory, formattingService, DocumentMappingService, optionsMonitor, clientConnection);
         var (containingCompletionList, csharpCompletionParams) = await GetCompletionListAndOriginalParamsAsync(
             cursorPosition, codeDocument, csharpServer);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.NetFx.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.NetFx.cs
@@ -86,7 +86,7 @@ public class DelegatedCompletionItemResolverTest : CompletionTestBase
         var clientConnection = CreateClientConnectionForResolve(response: null);
         var optionsMonitor = TestRazorLSPOptionsMonitor.Create();
         var formattingService = await _lazyFormattingService.GetValueAsync(DisposalToken);
-        var resolver = new DelegatedCompletionItemResolver(DocumentContextFactory, formattingService, DocumentMappingService, optionsMonitor, clientConnection);
+        var resolver = new DelegatedCompletionItemResolver(DocumentContextFactory, formattingService, DocumentMappingService, optionsMonitor, clientConnection, LoggerFactory);
         var item = new VSInternalCompletionItem();
         var notContainingCompletionList = new RazorVSInternalCompletionList() { Items = [] };
         var originalRequestContext = StrictMock.Of<ICompletionResolveContext>();
@@ -106,7 +106,7 @@ public class DelegatedCompletionItemResolverTest : CompletionTestBase
         var clientConnection = CreateClientConnectionForResolve(response: null);
         var optionsMonitor = TestRazorLSPOptionsMonitor.Create();
         var formattingService = await _lazyFormattingService.GetValueAsync(DisposalToken);
-        var resolver = new DelegatedCompletionItemResolver(DocumentContextFactory, formattingService, DocumentMappingService, optionsMonitor, clientConnection);
+        var resolver = new DelegatedCompletionItemResolver(DocumentContextFactory, formattingService, DocumentMappingService, optionsMonitor, clientConnection, LoggerFactory);
         var item = new VSInternalCompletionItem();
         var containingCompletionList = new RazorVSInternalCompletionList() { Items = [item] };
         var originalRequestContext = StrictMock.Of<ICompletionResolveContext>();
@@ -127,7 +127,7 @@ public class DelegatedCompletionItemResolverTest : CompletionTestBase
         var clientConnection = CreateClientConnectionForResolve(response: null, ValidateResolveParams);
         var optionsMonitor = TestRazorLSPOptionsMonitor.Create();
         var formattingService = await _lazyFormattingService.GetValueAsync(DisposalToken);
-        var resolver = new DelegatedCompletionItemResolver(DocumentContextFactory, formattingService, DocumentMappingService, optionsMonitor, clientConnection);
+        var resolver = new DelegatedCompletionItemResolver(DocumentContextFactory, formattingService, DocumentMappingService, optionsMonitor, clientConnection, LoggerFactory);
         var item = new VSInternalCompletionItem()
         {
             Data = expectedData,
@@ -155,7 +155,7 @@ public class DelegatedCompletionItemResolverTest : CompletionTestBase
 
         var optionsMonitor = TestRazorLSPOptionsMonitor.Create();
         var formattingService = await _lazyFormattingService.GetValueAsync(DisposalToken);
-        var resolver = new DelegatedCompletionItemResolver(DocumentContextFactory, formattingService, DocumentMappingService, optionsMonitor, clientConnection);
+        var resolver = new DelegatedCompletionItemResolver(DocumentContextFactory, formattingService, DocumentMappingService, optionsMonitor, clientConnection, LoggerFactory);
         var item = new VSInternalCompletionItem();
         var containingCompletionList = new RazorVSInternalCompletionList() { Items = [item], Data = new object() };
         var originalRequestContext = new DelegatedCompletionResolutionContext(_csharpCompletionParams.Identifier, _csharpCompletionParams.ProjectedKind, expectedData);
@@ -223,7 +223,7 @@ public class DelegatedCompletionItemResolverTest : CompletionTestBase
 
         var optionsMonitor = TestRazorLSPOptionsMonitor.Create();
         var formattingService = await _lazyFormattingService.GetValueAsync(DisposalToken);
-        var resolver = new DelegatedCompletionItemResolver(DocumentContextFactory, formattingService, DocumentMappingService, optionsMonitor, clientConnection);
+        var resolver = new DelegatedCompletionItemResolver(DocumentContextFactory, formattingService, DocumentMappingService, optionsMonitor, clientConnection, LoggerFactory);
         var item = new VSInternalCompletionItem();
         var containingCompletionList = new RazorVSInternalCompletionList() { Items = [item] };
         var originalRequestContext = new DelegatedCompletionResolutionContext(_htmlCompletionParams.Identifier, _htmlCompletionParams.ProjectedKind, new object());
@@ -252,7 +252,7 @@ public class DelegatedCompletionItemResolverTest : CompletionTestBase
         var documentContextFactory = new TestDocumentContextFactory("C:/path/to/file.razor", codeDocument);
         var optionsMonitor = TestRazorLSPOptionsMonitor.Create();
         var formattingService = await _lazyFormattingService.GetValueAsync(DisposalToken);
-        var resolver = new DelegatedCompletionItemResolver(documentContextFactory, formattingService, DocumentMappingService, optionsMonitor, clientConnection);
+        var resolver = new DelegatedCompletionItemResolver(documentContextFactory, formattingService, DocumentMappingService, optionsMonitor, clientConnection, LoggerFactory);
         var (containingCompletionList, csharpCompletionParams) = await GetCompletionListAndOriginalParamsAsync(
             cursorPosition, codeDocument, csharpServer);
 

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/RazorCompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/RazorCompletionListProviderTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text.Json;
@@ -39,7 +38,7 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
                 {
                     CompletionItemKind = new CompletionItemKindSetting()
                     {
-                        ValueSet = new[] { CompletionItemKind.TagHelper }
+                        ValueSet = [CompletionItemKind.TagHelper]
                     },
                     CompletionList = new VSInternalCompletionListSetting()
                     {
@@ -54,21 +53,13 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
         _razorCompletionOptions = new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true);
     }
 
-    private static IEnumerable<IRazorCompletionItemProvider> GetCompletionProviders()
-    {
-        // Working around strong naming restriction.
-        var tagHelperCompletionService = new TagHelperCompletionService();
-
-        var completionProviders = new IRazorCompletionItemProvider[]
-        {
+    private static IRazorCompletionItemProvider[] GetCompletionProviders()
+        => [
             new DirectiveCompletionItemProvider(),
             new DirectiveAttributeCompletionItemProvider(),
             new DirectiveAttributeParameterCompletionItemProvider(),
-            new TagHelperCompletionProvider(tagHelperCompletionService)
-        };
-
-        return completionProviders;
-    }
+            new TagHelperCompletionProvider(new TagHelperCompletionService())
+        ];
 
     [Fact]
     public void IsApplicableTriggerContext_Deletion_ReturnsFalse()
@@ -476,8 +467,7 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
             codeDocument, absoluteIndex: 1, completionContext, _clientCapabilities, existingCompletions: null, _razorCompletionOptions);
 
         // Assert
-        Assert.NotNull(completionList);
-        Assert.Empty(completionList.Items);
+        Assert.Null(completionList);
     }
 
     [Fact]

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionEndpointTest.cs
@@ -180,6 +180,47 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
             expectedResolvedItemDescription: "(awaitable) Task ComponentBase.SetParametersAsync(ParameterView parameters)");
     }
 
+    [Fact]
+    public async Task CSharpOverrideMethods_VSCode()
+    {
+        await VerifyCompletionListAsync(
+            input: """
+                This is a Razor document.
+
+                <div></div>
+
+                @code {
+                    public override $$
+                }
+
+                The end.
+                """,
+            expected: """
+                This is a Razor document.
+            
+                <div></div>
+            
+                @code {
+                    public override Task SetParametersAsync(ParameterView parameters)
+                    {
+                        return base.SetParametersAsync(parameters);
+                    }
+                }
+            
+                The end.
+                """,
+            completionContext: new VSInternalCompletionContext()
+            {
+                InvokeKind = VSInternalCompletionInvokeKind.Explicit,
+                TriggerCharacter = null,
+                TriggerKind = CompletionTriggerKind.Invoked
+            },
+            expectedItemLabels: ["Equals(object? obj)", "GetHashCode()", "SetParametersAsync(ParameterView parameters)", "ToString()"],
+            itemToResolve: "SetParametersAsync(ParameterView parameters)",
+            expectedResolvedItemDescription: "(awaitable) Task ComponentBase.SetParametersAsync(ParameterView parameters)",
+            supportsVisualStudioExtensions: false);
+    }
+
     // Tests MarkupTransitionCompletionItemProvider
     [Fact]
     public async Task CSharpMarkupTransitionAndTagHelpersInCodeBlock()
@@ -594,8 +635,15 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
         string? expected = null,
         string? expectedResolvedItemDescription = null,
         bool autoInsertAttributeQuotes = true,
-        bool commitElementsWithSpace = true)
+        bool commitElementsWithSpace = true,
+        bool supportsVisualStudioExtensions = true)
     {
+        UpdateClientLSPInitializationOptions(c =>
+        {
+            c.ClientCapabilities.SupportsVisualStudioExtensions = supportsVisualStudioExtensions;
+            return c;
+        });
+
         var document = CreateProjectAndRazorDocument(input.Text);
         var sourceText = await document.GetTextAsync(DisposalToken);
 
@@ -690,9 +738,14 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
             return;
         }
 
-        Assert.NotNull(expectedResolvedItemDescription);
-
+        // In the real world the client will send us back the data for the item to resolve, but in tests its easier if we just set it here.
+        // We clone the item first though, to ensure us setting the data doesn't hide a bug in our caching logic, around wrapping" the data.
         var item = Assert.Single(result.Items.Where(i => i.Label == itemToResolve));
+        item = JsonSerializer.Deserialize<VSInternalCompletionItem>(JsonSerializer.SerializeToElement(item, JsonHelpers.JsonSerializerOptions), JsonHelpers.JsonSerializerOptions)!;
+        item.Data ??= result.Data ?? result.ItemDefaults?.Data;
+
+        Assert.NotNull(item);
+        Assert.NotNull(expectedResolvedItemDescription);
 
         await VerifyCompletionResolveAsync(document, completionListCache, item, expected, expectedResolvedItemDescription);
     }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionEndpointTest.cs
@@ -303,14 +303,6 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
 
                 The end.
                 """,
-            expected:
-                """
-                This is a Razor document.
-
-                <EditForm 
-
-                The end.
-                """,
             completionContext: new VSInternalCompletionContext()
             {
                 InvokeKind = VSInternalCompletionInvokeKind.Typing,

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostEndpointTestBase.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostEndpointTestBase.cs
@@ -85,16 +85,17 @@ public abstract class CohostEndpointTestBase(ITestOutputHelper testOutputHelper)
         };
         UpdateClientInitializationOptions(c => c);
 
-        var completionSetting = new CompletionSetting
+        var completionSetting = new VSInternalCompletionSetting
         {
             CompletionItem = new CompletionItemSetting(),
             CompletionItemKind = new CompletionItemKindSetting()
             {
                 ValueSet = (CompletionItemKind[])Enum.GetValues(typeof(CompletionItemKind)),
             },
+            CompletionList = new VSInternalCompletionListSetting() { Data = true },
             CompletionListSetting = new CompletionListSetting()
             {
-                ItemDefaults = ["commitCharacters", "editRange", "insertTextFormat"]
+                ItemDefaults = ["commitCharacters", "editRange", "insertTextFormat", "data"]
             },
             ContextSupport = false,
             InsertTextMode = InsertTextMode.AsIs,


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/11840

Two main bits to this change:

1. Roslyn uses a command to perform text edits in VS Code, so this extends our text edit mapping to support that
2. Roslyn uses the completion list `ItemDefaults.Data` for VS Code, and all of our data merging and wrapping didn't support it

I broke things up into lots of commits because it was lots of little changes in lots of places, so might be easier to review that way.