### PR TITLE
Reduce allocations under SyntaxNodeExtensions.GetContent

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/GreenNode.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/GreenNode.cs
@@ -28,7 +28,7 @@ internal abstract class GreenNode
     /// Pool of StringWriters for use in <see cref="ToString()"/>. Users should not dispose the StringWriter directly
     /// (but should dispose of the PooledObject returned from Pool.GetPooledObject).
     /// </summary>
-    private static readonly ObjectPool<StringWriter> CurrentCultureStringWriterPool = DefaultPool.Create(Policy.Instance);
+    private static readonly ObjectPool<StringWriter> StringWriterPool = DefaultPool.Create(Policy.Instance);
 
     private int _width;
     private byte _slotCount;
@@ -242,15 +242,7 @@ internal abstract class GreenNode
 
     public override string ToString()
     {
-        using var _ = StringBuilderPool.GetPooledObject(out var builder);
-        using var writer = new StringWriter(builder, CultureInfo.InvariantCulture);
-        WriteTo(writer);
-        return builder.ToString();
-    }
-
-    internal string ToStringInCurrentCulture()
-    {
-        using var _ = CurrentCultureStringWriterPool.GetPooledObject(out var writer);
+        using var _ = StringWriterPool.GetPooledObject(out var writer);
 
         WriteTo(writer);
 
@@ -378,7 +370,7 @@ internal abstract class GreenNode
         }
 
         public StringWriter Create()
-            => new StringWriter(new StringBuilder());
+            => new StringWriter(new StringBuilder(), CultureInfo.InvariantCulture);
 
         public bool Return(StringWriter writer)
         {

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/GreenNode.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/GreenNode.cs
@@ -8,7 +8,9 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Text;
 using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.Extensions.ObjectPool;
 
 namespace Microsoft.AspNetCore.Razor.Language.Syntax;
 
@@ -21,6 +23,12 @@ internal abstract class GreenNode
         new ConditionalWeakTable<GreenNode, RazorDiagnostic[]>();
     private static readonly ConditionalWeakTable<GreenNode, SyntaxAnnotation[]> AnnotationsTable =
         new ConditionalWeakTable<GreenNode, SyntaxAnnotation[]>();
+
+    /// <summary>
+    /// Pool of StringWriters for use in <see cref="ToString()"/>. Users should not dispose the StringWriter directly
+    /// (but should dispose of the PooledObject returned from Pool.GetPooledObject).
+    /// </summary>
+    private static readonly ObjectPool<StringWriter> CurrentCultureStringWriterPool = DefaultPool.Create(Policy.Instance);
 
     private int _width;
     private byte _slotCount;
@@ -240,6 +248,15 @@ internal abstract class GreenNode
         return builder.ToString();
     }
 
+    internal string ToStringInCurrentCulture()
+    {
+        using var _ = CurrentCultureStringWriterPool.GetPooledObject(out var writer);
+
+        WriteTo(writer);
+
+        return writer.ToString();
+    }
+
     public void WriteTo(TextWriter writer)
     {
         // Use an actual Stack so we can write out deeply recursive structures without overflowing.
@@ -351,4 +368,30 @@ internal abstract class GreenNode
     public abstract TResult Accept<TResult>(InternalSyntax.SyntaxVisitor<TResult> visitor);
 
     public abstract void Accept(InternalSyntax.SyntaxVisitor visitor);
+
+    private sealed class Policy : IPooledObjectPolicy<StringWriter>
+    {
+        public static readonly Policy Instance = new();
+
+        private Policy()
+        {
+        }
+
+        public StringWriter Create()
+            => new StringWriter(new StringBuilder());
+
+        public bool Return(StringWriter writer)
+        {
+            var builder = writer.GetStringBuilder();
+
+            // Very similar to StringBuilderPool.Policy implementation.
+            builder.Clear();
+            if (builder.Capacity > DefaultPool.MaximumObjectSize)
+            {
+                builder.Capacity = DefaultPool.MaximumObjectSize;
+            }
+
+            return true;
+        }
+    }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxNodeExtensions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxNodeExtensions.cs
@@ -302,7 +302,7 @@ internal static class SyntaxNodeExtensions
 
     public static string GetContent<TNode>(this TNode node) where TNode : SyntaxNode
     {
-        return node.Green.ToStringInCurrentCulture();
+        return node.Green.ToString();
     }
 
     private sealed class DiagnosticSyntaxWalker(List<RazorDiagnostic> diagnostics) : SyntaxWalker

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxNodeExtensions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxNodeExtensions.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.AspNetCore.Razor.Language.Syntax;
@@ -303,11 +302,7 @@ internal static class SyntaxNodeExtensions
 
     public static string GetContent<TNode>(this TNode node) where TNode : SyntaxNode
     {
-        using var _ = StringBuilderPool.GetPooledObject(out var builder);
-        using var writer = new System.IO.StringWriter(builder);
-        node.Green.WriteTo(writer);
-
-        return writer.ToString();
+        return node.Green.ToStringInCurrentCulture();
     }
 
     private sealed class DiagnosticSyntaxWalker(List<RazorDiagnostic> diagnostics) : SyntaxWalker


### PR DESCRIPTION
This method was creating a new StringWriter on every invocation. On net framework, each StringWriter incurs an additional char array allocation during construction. Instead, add a pool for stringwriters in GreenNode to avoid these allocations on every call. This reduced allocations spent under this method during the typing scenario in the razor lsp speedometer test from 3.5% to 1.9%.

Note that it would be nice to have GreenNode.ToString use this optimization too, however it differed (intentionally?) from the caller in SyntaxNodeExtensions.GetContent by passing in the invariant culture to the StringWriter during construction. I don't see ToString called near as often in the profile I'm looking at, so, it didn't seem to warrant creating a separate pool for that method. I would appreciate verification though that it's intentional that these two calls use different culture semantics.

Speedometer run: https://dev.azure.com/devdiv/DevDiv/_apps/hub/ms-vseng.pit-vsengPerf.pit-hub?targetBuild=10711.132.dn-bot.250612.052736.643013&targetBranch=main&targetPerfBuildId=11746547&runGroup=Speedometer&baselineBuild=10711.132&baselineBranch=main

Allocations before change
![image](https://github.com/user-attachments/assets/4b9a713e-6c3a-45b4-9c7d-f4566d7648dd)

Allocations with change
![image](https://github.com/user-attachments/assets/c93cbadb-1eca-4961-98e2-51d579393993)