### PR TITLE
Followups to previous PR that need EA changes

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostDocumentFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostDocumentFormattingEndpoint.cs
@@ -79,6 +79,8 @@ internal sealed class CohostDocumentFormattingEndpoint(
 
         var options = RazorFormattingOptions.From(request.Options, _clientSettingsManager.GetClientSettings().AdvancedSettings.CodeBlockBraceOnNextLine);
 
+        
+
         _logger.LogDebug($"Calling OOP with the {htmlChanges.Length} html edits, so it can fill in the rest");
         var remoteResult = await _remoteServiceInvoker.TryInvokeAsync<IRemoteFormattingService, ImmutableArray<TextChange>>(
             razorDocument.Project.Solution,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.Formatting;
 using Microsoft.CodeAnalysis.Razor.Logging;
@@ -285,7 +286,7 @@ internal static class DelegatedCompletionHelper
     {
         // In VS Code, Roslyn does resolve via a custom command. Thats fine, but we have to modify the text edit sitting within it,
         // rather than the one LSP knows about.
-        if (resolvedCompletionItem.Command is { CommandIdentifier: "roslyn.client.completionComplexEdit", Arguments: var args })
+        if (resolvedCompletionItem.Command is { CommandIdentifier: Constants.CompleteComplexEditCommand, Arguments: var args })
         {
             if (args is [TextDocumentIdentifier, TextEdit complexEdit, _, int nextCursorPosition])
             {
@@ -310,7 +311,7 @@ internal static class DelegatedCompletionHelper
             }
             else
             {
-                logger.LogError($"Unexpected arguments for command '{resolvedCompletionItem.Command.CommandIdentifier}': Expected: [TextDocumentIdentifier, TextEdit, _, int], Actual: {GetArgumentTypesLogString(resolvedCompletionItem)}");
+                logger.LogError($"Unexpected arguments for command '{Constants.CompleteComplexEditCommand}': Expected: [TextDocumentIdentifier, TextEdit, _, int], Actual: {GetArgumentTypesLogString(resolvedCompletionItem)}");
                 Debug.Fail("Unexpected arguments for Roslyn complex edit command. Have they changed things?");
             }
         }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/CSharpFormatter.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/CSharpFormatter.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Text;
@@ -23,14 +24,20 @@ internal sealed class CSharpFormatter(IDocumentMappingService documentMappingSer
 
     private readonly IDocumentMappingService _documentMappingService = documentMappingService;
 
-    public async Task<ImmutableArray<TextChange>> FormatAsync(HostWorkspaceServices hostWorkspaceServices, Document csharpDocument, FormattingContext context, LinePositionSpan spanToFormat, CancellationToken cancellationToken)
+    public async Task<ImmutableArray<TextChange>> FormatAsync(
+        HostWorkspaceServices hostWorkspaceServices,
+        Document csharpDocument,
+        FormattingContext context,
+        LinePositionSpan spanToFormat,
+        RazorCSharpSyntaxFormattingOptions? formattingOptionsOverride,
+        CancellationToken cancellationToken)
     {
         if (!_documentMappingService.TryMapToGeneratedDocumentRange(context.CodeDocument.GetCSharpDocument(), spanToFormat, out var projectedSpan))
         {
             return [];
         }
 
-        var edits = await GetFormattingEditsAsync(hostWorkspaceServices, csharpDocument, projectedSpan, context.Options.ToIndentationOptions(), cancellationToken).ConfigureAwait(false);
+        var edits = await GetFormattingEditsAsync(hostWorkspaceServices, csharpDocument, projectedSpan, context.Options.ToIndentationOptions(), formattingOptionsOverride, cancellationToken).ConfigureAwait(false);
         var mappedEdits = MapEditsToHostDocument(context.CodeDocument, edits);
         return mappedEdits;
     }
@@ -56,14 +63,20 @@ internal sealed class CSharpFormatter(IDocumentMappingService documentMappingSer
         return actualEdits.ToImmutableArray();
     }
 
-    private static async Task<ImmutableArray<TextChange>> GetFormattingEditsAsync(HostWorkspaceServices hostWorkspaceServices, Document csharpDocument, LinePositionSpan projectedSpan, RazorIndentationOptions indentationOptions, CancellationToken cancellationToken)
+    private static async Task<ImmutableArray<TextChange>> GetFormattingEditsAsync(
+        HostWorkspaceServices hostWorkspaceServices,
+        Document csharpDocument,
+        LinePositionSpan projectedSpan,
+        RazorIndentationOptions indentationOptions,
+        RazorCSharpSyntaxFormattingOptions? formattingOptionsOverride,
+        CancellationToken cancellationToken)
     {
         var root = await csharpDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
         var csharpSourceText = await csharpDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
         var spanToFormat = csharpSourceText.GetTextSpan(projectedSpan);
         Assumes.NotNull(root);
 
-        var changes = RazorCSharpFormattingInteractionService.GetFormattedTextChanges(hostWorkspaceServices, root, spanToFormat, indentationOptions, cancellationToken);
+        var changes = RazorCSharpFormattingInteractionService.GetFormattedTextChanges(hostWorkspaceServices, root, spanToFormat, indentationOptions, formattingOptionsOverride, cancellationToken);
         return changes.ToImmutableArray();
     }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPass.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPass.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.Logging;
@@ -27,6 +28,8 @@ internal sealed class CSharpFormattingPass(
 {
     private readonly CSharpFormatter _csharpFormatter = new(documentMappingService);
     private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<CSharpFormattingPass>();
+
+    private RazorCSharpSyntaxFormattingOptions? _csharpSyntaxFormattingOptionsOverride;
 
     protected async override Task<ImmutableArray<TextChange>> ExecuteCoreAsync(FormattingContext context, RoslynWorkspaceHelper roslynWorkspaceHelper, ImmutableArray<TextChange> changes, CancellationToken cancellationToken)
     {
@@ -88,10 +91,20 @@ internal sealed class CSharpFormattingPass(
             // These should already be remapped.
             var spanToFormat = sourceText.GetLinePositionSpan(span);
 
-            var changes = await _csharpFormatter.FormatAsync(hostWorkspaceServices, csharpDocument, context, spanToFormat, cancellationToken).ConfigureAwait(false);
+            var changes = await _csharpFormatter.FormatAsync(hostWorkspaceServices, csharpDocument, context, spanToFormat, _csharpSyntaxFormattingOptionsOverride, cancellationToken).ConfigureAwait(false);
             csharpChanges.AddRange(changes.Where(e => spanToFormat.Contains(sourceText.GetLinePositionSpan(e.Span))));
         }
 
         return csharpChanges.ToImmutable();
+    }
+
+    internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+
+    internal readonly struct TestAccessor(CSharpFormattingPass instance)
+    {
+        public void SetCSharpSyntaxFormattingOptionsOverride(RazorCSharpSyntaxFormattingOptions? optionsOverride)
+        {
+            instance._csharpSyntaxFormattingOptionsOverride = optionsOverride;
+        }
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/RazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/RazorFormattingService.cs
@@ -5,13 +5,13 @@ using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -397,13 +397,17 @@ internal class RazorFormattingService : IRazorFormattingService
             contentValidationPass.DebugAssertsEnabled = debugAssertsEnabled;
         }
 
-        public void SetFormattedCSharpDocumentModifierFunc(Func<SourceText, SourceText> func)
+        public void SetCSharpSyntaxFormattingOptionsOverride(RazorCSharpSyntaxFormattingOptions? optionsOverride)
         {
-            // This is only valid for the new formatting engine, so a test that sets it for the old formatter is probably written incorrectly.
-            Debug.Assert(service._languageServerFeatureOptions.UseNewFormattingEngine);
+            if (service._documentFormattingPasses.OfType<CSharpFormattingPass>().SingleOrDefault() is { } pass)
+            {
+                pass.GetTestAccessor().SetCSharpSyntaxFormattingOptionsOverride(optionsOverride);
+            }
 
-            var pass = service._documentFormattingPasses.OfType<New.CSharpFormattingPass>().Single();
-            pass.GetTestAccessor().SetFormattedCSharpDocumentModifierFunc(func);
+            if (service._documentFormattingPasses.OfType<New.CSharpFormattingPass>().SingleOrDefault() is { } newPass)
+            {
+                newPass.GetTestAccessor().SetCSharpSyntaxFormattingOptionsOverride(optionsOverride);
+            }
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentFormattingTest.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Text.RegularExpressions;
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
 using Microsoft.CodeAnalysis.Razor.Formatting;
-using Microsoft.CodeAnalysis.Text;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -30,7 +30,7 @@ public class DocumentFormattingTest(FormattingTestContext context, HtmlFormattin
             expected: "");
     }
 
-    [FormattingTestFact(SkipOldFormattingEngine = true)]
+    [FormattingTestFact]
     public async Task RoslynFormatBracesAsKandR()
     {
         // To format code blocks we emit a class so that class members are parsed properly by Roslyn, and ignore
@@ -66,16 +66,13 @@ public class DocumentFormattingTest(FormattingTestContext context, HtmlFormattin
                     }
                 }
                 """,
-            // I'm so sorry, but I could not find any way to change Roslyn formatting options from our test infra. Forgive my hacky sins
-            csharpModifierFunc: formattedCSharpText => SourceText.From(
-                Regex.Replace(
-                    formattedCSharpText.ToString(),
-                    @"(class|void) ([\S]+)[\s]+{",
-                    "$1 $2 {"
-                )));
+            formattingOptionsOverride: new RazorCSharpSyntaxFormattingOptions() with
+            {
+                NewLines = RazorNewLinePlacement.None
+            });
     }
 
-    [FormattingTestFact(SkipOldFormattingEngine = true)]
+    [FormattingTestFact]
     public async Task PropertyShrunkToOneLine()
     {
         await RunFormattingTestAsync(
@@ -90,20 +87,16 @@ public class DocumentFormattingTest(FormattingTestContext context, HtmlFormattin
                 """,
             expected: """
                 @code {
-                    public string Name { get; set; }
+                    public string Name {
+                        get;
+                        set;
+                    }
                 }
                 """,
-            // I'm so sorry, but I could not find any way to change Roslyn formatting options from our test infra. Forgive my hacky sins
-            csharpModifierFunc: formattedCSharpText => SourceText.From(
-                formattedCSharpText.ToString().Replace(
-                    """
-                    public string Name
-                        {
-                            get;
-                            set;
-                        }
-                    """,
-                    "public string Name { get; set; }")));
+            formattingOptionsOverride: new RazorCSharpSyntaxFormattingOptions() with
+            {
+                NewLines = RazorNewLinePlacement.None
+            });
     }
 
     [FormattingTestFact]

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingTestBase.cs
@@ -19,7 +19,7 @@ using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.AspNetCore.Razor.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
 using Microsoft.CodeAnalysis.Razor.Formatting;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectEngineHost;
@@ -66,13 +66,13 @@ public abstract class FormattingTestBase : RazorToolingIntegrationTestBase
         bool codeBlockBraceOnNextLine = false,
         bool inGlobalNamespace = false,
         bool debugAssertsEnabled = true,
-        Func<SourceText, SourceText>? csharpModifierFunc = null)
+        RazorCSharpSyntaxFormattingOptions? formattingOptionsOverride = null)
     {
         (input, expected) = ProcessFormattingContext(input, expected);
 
         var razorLSPOptions = RazorLSPOptions.Default with { CodeBlockBraceOnNextLine = codeBlockBraceOnNextLine };
 
-        await RunFormattingTestInternalAsync(input, expected, tabSize, insertSpaces, fileKind, tagHelpers, allowDiagnostics, razorLSPOptions, inGlobalNamespace, debugAssertsEnabled, csharpModifierFunc);
+        await RunFormattingTestInternalAsync(input, expected, tabSize, insertSpaces, fileKind, tagHelpers, allowDiagnostics, razorLSPOptions, inGlobalNamespace, debugAssertsEnabled, formattingOptionsOverride);
     }
 
     private async Task RunFormattingTestInternalAsync(
@@ -86,7 +86,7 @@ public abstract class FormattingTestBase : RazorToolingIntegrationTestBase
         RazorLSPOptions? razorLSPOptions,
         bool inGlobalNamespace,
         bool debugAssertsEnabled,
-        Func<SourceText, SourceText>? csharpModifierFunc)
+        RazorCSharpSyntaxFormattingOptions? formattingOptionsOverride)
     {
         // Arrange
         var fileKindValue = fileKind ?? RazorFileKind.Component;
@@ -113,7 +113,7 @@ public abstract class FormattingTestBase : RazorToolingIntegrationTestBase
 
         var languageServerFeatureOptions = new TestLanguageServerFeatureOptions(useNewFormattingEngine: _context.UseNewFormattingEngine);
 
-        var formattingService = await TestRazorFormattingService.CreateWithFullSupportAsync(LoggerFactory, codeDocument, razorLSPOptions, languageServerFeatureOptions, debugAssertsEnabled, csharpModifierFunc);
+        var formattingService = await TestRazorFormattingService.CreateWithFullSupportAsync(LoggerFactory, codeDocument, razorLSPOptions, languageServerFeatureOptions, debugAssertsEnabled, formattingOptionsOverride);
         var documentContext = new DocumentContext(uri, documentSnapshot, projectContext: null);
 
         var client = new FormattingLanguageServerClient(_htmlFormattingService, LoggerFactory);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/TestRazorFormattingService.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/TestRazorFormattingService.cs
@@ -8,10 +8,10 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
 using Microsoft.CodeAnalysis.Razor.Formatting;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
-using Microsoft.CodeAnalysis.Text;
 using Moq;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
@@ -24,7 +24,7 @@ internal static class TestRazorFormattingService
         RazorLSPOptions? razorLSPOptions = null,
         LanguageServerFeatureOptions? languageServerFeatureOptions = null,
         bool debugAssertsEnabled = false,
-        Func<SourceText, SourceText>? csharpModifierFunc = null)
+        RazorCSharpSyntaxFormattingOptions? formattingOptionsOverride = null)
     {
         codeDocument ??= TestRazorCodeDocument.CreateEmpty();
 
@@ -50,10 +50,7 @@ internal static class TestRazorFormattingService
         var service = new RazorFormattingService(mappingService, hostServicesProvider, languageServerFeatureOptions, loggerFactory);
         var accessor = service.GetTestAccessor();
         accessor.SetDebugAssertsEnabled(debugAssertsEnabled);
-        if (csharpModifierFunc is not null)
-        {
-            accessor.SetFormattedCSharpDocumentModifierFunc(csharpModifierFunc);
-        }
+        accessor.SetCSharpSyntaxFormattingOptionsOverride(formattingOptionsOverride);
 
         return service;
     }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/FormattingTestBase.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
 using Microsoft.CodeAnalysis.Razor.Formatting;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.Remote;
