### PR TITLE
Optimize allocations under RuntimeNodeWriter.WriteHtmlContent

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/CodeGeneration/RuntimeNodeWriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/CodeGeneration/RuntimeNodeWriterTest.cs
@@ -407,7 +407,7 @@ if (true) { }
         using var context = TestCodeRenderingContext.CreateRuntime();
 
         // Act
-        writer.WriteHtmlLiteral(context, maxStringLiteralLength: 6, "Hello");
+        writer.WriteHtmlLiteral(context, maxStringLiteralLength: 6, "Hello".AsMemory());
 
         // Assert
         var csharp = context.CodeWriter.GetText().ToString();
@@ -426,7 +426,7 @@ if (true) { }
         using var context = TestCodeRenderingContext.CreateRuntime();
 
         // Act
-        writer.WriteHtmlLiteral(context, maxStringLiteralLength: 6, "Hello World");
+        writer.WriteHtmlLiteral(context, maxStringLiteralLength: 6, "Hello World".AsMemory());
 
         // Assert
         var csharp = context.CodeWriter.GetText().ToString();
@@ -446,7 +446,7 @@ WriteLiteral(""World"");
         using var context = TestCodeRenderingContext.CreateRuntime();
 
         // Act
-        writer.WriteHtmlLiteral(context, maxStringLiteralLength: 2, " 👦");
+        writer.WriteHtmlLiteral(context, maxStringLiteralLength: 2, " 👦".AsMemory());
 
         // Assert
         var csharp = context.CodeWriter.GetText().ToString();
@@ -466,7 +466,7 @@ WriteLiteral(""👦"");
         using var context = TestCodeRenderingContext.CreateRuntime();
 
         // Act
-        writer.WriteHtmlLiteral(context, maxStringLiteralLength: 6, "👩‍👩‍👧‍👧👩‍👩‍👧‍👧");
+        writer.WriteHtmlLiteral(context, maxStringLiteralLength: 6, "👩‍👩‍👧‍👧👩‍👩‍👧‍👧".AsMemory());
 
         // Assert
         var csharp = context.CodeWriter.GetText().ToString();


### PR DESCRIPTION
This method was creating a StringBuilder with unknown size allocating both a final string and char array along with resize allocations. Instead, calculate the result length and calculate a single char array. This reduced allocations in the typing scenario in the razor lsp speedometer test under this method from about 3.8% to 2.3%.

Speedometer run: https://dev.azure.com/devdiv/DevDiv/_apps/hub/ms-vseng.pit-vsengPerf.pit-hub?targetBuild=10711.132.dn-bot.250612.042302.643010&targetBranch=main&targetPerfBuildId=11746459&runGroup=Speedometer&baselineBuild=10711.80&baselineBranch=main

Allocations before change
![image](https://github.com/user-attachments/assets/17a7348f-1be1-470d-8c53-6850bb5043c7)

Allocations with change
![image](https://github.com/user-attachments/assets/6c3fb51a-fc0f-4c81-93dc-4179903f1154)