@@ -45,7 +46,7 @@ public abstract class FormattingTestBase : CohostEndpointTestBase
         int tabSize = 4,
         bool allowDiagnostics = false,
         bool debugAssertsEnabled = true,
-        Func<SourceText, SourceText>? csharpModifierFunc = null)
+        RazorCSharpSyntaxFormattingOptions? formattingOptionsOverride = null)
     {
         (input, expected) = ProcessFormattingContext(input, expected);
 
@@ -65,10 +66,7 @@ public abstract class FormattingTestBase : CohostEndpointTestBase
         var formattingService = (RazorFormattingService)OOPExportProvider.GetExportedValue<IRazorFormattingService>();
         var accessor = formattingService.GetTestAccessor();
         accessor.SetDebugAssertsEnabled(debugAssertsEnabled);
-        if (csharpModifierFunc is not null)
-        {
-            accessor.SetFormattedCSharpDocumentModifierFunc(csharpModifierFunc);
-        }
+        accessor.SetCSharpSyntaxFormattingOptionsOverride(formattingOptionsOverride);
 
         var generatedHtml = await RemoteServiceInvoker.TryInvokeAsync<IRemoteHtmlDocumentService, string?>(document.Project.Solution,
             (service, solutionInfo, ct) => service.GetHtmlDocumentTextAsync(solutionInfo, document.Id, ct),


### PR DESCRIPTION
Razor side of https://github.com/dotnet/roslyn/pull/78949

Two followups from previous PRs:
* Export formatting options for Razor testing: https://github.com/dotnet/razor/pull/11911#discussion_r2126925116
* Share const for complex edit command name: https://github.com/dotnet/razor/pull/11938#discussion_r2140502017

Won't build, of course, without the above PR merged and packages referenced