### PR TITLE
Add Parent property to nested tag helper objects

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/BoundAttributeDescriptorExtensionsTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/BoundAttributeDescriptorExtensionsTest.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using Xunit;
 using static Microsoft.AspNetCore.Razor.Language.CommonMetadata;
 
@@ -16,19 +14,18 @@ public class BoundAttributeDescriptorExtensionsTest
         // Arrange
         var expectedPropertyName = "IntProperty";
 
-        var tagHelperBuilder = new TagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "TestTagHelper", "Test");
-        tagHelperBuilder.Metadata(TypeName("TestTagHelper"));
+        var tagHelper = TagHelperDescriptorBuilder.Create(TagHelperConventions.DefaultKind, "TestTagHelper", "Test")
+            .Metadata(TypeName("TestTagHelper"))
+            .BoundAttributeDescriptor(attribute => attribute
+                .Name("test")
+                .Metadata(PropertyName(expectedPropertyName))
+                .TypeName(typeof(int).FullName))
+            .Build();
 
-        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
-        builder
-            .Name("test")
-            .Metadata(PropertyName(expectedPropertyName))
-            .TypeName(typeof(int).FullName);
-
-        var descriptor = builder.Build();
+        var boundAttribute = Assert.Single(tagHelper.BoundAttributes);
 
         // Act
-        var propertyName = descriptor.GetPropertyName();
+        var propertyName = boundAttribute.GetPropertyName();
 
         // Assert
         Assert.Equal(expectedPropertyName, propertyName);
@@ -38,18 +35,17 @@ public class BoundAttributeDescriptorExtensionsTest
     public void GetPropertyName_ReturnsNullIfNoPropertyName()
     {
         // Arrange
-        var tagHelperBuilder = new TagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "TestTagHelper", "Test");
-        tagHelperBuilder.Metadata(TypeName("TestTagHelper"));
+        var tagHelper = TagHelperDescriptorBuilder.Create(TagHelperConventions.DefaultKind, "TestTagHelper", "Test")
+            .Metadata(TypeName("TestTagHelper"))
+            .BoundAttributeDescriptor(attribute => attribute
+                .Name("test")
+                .TypeName(typeof(int).FullName))
+            .Build();
 
-        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
-        builder
-            .Name("test")
-            .TypeName(typeof(int).FullName);
-
-        var descriptor = builder.Build();
+        var boundAttribute = Assert.Single(tagHelper.BoundAttributes);
 
         // Act
-        var propertyName = descriptor.GetPropertyName();
+        var propertyName = boundAttribute.GetPropertyName();
 
         // Assert
         Assert.Null(propertyName);
@@ -59,19 +55,18 @@ public class BoundAttributeDescriptorExtensionsTest
     public void IsDefaultKind_ReturnsTrue_IfKindIsDefault()
     {
         // Arrange
-        var tagHelperBuilder = new TagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "TestTagHelper", "Test");
-        tagHelperBuilder.Metadata(TypeName("TestTagHelper"));
+        var tagHelper = TagHelperDescriptorBuilder.Create(TagHelperConventions.DefaultKind, "TestTagHelper", "Test")
+            .Metadata(TypeName("TestTagHelper"))
+            .BoundAttributeDescriptor(attribute => attribute
+                .Name("test")
+                .Metadata(PropertyName("IntProperty"))
+                .TypeName(typeof(int).FullName))
+            .Build();
 
-        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
-        builder
-            .Name("test")
-            .Metadata(PropertyName("IntProperty"))
-            .TypeName(typeof(int).FullName);
-
-        var descriptor = builder.Build();
+        var boundAttribute = Assert.Single(tagHelper.BoundAttributes);
 
         // Act
-        var isDefault = descriptor.IsDefaultKind();
+        var isDefault = boundAttribute.IsDefaultKind();
 
         // Assert
         Assert.True(isDefault);
@@ -81,19 +76,18 @@ public class BoundAttributeDescriptorExtensionsTest
     public void IsDefaultKind_ReturnsFalse_IfKindIsNotDefault()
     {
         // Arrange
-        var tagHelperBuilder = new TagHelperDescriptorBuilder("other-kind", "TestTagHelper", "Test");
-        tagHelperBuilder.Metadata(TypeName("TestTagHelper"));
+        var tagHelper = TagHelperDescriptorBuilder.Create("other-kind", "TestTagHelper", "Test")
+            .Metadata(TypeName("TestTagHelper"))
+            .BoundAttributeDescriptor(attribute => attribute
+                .Name("test")
+                .Metadata(PropertyName("IntProperty"))
+                .TypeName(typeof(int).FullName))
+            .Build();
 
-        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder, "other-kind");
-        builder
-            .Name("test")
-            .Metadata(PropertyName("IntProperty"))
-            .TypeName(typeof(int).FullName);
-
-        var descriptor = builder.Build();
+        var boundAttribute = Assert.Single(tagHelper.BoundAttributes);
 
         // Act
-        var isDefault = descriptor.IsDefaultKind();
+        var isDefault = boundAttribute.IsDefaultKind();
 
         // Assert
         Assert.False(isDefault);
@@ -103,19 +97,18 @@ public class BoundAttributeDescriptorExtensionsTest
     public void ExpectsStringValue_ReturnsTrue_ForStringProperty()
     {
         // Arrange
-        var tagHelperBuilder = new TagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "TestTagHelper", "Test");
-        tagHelperBuilder.Metadata(TypeName("TestTagHelper"));
+        var tagHelper = TagHelperDescriptorBuilder.Create(TagHelperConventions.DefaultKind, "TestTagHelper", "Test")
+            .Metadata(TypeName("TestTagHelper"))
+            .BoundAttributeDescriptor(attribute => attribute
+                .Name("test")
+                .Metadata(PropertyName("BoundProp"))
+                .TypeName(typeof(string).FullName))
+            .Build();
 
-        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
-        builder
-            .Name("test")
-            .Metadata(PropertyName("BoundProp"))
-            .TypeName(typeof(string).FullName);
-
-        var descriptor = builder.Build();
+        var boundAttribute = Assert.Single(tagHelper.BoundAttributes);
 
         // Act
-        var result = descriptor.ExpectsStringValue("test");
+        var result = boundAttribute.ExpectsStringValue("test");
 
         // Assert
         Assert.True(result);
@@ -125,19 +118,18 @@ public class BoundAttributeDescriptorExtensionsTest
     public void ExpectsStringValue_ReturnsFalse_ForNonStringProperty()
     {
         // Arrange
-        var tagHelperBuilder = new TagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "TestTagHelper", "Test");
-        tagHelperBuilder.Metadata(TypeName("TestTagHelper"));
+        var tagHelper = TagHelperDescriptorBuilder.Create(TagHelperConventions.DefaultKind, "TestTagHelper", "Test")
+            .Metadata(TypeName("TestTagHelper"))
+            .BoundAttributeDescriptor(attribute => attribute
+                .Name("test")
+                .Metadata(PropertyName("BoundProp"))
+                .TypeName(typeof(bool).FullName))
+            .Build();
 
-        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
-        builder
-            .Name("test")
-            .Metadata(PropertyName("BoundProp"))
-            .TypeName(typeof(bool).FullName);
-
-        var descriptor = builder.Build();
+        var boundAttribute = Assert.Single(tagHelper.BoundAttributes);
 
         // Act
-        var result = descriptor.ExpectsStringValue("test");
+        var result = boundAttribute.ExpectsStringValue("test");
 
         // Assert
         Assert.False(result);
@@ -147,20 +139,19 @@ public class BoundAttributeDescriptorExtensionsTest
     public void ExpectsStringValue_ReturnsTrue_StringIndexerAndNameMatch()
     {
         // Arrange
-        var tagHelperBuilder = new TagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "TestTagHelper", "Test");
-        tagHelperBuilder.Metadata(TypeName("TestTagHelper"));
+        var tagHelper = TagHelperDescriptorBuilder.Create(TagHelperConventions.DefaultKind, "TestTagHelper", "Test")
+            .Metadata(TypeName("TestTagHelper"))
+            .BoundAttributeDescriptor(attribute => attribute
+                .Name("test")
+                .Metadata(PropertyName("BoundProp"))
+                .TypeName("System.Collection.Generic.IDictionary<string, string>")
+                .AsDictionary("prefix-test-", typeof(string).FullName))
+            .Build();
 
-        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
-        builder
-            .Name("test")
-            .Metadata(PropertyName("BoundProp"))
-            .TypeName("System.Collection.Generic.IDictionary<string, string>")
-            .AsDictionary("prefix-test-", typeof(string).FullName);
-
-        var descriptor = builder.Build();
+        var boundAttribute = Assert.Single(tagHelper.BoundAttributes);
 
         // Act
-        var result = descriptor.ExpectsStringValue("prefix-test-key");
+        var result = boundAttribute.ExpectsStringValue("prefix-test-key");
 
         // Assert
         Assert.True(result);
@@ -170,20 +161,19 @@ public class BoundAttributeDescriptorExtensionsTest
     public void ExpectsStringValue_ReturnsFalse_StringIndexerAndNameMismatch()
     {
         // Arrange
-        var tagHelperBuilder = new TagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "TestTagHelper", "Test");
-        tagHelperBuilder.Metadata(TypeName("TestTagHelper"));
+        var tagHelper = TagHelperDescriptorBuilder.Create(TagHelperConventions.DefaultKind, "TestTagHelper", "Test")
+            .Metadata(TypeName("TestTagHelper"))
+            .BoundAttributeDescriptor(attribute => attribute
+                .Name("test")
+                .Metadata(PropertyName("BoundProp"))
+                .TypeName("System.Collection.Generic.IDictionary<string, string>")
+                .AsDictionary("prefix-test-", typeof(string).FullName))
+            .Build();
 
-        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
-        builder
-            .Name("test")
-            .Metadata(PropertyName("BoundProp"))
-            .TypeName("System.Collection.Generic.IDictionary<string, string>")
-            .AsDictionary("prefix-test-", typeof(string).FullName);
-
-        var descriptor = builder.Build();
+        var boundAttribute = Assert.Single(tagHelper.BoundAttributes);
 
         // Act
-        var result = descriptor.ExpectsStringValue("test");
+        var result = boundAttribute.ExpectsStringValue("test");
 
         // Assert
         Assert.False(result);
@@ -193,19 +183,18 @@ public class BoundAttributeDescriptorExtensionsTest
     public void ExpectsBooleanValue_ReturnsTrue_ForBooleanProperty()
     {
         // Arrange
-        var tagHelperBuilder = new TagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "TestTagHelper", "Test");
-        tagHelperBuilder.Metadata(TypeName("TestTagHelper"));
+        var tagHelper = TagHelperDescriptorBuilder.Create(TagHelperConventions.DefaultKind, "TestTagHelper", "Test")
+            .Metadata(TypeName("TestTagHelper"))
+            .BoundAttributeDescriptor(attribute => attribute
+                .Name("test")
+                .Metadata(PropertyName("BoundProp"))
+                .TypeName(typeof(bool).FullName))
+            .Build();
 
-        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
-        builder
-            .Name("test")
-            .Metadata(PropertyName("BoundProp"))
-            .TypeName(typeof(bool).FullName);
-
-        var descriptor = builder.Build();
+        var boundAttribute = Assert.Single(tagHelper.BoundAttributes);
 
         // Act
-        var result = descriptor.ExpectsBooleanValue("test");
+        var result = boundAttribute.ExpectsBooleanValue("test");
 
         // Assert
         Assert.True(result);
@@ -215,19 +204,18 @@ public class BoundAttributeDescriptorExtensionsTest
     public void ExpectsBooleanValue_ReturnsFalse_ForNonBooleanProperty()
     {
         // Arrange
-        var tagHelperBuilder = new TagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "TestTagHelper", "Test");
-        tagHelperBuilder.Metadata(TypeName("TestTagHelper"));
+        var tagHelper = TagHelperDescriptorBuilder.Create(TagHelperConventions.DefaultKind, "TestTagHelper", "Test")
+            .Metadata(TypeName("TestTagHelper"))
+            .BoundAttributeDescriptor(attribute => attribute
+                .Name("test")
+                .Metadata(PropertyName("BoundProp"))
+                .TypeName(typeof(int).FullName))
+            .Build();
 
-        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
-        builder
-            .Name("test")
-            .Metadata(PropertyName("BoundProp"))
-            .TypeName(typeof(int).FullName);
-
-        var descriptor = builder.Build();
+        var boundAttribute = Assert.Single(tagHelper.BoundAttributes);
 
         // Act
-        var result = descriptor.ExpectsBooleanValue("test");
+        var result = boundAttribute.ExpectsBooleanValue("test");
 
         // Assert
         Assert.False(result);
@@ -237,20 +225,19 @@ public class BoundAttributeDescriptorExtensionsTest
     public void ExpectsBooleanValue_ReturnsTrue_BooleanIndexerAndNameMatch()
     {
         // Arrange
-        var tagHelperBuilder = new TagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "TestTagHelper", "Test");
-        tagHelperBuilder.Metadata(TypeName("TestTagHelper"));
+        var tagHelper = TagHelperDescriptorBuilder.Create(TagHelperConventions.DefaultKind, "TestTagHelper", "Test")
+            .Metadata(TypeName("TestTagHelper"))
+            .BoundAttributeDescriptor(attribute => attribute
+                .Name("test")
+                .Metadata(PropertyName("BoundProp"))
+                .TypeName("System.Collection.Generic.IDictionary<string, bool>")
+                .AsDictionary("prefix-test-", typeof(bool).FullName))
+            .Build();
 
-        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
-        builder
-            .Name("test")
-            .Metadata(PropertyName("BoundProp"))
-            .TypeName("System.Collection.Generic.IDictionary<string, bool>")
-            .AsDictionary("prefix-test-", typeof(bool).FullName);
-
-        var descriptor = builder.Build();
+        var boundAttribute = Assert.Single(tagHelper.BoundAttributes);
 
         // Act
-        var result = descriptor.ExpectsBooleanValue("prefix-test-key");
+        var result = boundAttribute.ExpectsBooleanValue("prefix-test-key");
 
         // Assert
         Assert.True(result);
@@ -260,20 +247,19 @@ public class BoundAttributeDescriptorExtensionsTest
     public void ExpectsBooleanValue_ReturnsFalse_BooleanIndexerAndNameMismatch()
     {
         // Arrange
-        var tagHelperBuilder = new TagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "TestTagHelper", "Test");
-        tagHelperBuilder.Metadata(TypeName("TestTagHelper"));
+        var tagHelper = TagHelperDescriptorBuilder.Create(TagHelperConventions.DefaultKind, "TestTagHelper", "Test")
+            .Metadata(TypeName("TestTagHelper"))
+            .BoundAttributeDescriptor(attribute => attribute
+                .Name("test")
+                .Metadata(PropertyName("BoundProp"))
+                .TypeName("System.Collection.Generic.IDictionary<string, bool>")
+                .AsDictionary("prefix-test-", typeof(bool).FullName))
+            .Build();
 
-        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
-        builder
-            .Name("test")
-            .Metadata(PropertyName("BoundProp"))
-            .TypeName("System.Collection.Generic.IDictionary<string, bool>")
-            .AsDictionary("prefix-test-", typeof(bool).FullName);
-
-        var descriptor = builder.Build();
+        var boundAttribute = Assert.Single(tagHelper.BoundAttributes);
 
         // Act
-        var result = descriptor.ExpectsBooleanValue("test");
+        var result = boundAttribute.ExpectsBooleanValue("test");
 
         // Assert
         Assert.False(result);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DefaultBoundAttributeDescriptorBuilderTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DefaultBoundAttributeDescriptorBuilderTest.cs
@@ -16,7 +16,7 @@ public class DefaultBoundAttributeDescriptorBuilderTest
 
         var tagHelperBuilder = new TagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "TestTagHelper", "Test");
 
-        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
+        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder);
         builder.DisplayName(expectedDisplayName);
 
         // Act
@@ -33,7 +33,7 @@ public class DefaultBoundAttributeDescriptorBuilderTest
         var tagHelperBuilder = new TagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "TestTagHelper", "Test");
         tagHelperBuilder.Metadata(TypeName("TestTagHelper"));
 
-        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
+        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder);
         builder
             .TypeName(typeof(int).FullName)
             .Metadata(PropertyName("SomeProperty"));
@@ -56,12 +56,12 @@ public class DefaultBoundAttributeDescriptorBuilderTest
 
         var metadata = MetadataCollection.Create(PropertyName("SomeProperty"));
 
-        var builder1 = new BoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind)
+        var builder1 = new BoundAttributeDescriptorBuilder(tagHelperBuilder)
         {
             TypeName = typeof(int).FullName
         };
 
-        var builder2 = new BoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind)
+        var builder2 = new BoundAttributeDescriptorBuilder(tagHelperBuilder)
         {
             TypeName = typeof(int).FullName
         };
@@ -86,12 +86,12 @@ public class DefaultBoundAttributeDescriptorBuilderTest
         // Arrange
         var tagHelperBuilder = new TagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "TestTagHelper", "Test");
 
-        var builder1 = new BoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind)
+        var builder1 = new BoundAttributeDescriptorBuilder(tagHelperBuilder)
         {
             TypeName = typeof(int).FullName
         };
 
-        var builder2 = new BoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind)
+        var builder2 = new BoundAttributeDescriptorBuilder(tagHelperBuilder)
         {
             TypeName = typeof(int).FullName
         };

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Extensions/PreallocatedAttributeTargetExtensionTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Extensions/PreallocatedAttributeTargetExtensionTest.cs
@@ -130,7 +130,7 @@ public class PreallocatedAttributeTargetExtensionTest
         var tagHelperBuilder = new TagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "FooTagHelper", "Test");
         tagHelperBuilder.Metadata(TypeName("FooTagHelper"));
 
-        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
+        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder);
         builder
             .Name("Foo")
             .TypeName("System.String")
@@ -173,7 +173,7 @@ __tagHelperExecutionContext.AddTagHelperAttribute(_tagHelper1);
         var tagHelperBuilder = new TagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "FooTagHelper", "Test");
         tagHelperBuilder.Metadata(TypeName("FooTagHelper"));
 
-        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
+        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder);
         builder
             .Name("Foo")
             .TypeName("System.Collections.Generic.Dictionary<System.String, System.String>")
@@ -223,7 +223,7 @@ __tagHelperExecutionContext.AddTagHelperAttribute(_tagHelper1);
         var tagHelperBuilder = new TagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "FooTagHelper", "Test");
         tagHelperBuilder.Metadata(TypeName("FooTagHelper"));
 
-        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
+        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder);
         builder
             .Name("Foo")
             .TypeName("System.Collections.Generic.Dictionary<System.String, System.String>")

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TagHelperMatchingConventionsTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TagHelperMatchingConventionsTest.cs
@@ -163,7 +163,7 @@ public class TagHelperMatchingConventionsTest
     {
         // Arrange
         var tagHelperBuilder = new TagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "TestTagHelper", "Test");
-        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
+        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder);
         builder.AsDictionary("asp-", typeof(Dictionary<string, string>).FullName);
 
         var boundAttribute = builder.Build();
@@ -180,7 +180,7 @@ public class TagHelperMatchingConventionsTest
     {
         // Arrange
         var tagHelperBuilder = new TagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "TestTagHelper", "Test");
-        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
+        var builder = new BoundAttributeDescriptorBuilder(tagHelperBuilder);
         builder.AsDictionary("asp-", typeof(Dictionary<string, string>).FullName);
 
         var boundAttribute = builder.Build();

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/AllowedChildTagDescriptor.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/AllowedChildTagDescriptor.cs
@@ -2,12 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using Microsoft.AspNetCore.Razor.Utilities;
 
 namespace Microsoft.AspNetCore.Razor.Language;
 
 public sealed class AllowedChildTagDescriptor : TagHelperObject<AllowedChildTagDescriptor>
 {
+    private TagHelperDescriptor? _parent;
+
     public string Name { get; }
     public string DisplayName { get; }
 
@@ -22,6 +25,17 @@ public sealed class AllowedChildTagDescriptor : TagHelperObject<AllowedChildTagD
     {
         builder.AppendData(Name);
         builder.AppendData(DisplayName);
+    }
+
+    public TagHelperDescriptor Parent
+        => _parent ?? ThrowHelper.ThrowInvalidOperationException<TagHelperDescriptor>(Resources.Parent_has_not_been_set);
+
+    internal void SetParent(TagHelperDescriptor parent)
+    {
+        Debug.Assert(parent != null);
+        Debug.Assert(_parent == null);
+
+        _parent = parent;
     }
 
     public override string ToString()

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/BoundAttributeDescriptor.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/BoundAttributeDescriptor.cs
@@ -34,7 +34,6 @@ public sealed class BoundAttributeDescriptor : TagHelperObject<BoundAttributeDes
 
     private TagHelperDescriptor? _parent;
 
-    public string Kind { get; }
     public string Name { get; }
     public string TypeName { get; }
     public string DisplayName { get; }
@@ -57,7 +56,6 @@ public sealed class BoundAttributeDescriptor : TagHelperObject<BoundAttributeDes
     public MetadataCollection Metadata { get; }
 
     internal BoundAttributeDescriptor(
-        string kind,
         string name,
         string typeName,
         bool isEnum,
@@ -74,7 +72,6 @@ public sealed class BoundAttributeDescriptor : TagHelperObject<BoundAttributeDes
         ImmutableArray<RazorDiagnostic> diagnostics)
         : base(diagnostics)
     {
-        Kind = kind;
         Name = name;
         TypeName = typeName;
         IndexerNamePrefix = indexerNamePrefix;
@@ -142,7 +139,6 @@ public sealed class BoundAttributeDescriptor : TagHelperObject<BoundAttributeDes
 
     private protected override void BuildChecksum(in Checksum.Builder builder)
     {
-        builder.AppendData(Kind);
         builder.AppendData(Name);
         builder.AppendData(TypeName);
         builder.AppendData(IndexerNamePrefix);

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/BoundAttributeDescriptor.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/BoundAttributeDescriptor.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.Utilities;
 
@@ -30,6 +31,8 @@ public sealed class BoundAttributeDescriptor : TagHelperObject<BoundAttributeDes
 
     private readonly BoundAttributeFlags _flags;
     private readonly DocumentationObject _documentationObject;
+
+    private TagHelperDescriptor? _parent;
 
     public string Kind { get; }
     public string Name { get; }
@@ -81,6 +84,11 @@ public sealed class BoundAttributeDescriptor : TagHelperObject<BoundAttributeDes
         ContainingType = containingType;
         Parameters = parameters.NullToEmpty();
         Metadata = metadata ?? MetadataCollection.Empty;
+
+        foreach (var parameter in Parameters)
+        {
+            parameter.SetParent(this);
+        }
 
         BoundAttributeFlags flags = 0;
 
@@ -159,6 +167,17 @@ public sealed class BoundAttributeDescriptor : TagHelperObject<BoundAttributeDes
         }
 
         builder.AppendData(Metadata.Checksum);
+    }
+
+    public TagHelperDescriptor Parent
+        => _parent ?? ThrowHelper.ThrowInvalidOperationException<TagHelperDescriptor>(Resources.Parent_has_not_been_set);
+
+    internal void SetParent(TagHelperDescriptor parent)
+    {
+        Debug.Assert(parent != null);
+        Debug.Assert(_parent == null);
+
+        _parent = parent;
     }
 
     public string? Documentation => _documentationObject.GetText();

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/BoundAttributeDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/BoundAttributeDescriptorBuilder.cs
@@ -35,8 +35,6 @@ public sealed partial class BoundAttributeDescriptorBuilder : TagHelperObjectBui
 
     [AllowNull]
     private TagHelperDescriptorBuilder _parent;
-    [AllowNull]
-    private string _kind;
     private DocumentationObject _documentationObject;
     private MetadataHolder _metadata;
     private bool? _caseSensitive;
@@ -45,10 +43,9 @@ public sealed partial class BoundAttributeDescriptorBuilder : TagHelperObjectBui
     {
     }
 
-    internal BoundAttributeDescriptorBuilder(TagHelperDescriptorBuilder parent, string kind)
+    internal BoundAttributeDescriptorBuilder(TagHelperDescriptorBuilder parent)
     {
         _parent = parent;
-        _kind = kind;
     }
 
     [AllowNull]
@@ -111,7 +108,6 @@ public sealed partial class BoundAttributeDescriptorBuilder : TagHelperObjectBui
     private protected override BoundAttributeDescriptor BuildCore(ImmutableArray<RazorDiagnostic> diagnostics)
     {
         return new BoundAttributeDescriptor(
-            _kind,
             Name ?? string.Empty,
             TypeName ?? string.Empty,
             IsEnum,

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/BoundAttributeDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/BoundAttributeDescriptorBuilder.cs
@@ -93,7 +93,7 @@ public sealed partial class BoundAttributeDescriptorBuilder : TagHelperObjectBui
             throw new ArgumentNullException(nameof(configure));
         }
 
-        var builder = BoundAttributeParameterDescriptorBuilder.GetInstance(this, _kind);
+        var builder = BoundAttributeParameterDescriptorBuilder.GetInstance(this);
         configure(builder);
         Parameters.Add(builder);
     }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/BoundAttributeDescriptorBuilder_Pooling.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/BoundAttributeDescriptorBuilder_Pooling.cs
@@ -10,12 +10,11 @@ public partial class BoundAttributeDescriptorBuilder
 {
     internal static readonly ObjectPool<BoundAttributeDescriptorBuilder> Pool = DefaultPool.Create(Policy.Instance);
 
-    internal static BoundAttributeDescriptorBuilder GetInstance(TagHelperDescriptorBuilder parent, string kind)
+    internal static BoundAttributeDescriptorBuilder GetInstance(TagHelperDescriptorBuilder parent)
     {
         var builder = Pool.Get();
 
         builder._parent = parent;
-        builder._kind = kind;
 
         return builder;
     }
@@ -23,7 +22,6 @@ public partial class BoundAttributeDescriptorBuilder
     private protected override void Reset()
     {
         _parent = null;
-        _kind = null;
         _documentationObject = default;
         _caseSensitive = null;
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/BoundAttributeDescriptorExtensions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/BoundAttributeDescriptorExtensions.cs
@@ -56,7 +56,7 @@ public static class BoundAttributeDescriptorExtensions
     {
         ArgHelper.ThrowIfNull(parameter);
 
-        return parameter.Kind == TagHelperConventions.DefaultKind;
+        return parameter.Parent.Parent.Kind == TagHelperConventions.DefaultKind;
     }
 
     public static string? GetPropertyName(this BoundAttributeParameterDescriptor parameter)

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/BoundAttributeDescriptorExtensions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/BoundAttributeDescriptorExtensions.cs
@@ -1,31 +1,23 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.AspNetCore.Razor.Language;
 
 public static class BoundAttributeDescriptorExtensions
 {
-    public static string GetPropertyName(this BoundAttributeDescriptor attribute)
+    public static string? GetPropertyName(this BoundAttributeDescriptor attribute)
     {
-        if (attribute == null)
-        {
-            throw new ArgumentNullException(nameof(attribute));
-        }
+        ArgHelper.ThrowIfNull(attribute);
 
         attribute.Metadata.TryGetValue(TagHelperMetadata.Common.PropertyName, out var propertyName);
         return propertyName;
     }
 
-    public static string GetGloballyQualifiedTypeName(this BoundAttributeDescriptor attribute)
+    public static string? GetGloballyQualifiedTypeName(this BoundAttributeDescriptor attribute)
     {
-        if (attribute == null)
-        {
-            throw new ArgumentNullException(nameof(attribute));
-        }
+        ArgHelper.ThrowIfNull(attribute);
 
         attribute.Metadata.TryGetValue(TagHelperMetadata.Common.GloballyQualifiedTypeName, out var propertyName);
         return propertyName;
@@ -33,10 +25,7 @@ public static class BoundAttributeDescriptorExtensions
 
     public static bool IsDefaultKind(this BoundAttributeDescriptor attribute)
     {
-        if (attribute == null)
-        {
-            throw new ArgumentNullException(nameof(attribute));
-        }
+        ArgHelper.ThrowIfNull(attribute);
 
         return attribute.Kind == TagHelperConventions.DefaultKind;
     }
@@ -65,20 +54,14 @@ public static class BoundAttributeDescriptorExtensions
 
     public static bool IsDefaultKind(this BoundAttributeParameterDescriptor parameter)
     {
-        if (parameter == null)
-        {
-            throw new ArgumentNullException(nameof(parameter));
-        }
+        ArgHelper.ThrowIfNull(parameter);
 
         return parameter.Kind == TagHelperConventions.DefaultKind;
     }
 
-    public static string GetPropertyName(this BoundAttributeParameterDescriptor parameter)
+    public static string? GetPropertyName(this BoundAttributeParameterDescriptor parameter)
     {
-        if (parameter == null)
-        {
-            throw new ArgumentNullException(nameof(parameter));
-        }
+        ArgHelper.ThrowIfNull(parameter);
 
         parameter.Metadata.TryGetValue(TagHelperMetadata.Common.PropertyName, out var propertyName);
         return propertyName;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/BoundAttributeDescriptorExtensions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/BoundAttributeDescriptorExtensions.cs
@@ -27,7 +27,7 @@ public static class BoundAttributeDescriptorExtensions
     {
         ArgHelper.ThrowIfNull(attribute);
 
-        return attribute.Kind == TagHelperConventions.DefaultKind;
+        return attribute.Parent.Kind == TagHelperConventions.DefaultKind;
     }
 
     internal static bool ExpectsStringValue(this BoundAttributeDescriptor attribute, string name)

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/BoundAttributeParameterDescriptor.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/BoundAttributeParameterDescriptor.cs
@@ -24,7 +24,6 @@ public sealed class BoundAttributeParameterDescriptor : TagHelperObject<BoundAtt
 
     private BoundAttributeDescriptor? _parent;
 
-    public string Kind { get; }
     public string Name { get; }
     public string TypeName { get; }
     public string DisplayName { get; }
@@ -37,7 +36,6 @@ public sealed class BoundAttributeParameterDescriptor : TagHelperObject<BoundAtt
     public MetadataCollection Metadata { get; }
 
     internal BoundAttributeParameterDescriptor(
-        string kind,
         string name,
         string typeName,
         bool isEnum,
@@ -48,7 +46,6 @@ public sealed class BoundAttributeParameterDescriptor : TagHelperObject<BoundAtt
         ImmutableArray<RazorDiagnostic> diagnostics)
         : base(diagnostics)
     {
-        Kind = kind;
         Name = name;
         TypeName = typeName;
         _documentationObject = documentationObject;
@@ -82,7 +79,6 @@ public sealed class BoundAttributeParameterDescriptor : TagHelperObject<BoundAtt
 
     private protected override void BuildChecksum(in Checksum.Builder builder)
     {
-        builder.AppendData(Kind);
         builder.AppendData(Name);
         builder.AppendData(TypeName);
         builder.AppendData(DisplayName);

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/BoundAttributeParameterDescriptor.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/BoundAttributeParameterDescriptor.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using Microsoft.AspNetCore.Razor.Utilities;
 
 namespace Microsoft.AspNetCore.Razor.Language;
@@ -20,6 +21,8 @@ public sealed class BoundAttributeParameterDescriptor : TagHelperObject<BoundAtt
 
     private readonly BoundAttributeParameterFlags _flags;
     private readonly DocumentationObject _documentationObject;
+
+    private BoundAttributeDescriptor? _parent;
 
     public string Kind { get; }
     public string Name { get; }
@@ -91,6 +94,17 @@ public sealed class BoundAttributeParameterDescriptor : TagHelperObject<BoundAtt
         builder.AppendData(IsBooleanProperty);
         builder.AppendData(IsStringProperty);
         builder.AppendData(Metadata.Checksum);
+    }
+
+    public BoundAttributeDescriptor Parent
+        => _parent ?? ThrowHelper.ThrowInvalidOperationException<BoundAttributeDescriptor>(Resources.Parent_has_not_been_set);
+
+    internal void SetParent(BoundAttributeDescriptor parent)
+    {
+        Debug.Assert(parent != null);
+        Debug.Assert(_parent == null);
+
+        _parent = parent;
     }
 
     public string? Documentation => _documentationObject.GetText();

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/BoundAttributeParameterDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/BoundAttributeParameterDescriptorBuilder.cs
@@ -13,8 +13,6 @@ public sealed partial class BoundAttributeParameterDescriptorBuilder : TagHelper
 {
     [AllowNull]
     private BoundAttributeDescriptorBuilder _parent;
-    [AllowNull]
-    private string _kind;
     private DocumentationObject _documentationObject;
     private MetadataHolder _metadata;
 
@@ -22,10 +20,9 @@ public sealed partial class BoundAttributeParameterDescriptorBuilder : TagHelper
     {
     }
 
-    internal BoundAttributeParameterDescriptorBuilder(BoundAttributeDescriptorBuilder parent, string kind)
+    internal BoundAttributeParameterDescriptorBuilder(BoundAttributeDescriptorBuilder parent)
     {
         _parent = parent;
-        _kind = kind;
     }
 
     public string? Name { get; set; }
@@ -62,7 +59,6 @@ public sealed partial class BoundAttributeParameterDescriptorBuilder : TagHelper
     private protected override BoundAttributeParameterDescriptor BuildCore(ImmutableArray<RazorDiagnostic> diagnostics)
     {
         return new BoundAttributeParameterDescriptor(
-            _kind,
             Name ?? string.Empty,
             TypeName ?? string.Empty,
             IsEnum,

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/BoundAttributeParameterDescriptorBuilder_Pooling.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/BoundAttributeParameterDescriptorBuilder_Pooling.cs
@@ -10,12 +10,11 @@ public partial class BoundAttributeParameterDescriptorBuilder
 {
     internal static readonly ObjectPool<BoundAttributeParameterDescriptorBuilder> Pool = DefaultPool.Create(Policy.Instance);
 
-    internal static BoundAttributeParameterDescriptorBuilder GetInstance(BoundAttributeDescriptorBuilder parent, string kind)
+    internal static BoundAttributeParameterDescriptorBuilder GetInstance(BoundAttributeDescriptorBuilder parent)
     {
         var builder = Pool.Get();
 
         builder._parent = parent;
-        builder._kind = kind;
 
         return builder;
     }
@@ -23,7 +22,6 @@ public partial class BoundAttributeParameterDescriptorBuilder
     private protected override void Reset()
     {
         _parent = null;
-        _kind = null;
         _documentationObject = default;
 
         Name = null;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CommonMetadata.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CommonMetadata.cs
@@ -19,7 +19,7 @@ public static class CommonMetadata
         => new(key, bool.TrueString);
     internal static KeyValuePair<string, string?> GloballyQualifiedTypeName(string value)
         => new(TagHelperMetadata.Common.GloballyQualifiedTypeName, value);
-    public static KeyValuePair<string, string?> PropertyName(string value)
+    public static KeyValuePair<string, string?> PropertyName(string? value)
         => new(TagHelperMetadata.Common.PropertyName, value);
     internal static KeyValuePair<string, string?> RuntimeName(string value)
         => new(TagHelperMetadata.Runtime.Name, value);

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeDescriptor.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeDescriptor.cs
@@ -2,12 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using Microsoft.AspNetCore.Razor.Utilities;
 
 namespace Microsoft.AspNetCore.Razor.Language;
 
 public sealed class RequiredAttributeDescriptor : TagHelperObject<RequiredAttributeDescriptor>
 {
+    private TagMatchingRuleDescriptor? _parent;
+
     public string Name { get; }
     public NameComparisonMode NameComparison { get; }
     public string? Value { get; }
@@ -46,6 +49,17 @@ public sealed class RequiredAttributeDescriptor : TagHelperObject<RequiredAttrib
         builder.AppendData(DisplayName);
         builder.AppendData(CaseSensitive);
         builder.AppendData(Metadata.Checksum);
+    }
+
+    public TagMatchingRuleDescriptor Parent
+        => _parent ?? ThrowHelper.ThrowInvalidOperationException<TagMatchingRuleDescriptor>(Resources.Parent_has_not_been_set);
+
+    internal void SetParent(TagMatchingRuleDescriptor parent)
+    {
+        Debug.Assert(parent != null);
+        Debug.Assert(_parent == null);
+
+        _parent = parent;
     }
 
     public override string ToString()

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Resources.resx
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Resources.resx
@@ -616,4 +616,7 @@
   <data name="Possible_preprocessor_directive_is_misplaced" xml:space="preserve">
     <value>Possible C# preprocessor directive is misplaced. C# preprocessor directives must be at the start of the line, except for whitespace.</value>
   </data>
+  <data name="Parent_has_not_been_set" xml:space="preserve">
+    <value>Parent has not been set.</value>
+  </data>
 </root>

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperDescriptor.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperDescriptor.cs
@@ -83,6 +83,21 @@ public sealed class TagHelperDescriptor : TagHelperObject<TagHelperDescriptor>
         AllowedChildTags = allowedChildTags.NullToEmpty();
         Metadata = metadata ?? MetadataCollection.Empty;
 
+        foreach (var tagMatchingRule in TagMatchingRules)
+        {
+            tagMatchingRule.SetParent(this);
+        }
+
+        foreach (var boundAttribute in BoundAttributes)
+        {
+            boundAttribute.SetParent(this);
+        }
+
+        foreach (var allowedChildTag in AllowedChildTags)
+        {
+            allowedChildTag.SetParent(this);
+        }
+
         TagHelperFlags flags = 0;
 
         if (caseSensitive)

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperDescriptorBuilder.cs
@@ -83,7 +83,7 @@ public sealed partial class TagHelperDescriptorBuilder : TagHelperObjectBuilder<
             throw new ArgumentNullException(nameof(configure));
         }
 
-        var builder = BoundAttributeDescriptorBuilder.GetInstance(this, Kind);
+        var builder = BoundAttributeDescriptorBuilder.GetInstance(this);
         configure(builder);
         BoundAttributes.Add(builder);
     }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagMatchingRuleDescriptor.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagMatchingRuleDescriptor.cs
@@ -13,6 +13,8 @@ namespace Microsoft.AspNetCore.Razor.Language;
 [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
 public sealed class TagMatchingRuleDescriptor : TagHelperObject<TagMatchingRuleDescriptor>
 {
+    private TagHelperDescriptor? _parent;
+
     public string TagName { get; }
     public string? ParentTag { get; }
     public TagStructure TagStructure { get; }
@@ -33,6 +35,11 @@ public sealed class TagMatchingRuleDescriptor : TagHelperObject<TagMatchingRuleD
         TagStructure = tagStructure;
         CaseSensitive = caseSensitive;
         Attributes = attributes.NullToEmpty();
+
+        foreach (var attribute in Attributes)
+        {
+            attribute.SetParent(this);
+        }
     }
 
     private protected override void BuildChecksum(in Checksum.Builder builder)
@@ -47,6 +54,17 @@ public sealed class TagMatchingRuleDescriptor : TagHelperObject<TagMatchingRuleD
         {
             builder.AppendData(descriptor.Checksum);
         }
+    }
+
+    public TagHelperDescriptor Parent
+        => _parent ?? ThrowHelper.ThrowInvalidOperationException<TagHelperDescriptor>(Resources.Parent_has_not_been_set);
+
+    internal void SetParent(TagHelperDescriptor parent)
+    {
+        Debug.Assert(parent != null);
+        Debug.Assert(_parent == null);
+
+        _parent = parent;
     }
 
     public IEnumerable<RazorDiagnostic> GetAllDiagnostics()

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/test/BindTagHelperDescriptorProviderTest.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/test/BindTagHelperDescriptorProviderTest.cs
@@ -146,7 +146,7 @@ namespace Test
         // Invariants
         Assert.Empty(attribute.Diagnostics);
         Assert.False(attribute.HasErrors);
-        Assert.Equal(ComponentMetadata.Bind.TagHelperKind, attribute.Kind);
+        Assert.Equal(ComponentMetadata.Bind.TagHelperKind, attribute.Parent.Kind);
         Assert.False(attribute.IsDefaultKind());
         Assert.False(attribute.HasIndexer);
         Assert.Null(attribute.IndexerNamePrefix);
@@ -370,7 +370,7 @@ namespace Test
         // Invariants
         Assert.Empty(attribute.Diagnostics);
         Assert.False(attribute.HasErrors);
-        Assert.Equal(ComponentMetadata.Bind.TagHelperKind, attribute.Kind);
+        Assert.Equal(ComponentMetadata.Bind.TagHelperKind, attribute.Parent.Kind);
         Assert.False(attribute.IsDefaultKind());
         Assert.False(attribute.HasIndexer);
         Assert.Null(attribute.IndexerNamePrefix);
@@ -563,7 +563,7 @@ namespace Test
             // Invariants
             Assert.Empty(attribute.Diagnostics);
             Assert.False(attribute.HasErrors);
-            Assert.Equal(ComponentMetadata.Bind.TagHelperKind, attribute.Kind);
+            Assert.Equal(ComponentMetadata.Bind.TagHelperKind, attribute.Parent.Kind);
             Assert.False(attribute.IsDefaultKind());
             Assert.False(attribute.HasIndexer);
             Assert.Null(attribute.IndexerNamePrefix);
@@ -1157,7 +1157,7 @@ namespace Test
         // Invariants
         Assert.Empty(attribute.Diagnostics);
         Assert.False(attribute.HasErrors);
-        Assert.Equal(ComponentMetadata.Bind.TagHelperKind, attribute.Kind);
+        Assert.Equal(ComponentMetadata.Bind.TagHelperKind, attribute.Parent.Kind);
         Assert.False(attribute.IsDefaultKind());
         Assert.False(attribute.IsIndexerBooleanProperty);
         Assert.False(attribute.IsIndexerStringProperty);

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/test/BindTagHelperDescriptorProviderTest.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/test/BindTagHelperDescriptorProviderTest.cs
@@ -591,7 +591,7 @@ namespace Test
             // Invariants
             Assert.Empty(parameter.Diagnostics);
             Assert.False(parameter.HasErrors);
-            Assert.Equal(ComponentMetadata.Bind.TagHelperKind, parameter.Kind);
+            Assert.Equal(ComponentMetadata.Bind.TagHelperKind, parameter.Parent.Parent.Kind);
             Assert.False(parameter.IsDefaultKind());
 
             Assert.Equal(
@@ -614,7 +614,7 @@ namespace Test
             // Invariants
             Assert.Empty(parameter.Diagnostics);
             Assert.False(parameter.HasErrors);
-            Assert.Equal(ComponentMetadata.Bind.TagHelperKind, parameter.Kind);
+            Assert.Equal(ComponentMetadata.Bind.TagHelperKind, parameter.Parent.Parent.Kind);
             Assert.False(parameter.IsDefaultKind());
 
             Assert.Equal(
@@ -636,7 +636,7 @@ namespace Test
             // Invariants
             Assert.Empty(parameter.Diagnostics);
             Assert.False(parameter.HasErrors);
-            Assert.Equal(ComponentMetadata.Bind.TagHelperKind, parameter.Kind);
+            Assert.Equal(ComponentMetadata.Bind.TagHelperKind, parameter.Parent.Parent.Kind);
             Assert.False(parameter.IsDefaultKind());
 
             Assert.Equal(
@@ -658,7 +658,7 @@ namespace Test
             // Invariants
             Assert.Empty(parameter.Diagnostics);
             Assert.False(parameter.HasErrors);
-            Assert.Equal(ComponentMetadata.Bind.TagHelperKind, parameter.Kind);
+            Assert.Equal(ComponentMetadata.Bind.TagHelperKind, parameter.Parent.Parent.Kind);
             Assert.False(parameter.IsDefaultKind());
 
             Assert.Equal(
@@ -680,7 +680,7 @@ namespace Test
             // Invariants
             Assert.Empty(parameter.Diagnostics);
             Assert.False(parameter.HasErrors);
-            Assert.Equal(ComponentMetadata.Bind.TagHelperKind, parameter.Kind);
+            Assert.Equal(ComponentMetadata.Bind.TagHelperKind, parameter.Parent.Parent.Kind);
             Assert.False(parameter.IsDefaultKind());
 
             Assert.Equal(
@@ -1190,7 +1190,7 @@ namespace Test
         // Invariants
         Assert.Empty(parameter.Diagnostics);
         Assert.False(parameter.HasErrors);
-        Assert.Equal(ComponentMetadata.Bind.TagHelperKind, parameter.Kind);
+        Assert.Equal(ComponentMetadata.Bind.TagHelperKind, parameter.Parent.Parent.Kind);
         Assert.False(parameter.IsDefaultKind());
 
         Assert.Equal(
@@ -1215,7 +1215,7 @@ namespace Test
         // Invariants
         Assert.Empty(parameter.Diagnostics);
         Assert.False(parameter.HasErrors);
-        Assert.Equal(ComponentMetadata.Bind.TagHelperKind, parameter.Kind);
+        Assert.Equal(ComponentMetadata.Bind.TagHelperKind, parameter.Parent.Parent.Kind);
         Assert.False(parameter.IsDefaultKind());
 
         Assert.Equal(

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/test/ComponentTagHelperDescriptorProviderTest.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/test/ComponentTagHelperDescriptorProviderTest.cs
@@ -102,7 +102,7 @@ namespace Test
         // Invariants
         Assert.Empty(attribute.Diagnostics);
         Assert.False(attribute.HasErrors);
-        Assert.Equal("Components.Component", attribute.Kind);
+        Assert.Equal("Components.Component", attribute.Parent.Kind);
         Assert.False(attribute.IsDefaultKind());
 
         // Related to dictionaries/indexers, not supported currently, not sure if we ever will

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/test/DefaultTagHelperDescriptorFactoryTest.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/test/DefaultTagHelperDescriptorFactoryTest.cs
@@ -2432,7 +2432,7 @@ public class DefaultTagHelperDescriptorFactoryTest : TagHelperDescriptorProvider
         var tagHelperBuilder = new TagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, tagHelperTypeFullName.Split('.')[^1], "Test");
         tagHelperBuilder.Metadata(TypeName(tagHelperTypeFullName));
 
-        var attributeBuilder = new BoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
+        var attributeBuilder = new BoundAttributeDescriptorBuilder(tagHelperBuilder);
         configure(attributeBuilder);
         return attributeBuilder.Build();
     }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/test/EventHandlerTagHelperDescriptorProviderTest.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/test/EventHandlerTagHelperDescriptorProviderTest.cs
@@ -90,7 +90,7 @@ public class EventHandlerTagHelperDescriptorProviderTest : TagHelperDescriptorPr
         // Invariants
         Assert.Empty(attribute.Diagnostics);
         Assert.False(attribute.HasErrors);
-        Assert.Equal(ComponentMetadata.EventHandler.TagHelperKind, attribute.Kind);
+        Assert.Equal(ComponentMetadata.EventHandler.TagHelperKind, attribute.Parent.Kind);
         Assert.False(attribute.IsDefaultKind());
         Assert.False(attribute.HasIndexer);
         Assert.Null(attribute.IndexerNamePrefix);
@@ -230,7 +230,7 @@ public class EventHandlerTagHelperDescriptorProviderTest : TagHelperDescriptorPr
         // Invariants
         Assert.Empty(attribute.Diagnostics);
         Assert.False(attribute.HasErrors);
-        Assert.Equal(ComponentMetadata.EventHandler.TagHelperKind, attribute.Kind);
+        Assert.Equal(ComponentMetadata.EventHandler.TagHelperKind, attribute.Parent.Kind);
         Assert.False(attribute.IsDefaultKind());
         Assert.False(attribute.HasIndexer);
         Assert.Null(attribute.IndexerNamePrefix);

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/test/KeyTagHelperDescriptorProviderTest.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/test/KeyTagHelperDescriptorProviderTest.cs
@@ -66,7 +66,7 @@ public class KeyTagHelperDescriptorProviderTest : TagHelperDescriptorProviderTes
         var attribute = Assert.Single(item.BoundAttributes);
         Assert.Empty(attribute.Diagnostics);
         Assert.False(attribute.HasErrors);
-        Assert.Equal(ComponentMetadata.Key.TagHelperKind, attribute.Kind);
+        Assert.Equal(ComponentMetadata.Key.TagHelperKind, attribute.Parent.Kind);
         Assert.False(attribute.IsDefaultKind());
         Assert.False(attribute.HasIndexer);
         Assert.Null(attribute.IndexerNamePrefix);

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/test/RefTagHelperDescriptorProviderTest.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/test/RefTagHelperDescriptorProviderTest.cs
@@ -66,7 +66,7 @@ public class RefTagHelperDescriptorProviderTest : TagHelperDescriptorProviderTes
         var attribute = Assert.Single(item.BoundAttributes);
         Assert.Empty(attribute.Diagnostics);
         Assert.False(attribute.HasErrors);
-        Assert.Equal(ComponentMetadata.Ref.TagHelperKind, attribute.Kind);
+        Assert.Equal(ComponentMetadata.Ref.TagHelperKind, attribute.Parent.Kind);
         Assert.False(attribute.IsDefaultKind());
         Assert.False(attribute.HasIndexer);
         Assert.Null(attribute.IndexerNamePrefix);

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/test/SplatTagHelperDescriptorProviderTest.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/test/SplatTagHelperDescriptorProviderTest.cs
@@ -64,7 +64,7 @@ public class SplatTagHelperDescriptorProviderTest : TagHelperDescriptorProviderT
         var attribute = Assert.Single(item.BoundAttributes);
         Assert.Empty(attribute.Diagnostics);
         Assert.False(attribute.HasErrors);
-        Assert.Equal(ComponentMetadata.Splat.TagHelperKind, attribute.Kind);
+        Assert.Equal(ComponentMetadata.Splat.TagHelperKind, attribute.Parent.Kind);
         Assert.False(attribute.IsDefaultKind());
         Assert.False(attribute.HasIndexer);
         Assert.Null(attribute.IndexerNamePrefix);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/GoToDefinition/AbstractRazorComponentDefinitionService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/GoToDefinition/AbstractRazorComponentDefinitionService.cs
@@ -3,6 +3,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.Logging;
@@ -74,7 +75,7 @@ internal abstract class AbstractRazorComponentDefinitionService(
             _logger.LogInformation($"Attempting to get definition from an attribute directly.");
 
             var range = await RazorComponentDefinitionHelpers
-                .TryGetPropertyRangeAsync(documentSnapshot, attributeDescriptor.GetPropertyName(), _documentMappingService, _logger, cancellationToken)
+                .TryGetPropertyRangeAsync(documentSnapshot, attributeDescriptor.GetPropertyName().AssumeNotNull(), _documentMappingService, _logger, cancellationToken)
                 .ConfigureAwait(false);
 
             if (range is not null)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/MessagePack/Formatters/TagHelpers/BoundAttributeFormatter.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/MessagePack/Formatters/TagHelpers/BoundAttributeFormatter.cs
@@ -10,6 +10,8 @@ namespace Microsoft.CodeAnalysis.Razor.Serialization.MessagePack.Formatters.TagH
 
 internal sealed class BoundAttributeFormatter : ValueFormatter<BoundAttributeDescriptor>
 {
+    private const int PropertyCount = 14;
+
     public static readonly ValueFormatter<BoundAttributeDescriptor> Instance = new BoundAttributeFormatter();
 
     private BoundAttributeFormatter()
@@ -18,9 +20,8 @@ internal sealed class BoundAttributeFormatter : ValueFormatter<BoundAttributeDes
 
     public override BoundAttributeDescriptor Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
     {
-        reader.ReadArrayHeaderAndVerify(15);
+        reader.ReadArrayHeaderAndVerify(PropertyCount);
 
-        var kind = CachedStringFormatter.Instance.Deserialize(ref reader, options).AssumeNotNull();
         var name = CachedStringFormatter.Instance.Deserialize(ref reader, options);
         var typeName = CachedStringFormatter.Instance.Deserialize(ref reader, options).AssumeNotNull();
         var isEnum = reader.ReadBoolean();
@@ -38,7 +39,7 @@ internal sealed class BoundAttributeFormatter : ValueFormatter<BoundAttributeDes
         var diagnostics = reader.Deserialize<ImmutableArray<RazorDiagnostic>>(options);
 
         return new BoundAttributeDescriptor(
-            kind, name!, typeName, isEnum,
+            name!, typeName, isEnum,
             hasIndexer, indexerNamePrefix, indexerTypeName,
             documentationObject, displayName, containingType, caseSensitive, isEditorRequired,
             parameters, metadata, diagnostics);
@@ -46,9 +47,8 @@ internal sealed class BoundAttributeFormatter : ValueFormatter<BoundAttributeDes
 
     public override void Serialize(ref MessagePackWriter writer, BoundAttributeDescriptor value, SerializerCachingOptions options)
     {
-        writer.WriteArrayHeader(15);
+        writer.WriteArrayHeader(PropertyCount);
 
-        CachedStringFormatter.Instance.Serialize(ref writer, value.Kind, options);
         CachedStringFormatter.Instance.Serialize(ref writer, value.Name, options);
         CachedStringFormatter.Instance.Serialize(ref writer, value.TypeName, options);
         writer.Write(value.IsEnum);
@@ -68,9 +68,8 @@ internal sealed class BoundAttributeFormatter : ValueFormatter<BoundAttributeDes
 
     public override void Skim(ref MessagePackReader reader, SerializerCachingOptions options)
     {
-        reader.ReadArrayHeaderAndVerify(15);
+        reader.ReadArrayHeaderAndVerify(PropertyCount);
 
-        CachedStringFormatter.Instance.Skim(ref reader, options); // Kind;
         CachedStringFormatter.Instance.Skim(ref reader, options); // Name
         CachedStringFormatter.Instance.Skim(ref reader, options); // TypeName
         reader.Skip(); // IsEnum

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/MessagePack/Formatters/TagHelpers/BoundAttributeParameterFormatter.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/MessagePack/Formatters/TagHelpers/BoundAttributeParameterFormatter.cs
@@ -10,6 +10,8 @@ namespace Microsoft.CodeAnalysis.Razor.Serialization.MessagePack.Formatters.TagH
 
 internal sealed class BoundAttributeParameterFormatter : ValueFormatter<BoundAttributeParameterDescriptor>
 {
+    private const int PropertyCount = 8;
+
     public static readonly ValueFormatter<BoundAttributeParameterDescriptor> Instance = new BoundAttributeParameterFormatter();
 
     private BoundAttributeParameterFormatter()
@@ -18,9 +20,8 @@ internal sealed class BoundAttributeParameterFormatter : ValueFormatter<BoundAtt
 
     public override BoundAttributeParameterDescriptor Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
     {
-        reader.ReadArrayHeaderAndVerify(9);
+        reader.ReadArrayHeaderAndVerify(PropertyCount);
 
-        var kind = CachedStringFormatter.Instance.Deserialize(ref reader, options).AssumeNotNull();
         var name = CachedStringFormatter.Instance.Deserialize(ref reader, options);
         var typeName = CachedStringFormatter.Instance.Deserialize(ref reader, options).AssumeNotNull();
         var isEnum = reader.ReadBoolean();
@@ -32,16 +33,15 @@ internal sealed class BoundAttributeParameterFormatter : ValueFormatter<BoundAtt
         var diagnostics = reader.Deserialize<ImmutableArray<RazorDiagnostic>>(options);
 
         return new BoundAttributeParameterDescriptor(
-            kind, name!, typeName,
+            name!, typeName,
             isEnum, documentationObject, displayName, caseSensitive,
             metadata, diagnostics);
     }
 
     public override void Serialize(ref MessagePackWriter writer, BoundAttributeParameterDescriptor value, SerializerCachingOptions options)
     {
-        writer.WriteArrayHeader(9);
+        writer.WriteArrayHeader(PropertyCount);
 
-        CachedStringFormatter.Instance.Serialize(ref writer, value.Kind, options);
         CachedStringFormatter.Instance.Serialize(ref writer, value.Name, options);
         CachedStringFormatter.Instance.Serialize(ref writer, value.TypeName, options);
         writer.Write(value.IsEnum);
@@ -55,9 +55,8 @@ internal sealed class BoundAttributeParameterFormatter : ValueFormatter<BoundAtt
 
     public override void Skim(ref MessagePackReader reader, SerializerCachingOptions options)
     {
-        reader.ReadArrayHeaderAndVerify(9);
+        reader.ReadArrayHeaderAndVerify(PropertyCount);
 
-        CachedStringFormatter.Instance.Skim(ref reader, options); // Kind
         CachedStringFormatter.Instance.Skim(ref reader, options); // Name
         CachedStringFormatter.Instance.Skim(ref reader, options); // TypeName
         reader.Skip(); // IsEnum

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/MessagePack/SerializationFormat.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/MessagePack/SerializationFormat.cs
@@ -9,5 +9,5 @@ internal static class SerializationFormat
     // or any of the types that compose it changes. This includes: RazorConfiguration,
     // ProjectWorkspaceState, TagHelperDescriptor, and DocumentSnapshotHandle.
     // NOTE: If this version is changed, a coordinated insertion is required between Roslyn and Razor for the C# extension.
-    public const int Version = 8;
+    public const int Version = 9;
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Tooltip/BoundAttributeDescriptionInfo.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Tooltip/BoundAttributeDescriptionInfo.cs
@@ -21,7 +21,7 @@ internal record BoundAttributeDescriptionInfo(string ReturnTypeName, string Type
             throw new ArgumentNullException(nameof(parentTagHelperTypeName));
         }
 
-        var propertyName = parameterAttribute.GetPropertyName();
+        var propertyName = parameterAttribute.GetPropertyName().AssumeNotNull();
 
         return new BoundAttributeDescriptionInfo(
             parameterAttribute.TypeName,
@@ -41,7 +41,7 @@ internal record BoundAttributeDescriptionInfo(string ReturnTypeName, string Type
         }
 
         var returnTypeName = isIndexer ? boundAttribute.IndexerTypeName.AssumeNotNull() : boundAttribute.TypeName;
-        var propertyName = boundAttribute.GetPropertyName();
+        var propertyName = boundAttribute.GetPropertyName().AssumeNotNull();
 
         // The BoundAttributeDescriptor does not directly have the TagHelperTypeName information available.
         // Because of this we need to resolve it from other parts of it.

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders_TagHelpers.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders_TagHelpers.cs
@@ -153,7 +153,6 @@ internal static partial class ObjectReaders
 
             static BoundAttributeDescriptor ReadFromProperties(JsonDataReader reader)
             {
-                var kind = reader.ReadNonNullString(nameof(BoundAttributeDescriptor.Kind));
                 var name = reader.ReadString(nameof(BoundAttributeDescriptor.Name));
                 var typeName = reader.ReadNonNullString(nameof(BoundAttributeDescriptor.TypeName));
                 var isEnum = reader.ReadBooleanOrFalse(nameof(BoundAttributeDescriptor.IsEnum));
@@ -171,7 +170,7 @@ internal static partial class ObjectReaders
                 var diagnostics = reader.ReadImmutableArrayOrEmpty(nameof(BoundAttributeDescriptor.Diagnostics), ReadDiagnostic);
 
                 return new BoundAttributeDescriptor(
-                    Cached(kind), Cached(name)!, Cached(typeName), isEnum,
+                    Cached(name)!, Cached(typeName), isEnum,
                     hasIndexer, Cached(indexerNamePrefix), Cached(indexerTypeName),
                     documentationObject, Cached(displayName), Cached(containingType),
                     caseSensitive, isEditorRequired, parameters, metadata, diagnostics);

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders_TagHelpers.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders_TagHelpers.cs
@@ -184,7 +184,6 @@ internal static partial class ObjectReaders
 
             static BoundAttributeParameterDescriptor ReadFromProperties(JsonDataReader reader)
             {
-                var kind = reader.ReadNonNullString(nameof(BoundAttributeParameterDescriptor.Kind));
                 var name = reader.ReadString(nameof(BoundAttributeParameterDescriptor.Name));
                 var typeName = reader.ReadNonNullString(nameof(BoundAttributeParameterDescriptor.TypeName));
                 var isEnum = reader.ReadBooleanOrFalse(nameof(BoundAttributeParameterDescriptor.IsEnum));
@@ -196,7 +195,7 @@ internal static partial class ObjectReaders
                 var diagnostics = reader.ReadImmutableArrayOrEmpty(nameof(BoundAttributeParameterDescriptor.Diagnostics), ReadDiagnostic);
 
                 return new BoundAttributeParameterDescriptor(
-                    Cached(kind), Cached(name)!, Cached(typeName),
+                    Cached(name)!, Cached(typeName),
                     isEnum, documentationObject, Cached(displayName), caseSensitive,
                     metadata, diagnostics);
             }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters_TagHelpers.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters_TagHelpers.cs
@@ -93,7 +93,6 @@ internal static partial class ObjectWriters
         {
             writer.WriteObject(value, static (writer, value) =>
             {
-                writer.Write(nameof(value.Kind), value.Kind);
                 writer.Write(nameof(value.Name), value.Name);
                 writer.Write(nameof(value.TypeName), value.TypeName);
                 writer.WriteIfNotFalse(nameof(value.IsEnum), value.IsEnum);

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters_TagHelpers.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters_TagHelpers.cs
@@ -116,7 +116,6 @@ internal static partial class ObjectWriters
         {
             writer.WriteObject(value, static (writer, value) =>
             {
-                writer.Write(nameof(value.Kind), value.Kind);
                 writer.Write(nameof(value.Name), value.Name);
                 writer.Write(nameof(value.TypeName), value.TypeName);
                 writer.WriteIfNotFalse(nameof(value.IsEnum), value.IsEnum);

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/SerializationFormat.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/SerializationFormat.cs
@@ -9,5 +9,5 @@ internal static class SerializationFormat
     // or any of the types that compose it changes. This includes: RazorConfiguration,
     // ProjectWorkspaceState, TagHelperDescriptor, and DocumentSnapshotHandle.
     // NOTE: If this version is changed, a coordinated insertion is required between Roslyn and Razor for the C# extension.
-    public const int Version = 8;
+    public const int Version = 9;
 }

--- a/src/Shared/files/Compiler/taghelpers.json
+++ b/src/Shared/files/Compiler/taghelpers.json
@@ -181,10 +181,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5103726768287572875,
-      "Data2": 1228535271519439087,
-      "Data3": 3934523134984455119,
-      "Data4": -1138084443009337381
+      "Data1": -6285493797925254456,
+      "Data2": 5230266000370398179,
+      "Data3": 5282994923398116851,
+      "Data4": -7413786900130505343
     },
     "Kind": "Components.Component",
     "Name": "BlazorServer_31.Pages.Counter",
@@ -198,7 +198,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "FooVal",
         "TypeName": "System.Int32",
         "DisplayName": "int BlazorServer_31.Pages.Counter.FooVal",
@@ -207,7 +206,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Additional",
         "TypeName": "System.String",
         "DisplayName": "string BlazorServer_31.Pages.Counter.Additional",
@@ -216,7 +214,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "IncrementAmount",
         "TypeName": "System.Int32",
         "DisplayName": "int BlazorServer_31.Pages.Counter.IncrementAmount",
@@ -225,7 +222,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "MoreParams",
         "TypeName": "System.String",
         "DisplayName": "string BlazorServer_31.Pages.Counter.MoreParams",
@@ -241,10 +237,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 411475141902004935,
-      "Data2": 2832659190071318607,
-      "Data3": -8327767840022097740,
-      "Data4": -7311090378404797050
+      "Data1": -727774359383500369,
+      "Data2": 4100276776481800201,
+      "Data3": 437129531019142510,
+      "Data4": -5567453706843277089
     },
     "Kind": "Components.Component",
     "Name": "BlazorServer_31.Pages.Counter",
@@ -258,7 +254,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "FooVal",
         "TypeName": "System.Int32",
         "DisplayName": "int BlazorServer_31.Pages.Counter.FooVal",
@@ -267,7 +262,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Additional",
         "TypeName": "System.String",
         "DisplayName": "string BlazorServer_31.Pages.Counter.Additional",
@@ -276,7 +270,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "IncrementAmount",
         "TypeName": "System.Int32",
         "DisplayName": "int BlazorServer_31.Pages.Counter.IncrementAmount",
@@ -285,7 +278,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "MoreParams",
         "TypeName": "System.String",
         "DisplayName": "string BlazorServer_31.Pages.Counter.MoreParams",
@@ -437,10 +429,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3134080747629400708,
-      "Data2": -2841767300665240693,
-      "Data3": 3724282288752257774,
-      "Data4": 8545771908653691646
+      "Data1": 1525255544119811340,
+      "Data2": -4274531328727438325,
+      "Data3": -3577346935764423882,
+      "Data4": 3205003264317334181
     },
     "Kind": "Components.Component",
     "Name": "BlazorServer_31.Shared.MainLayout",
@@ -454,7 +446,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "Body",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment BlazorServer_31.Shared.MainLayout.Body",
@@ -472,10 +463,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 871733199913992329,
-      "Data2": -2420012031802068572,
-      "Data3": 3324635674429517507,
-      "Data4": -7788341820565075386
+      "Data1": -7659439374005865577,
+      "Data2": -3629106267293765934,
+      "Data3": -468250957127634144,
+      "Data4": 1478392243091004039
     },
     "Kind": "Components.Component",
     "Name": "BlazorServer_31.Shared.MainLayout",
@@ -489,7 +480,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "Body",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment BlazorServer_31.Shared.MainLayout.Body",
@@ -604,10 +594,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6617923719183829172,
-      "Data2": -3045124586689468326,
-      "Data3": 943409932018348320,
-      "Data4": 58392069699541603
+      "Data1": -6424674139523777741,
+      "Data2": 9087402222531581060,
+      "Data3": -1662888988193941955,
+      "Data4": 8468732869080090383
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.CascadingValue<TValue>",
@@ -622,7 +612,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TValue",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.CascadingValue<TValue>.TValue",
@@ -633,7 +622,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.CascadingValue<TValue>.ChildContent",
@@ -644,7 +632,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "IsFixed",
         "TypeName": "System.Boolean",
         "DisplayName": "bool Microsoft.AspNetCore.Components.CascadingValue<TValue>.IsFixed",
@@ -654,7 +641,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Name",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.CascadingValue<TValue>.Name",
@@ -664,7 +650,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "TValue",
         "DisplayName": "TValue Microsoft.AspNetCore.Components.CascadingValue<TValue>.Value",
@@ -683,10 +668,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2915383535887583506,
-      "Data2": 8947283128665344852,
-      "Data3": 5128216950952204205,
-      "Data4": 2476092302053695561
+      "Data1": -5961531942441589510,
+      "Data2": 5694225817492481095,
+      "Data3": 7673717850709483353,
+      "Data4": 8713325410871263232
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.CascadingValue<TValue>",
@@ -701,7 +686,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TValue",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.CascadingValue<TValue>.TValue",
@@ -712,7 +696,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.CascadingValue<TValue>.ChildContent",
@@ -723,7 +706,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "IsFixed",
         "TypeName": "System.Boolean",
         "DisplayName": "bool Microsoft.AspNetCore.Components.CascadingValue<TValue>.IsFixed",
@@ -733,7 +715,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Name",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.CascadingValue<TValue>.Name",
@@ -743,7 +724,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "TValue",
         "DisplayName": "TValue Microsoft.AspNetCore.Components.CascadingValue<TValue>.Value",
@@ -814,10 +794,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5377794705521642714,
-      "Data2": -7530199918571100162,
-      "Data3": 8583934446492963914,
-      "Data4": -2330949212290254340
+      "Data1": -8036079051599141261,
+      "Data2": 1380734537475420395,
+      "Data3": -4241593715894261034,
+      "Data4": 8736036591901201423
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.LayoutView",
@@ -832,7 +812,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.LayoutView.ChildContent",
@@ -843,7 +822,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Layout",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.LayoutView.Layout",
@@ -860,10 +838,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7291702709707787857,
-      "Data2": -4929818534113612134,
-      "Data3": -2591316850085605568,
-      "Data4": 3576407285049227960
+      "Data1": 4788454860963157552,
+      "Data2": -8919473922564372106,
+      "Data3": -1875239135074169066,
+      "Data4": 6970383222800094264
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.LayoutView",
@@ -878,7 +856,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.LayoutView.ChildContent",
@@ -889,7 +866,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Layout",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.LayoutView.Layout",
@@ -958,10 +934,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6217043889972804850,
-      "Data2": 4448752453671390215,
-      "Data3": -339628318859042442,
-      "Data4": -6117267340495694369
+      "Data1": 3352085566365714673,
+      "Data2": 5531507935179871547,
+      "Data3": -2202201493216844603,
+      "Data4": 5283040533389454113
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.RouteView",
@@ -976,7 +952,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "DefaultLayout",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.RouteView.DefaultLayout",
@@ -986,7 +961,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "RouteData",
         "TypeName": "Microsoft.AspNetCore.Components.RouteData",
         "DisplayName": "Microsoft.AspNetCore.Components.RouteData Microsoft.AspNetCore.Components.RouteView.RouteData",
@@ -1003,10 +977,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1645862209197178803,
-      "Data2": 8454815716882071758,
-      "Data3": -1595347272049710063,
-      "Data4": 2149068933797090014
+      "Data1": 3367395607974941374,
+      "Data2": -7407874676930401941,
+      "Data3": -1190023704270334827,
+      "Data4": -198530619561287352
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.RouteView",
@@ -1021,7 +995,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "DefaultLayout",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.RouteView.DefaultLayout",
@@ -1031,7 +1004,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "RouteData",
         "TypeName": "Microsoft.AspNetCore.Components.RouteData",
         "DisplayName": "Microsoft.AspNetCore.Components.RouteData Microsoft.AspNetCore.Components.RouteView.RouteData",
@@ -1049,10 +1021,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5338573273925669546,
-      "Data2": -5988416504756993895,
-      "Data3": -6577637726014275600,
-      "Data4": 5092339929206363959
+      "Data1": 3187449640968610167,
+      "Data2": 1113465327873938952,
+      "Data3": 6508456116516809307,
+      "Data4": 3207300116954634053
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Routing.Router",
@@ -1067,7 +1039,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAssemblies",
         "TypeName": "System.Collections.Generic.IEnumerable<System.Reflection.Assembly>",
         "DisplayName": "System.Collections.Generic.IEnumerable<System.Reflection.Assembly> Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblies",
@@ -1077,7 +1048,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AppAssembly",
         "TypeName": "System.Reflection.Assembly",
         "DisplayName": "System.Reflection.Assembly Microsoft.AspNetCore.Components.Routing.Router.AppAssembly",
@@ -1087,7 +1057,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Found",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.RouteData>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.RouteData> Microsoft.AspNetCore.Components.Routing.Router.Found",
@@ -1098,7 +1067,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "NotFound",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Routing.Router.NotFound",
@@ -1109,7 +1077,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Routing.Router.Context",
@@ -1127,10 +1094,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7515690267491972408,
-      "Data2": 8257627338306844447,
-      "Data3": 3442098358483975761,
-      "Data4": -2114290449000920339
+      "Data1": 4202352270562879913,
+      "Data2": 6505063418022422260,
+      "Data3": 3412600805250042747,
+      "Data4": 280560207558702199
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Routing.Router",
@@ -1145,7 +1112,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAssemblies",
         "TypeName": "System.Collections.Generic.IEnumerable<System.Reflection.Assembly>",
         "DisplayName": "System.Collections.Generic.IEnumerable<System.Reflection.Assembly> Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblies",
@@ -1155,7 +1121,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AppAssembly",
         "TypeName": "System.Reflection.Assembly",
         "DisplayName": "System.Reflection.Assembly Microsoft.AspNetCore.Components.Routing.Router.AppAssembly",
@@ -1165,7 +1130,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Found",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.RouteData>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.RouteData> Microsoft.AspNetCore.Components.Routing.Router.Found",
@@ -1176,7 +1140,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "NotFound",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Routing.Router.NotFound",
@@ -1187,7 +1150,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Routing.Router.Context",
@@ -1206,10 +1168,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6909475981366095087,
-      "Data2": -4131234571750972994,
-      "Data3": 8034817602415319459,
-      "Data4": 7375926634704443619
+      "Data1": -7809441188752400554,
+      "Data2": 241390636167674302,
+      "Data3": 549637519559342519,
+      "Data4": 1133441921036865863
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Routing.Router.Found",
@@ -1225,7 +1187,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Routing.Router.Found.Context",
@@ -1244,10 +1205,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2510713198858240400,
-      "Data2": 590200399062707798,
-      "Data3": 1599260516379024026,
-      "Data4": 6084009184278120022
+      "Data1": 9057471876373089647,
+      "Data2": -5602381831686400327,
+      "Data3": -5871141794450749010,
+      "Data4": -8233482659204213707
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Routing.Router.Found",
@@ -1263,7 +1224,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Routing.Router.Found.Context",
@@ -1381,10 +1341,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7592717434163593429,
-      "Data2": -1237590022871735187,
-      "Data3": 5648465350867348461,
-      "Data4": -6647408636713403774
+      "Data1": 383664143859662792,
+      "Data2": -3816497563300584175,
+      "Data3": 4141129611281033330,
+      "Data4": -3000855565080243070
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView",
@@ -1399,7 +1359,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "Authorizing",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.Authorizing",
@@ -1410,7 +1369,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "NotAuthorized",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState> Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.NotAuthorized",
@@ -1421,7 +1379,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "DefaultLayout",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.DefaultLayout",
@@ -1431,7 +1388,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "RouteData",
         "TypeName": "Microsoft.AspNetCore.Components.RouteData",
         "DisplayName": "Microsoft.AspNetCore.Components.RouteData Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.RouteData",
@@ -1441,7 +1397,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.Context",
@@ -1459,10 +1414,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1320254144997535576,
-      "Data2": 982571158012365790,
-      "Data3": -4349216451122297866,
-      "Data4": 4705439332341330613
+      "Data1": 4189096544155452148,
+      "Data2": 4409966182714980974,
+      "Data3": -6734569639620756862,
+      "Data4": 2074314151441422050
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView",
@@ -1477,7 +1432,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "Authorizing",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.Authorizing",
@@ -1488,7 +1442,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "NotAuthorized",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState> Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.NotAuthorized",
@@ -1499,7 +1452,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "DefaultLayout",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.DefaultLayout",
@@ -1509,7 +1461,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "RouteData",
         "TypeName": "Microsoft.AspNetCore.Components.RouteData",
         "DisplayName": "Microsoft.AspNetCore.Components.RouteData Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.RouteData",
@@ -1519,7 +1470,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.Context",
@@ -1589,10 +1539,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1754168664387951795,
-      "Data2": -3901096326046849761,
-      "Data3": 4509587919239536281,
-      "Data4": 6230482013594168417
+      "Data1": -81553618708279689,
+      "Data2": 5983692424647816550,
+      "Data3": -164441884661649168,
+      "Data4": 3970561830889228813
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.NotAuthorized",
@@ -1608,7 +1558,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.NotAuthorized.Context",
@@ -1627,10 +1576,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8763591535025361746,
-      "Data2": -9014189178895859833,
-      "Data3": -1288109135055401780,
-      "Data4": -3686471607644086875
+      "Data1": -4483959950316607233,
+      "Data2": 1680054156622769528,
+      "Data3": 5398128243875483992,
+      "Data4": -8117045675322111607
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.NotAuthorized",
@@ -1646,7 +1595,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.NotAuthorized.Context",
@@ -1666,10 +1614,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6535241596961352213,
-      "Data2": 5062123460007964486,
-      "Data3": -3881174111664447886,
-      "Data4": 1364378170248574867
+      "Data1": 2603808409714325246,
+      "Data2": 7988789779723720837,
+      "Data3": 4665369801574180611,
+      "Data4": -7020782095121867657
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeView",
@@ -1684,7 +1632,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "Policy",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Policy",
@@ -1694,7 +1641,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Roles",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Roles",
@@ -1704,7 +1650,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Authorized",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState> Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Authorized",
@@ -1715,7 +1660,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Authorizing",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Authorizing",
@@ -1726,7 +1670,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState> Microsoft.AspNetCore.Components.Authorization.AuthorizeView.ChildContent",
@@ -1737,7 +1680,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "NotAuthorized",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState> Microsoft.AspNetCore.Components.Authorization.AuthorizeView.NotAuthorized",
@@ -1748,7 +1690,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Resource",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Resource",
@@ -1758,7 +1699,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Context",
@@ -1776,10 +1716,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6169174336899041629,
-      "Data2": 5985529975052009456,
-      "Data3": -2742191437337334034,
-      "Data4": -4106127369862035769
+      "Data1": 267490053794775099,
+      "Data2": -1102090804338281076,
+      "Data3": -6482216651649297107,
+      "Data4": -6888309229980989177
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeView",
@@ -1794,7 +1734,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "Policy",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Policy",
@@ -1804,7 +1743,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Roles",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Roles",
@@ -1814,7 +1752,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Authorized",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState> Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Authorized",
@@ -1825,7 +1762,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Authorizing",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Authorizing",
@@ -1836,7 +1772,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState> Microsoft.AspNetCore.Components.Authorization.AuthorizeView.ChildContent",
@@ -1847,7 +1782,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "NotAuthorized",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState> Microsoft.AspNetCore.Components.Authorization.AuthorizeView.NotAuthorized",
@@ -1858,7 +1792,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Resource",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Resource",
@@ -1868,7 +1801,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Context",
@@ -1887,10 +1819,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7892245051096864750,
-      "Data2": -3151314404567288320,
-      "Data3": 7297228747282515303,
-      "Data4": -8816141115776911856
+      "Data1": 9051540928033437916,
+      "Data2": -4561944278361591759,
+      "Data3": -106982516652773991,
+      "Data4": -4336746823411513298
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Authorized",
@@ -1906,7 +1838,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Authorized.Context",
@@ -1925,10 +1856,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3075987439435239968,
-      "Data2": -69498062391188391,
-      "Data3": 5694013078454618235,
-      "Data4": -4964072175875648533
+      "Data1": -4509913698818065653,
+      "Data2": 3108494484668612480,
+      "Data3": 1956064421625746422,
+      "Data4": -5495091853800544263
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Authorized",
@@ -1944,7 +1875,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Authorized.Context",
@@ -2015,10 +1945,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 817805184534699571,
-      "Data2": -8189090942277436413,
-      "Data3": 6742339712997173331,
-      "Data4": 4765026566583164317
+      "Data1": -3222677893645941312,
+      "Data2": -2804772935296380011,
+      "Data3": 1045678252242401014,
+      "Data4": 3738891879585344031
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeView.ChildContent",
@@ -2034,7 +1964,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.ChildContent.Context",
@@ -2053,10 +1982,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4877944373808367001,
-      "Data2": 4506636171407630375,
-      "Data3": -1117268174291948265,
-      "Data4": -1322997367792857794
+      "Data1": 1989368445337416590,
+      "Data2": 6343148457145989463,
+      "Data3": 8518577890820144250,
+      "Data4": 4332923166750176624
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeView.ChildContent",
@@ -2072,7 +2001,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.ChildContent.Context",
@@ -2092,10 +2020,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7459421656754599778,
-      "Data2": 2652353820823210771,
-      "Data3": -3771739282023179678,
-      "Data4": 1539262260759644732
+      "Data1": 3161014210779999006,
+      "Data2": -2038458453097911949,
+      "Data3": 6547917612853868829,
+      "Data4": 5123234057769969420
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeView.NotAuthorized",
@@ -2111,7 +2039,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.NotAuthorized.Context",
@@ -2130,10 +2057,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -261465234443533156,
-      "Data2": -88179546101946229,
-      "Data3": 5706345454304336182,
-      "Data4": 2096749024609475558
+      "Data1": -305969839403588114,
+      "Data2": 3835628260288068723,
+      "Data3": 774589694985915623,
+      "Data4": 3486940796800817603
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeView.NotAuthorized",
@@ -2149,7 +2076,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.NotAuthorized.Context",
@@ -2169,10 +2095,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -863543916801400095,
-      "Data2": 8615298768519496802,
-      "Data3": 8607016578708498599,
-      "Data4": 2012295119091407992
+      "Data1": 7908584691536753002,
+      "Data2": -2279190400367037145,
+      "Data3": -6196962611230956512,
+      "Data4": 8256454089716564655
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Authorization.CascadingAuthenticationState",
@@ -2186,7 +2112,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Authorization.CascadingAuthenticationState.ChildContent",
@@ -2204,10 +2129,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3901280328545925953,
-      "Data2": 4709502549668387011,
-      "Data3": 1651675939900428970,
-      "Data4": -3217124211645843393
+      "Data1": 8212564033814540422,
+      "Data2": -3319785948415645279,
+      "Data3": -6194221474971536032,
+      "Data4": -8412901782968697597
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Authorization.CascadingAuthenticationState",
@@ -2221,7 +2146,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Authorization.CascadingAuthenticationState.ChildContent",
@@ -2291,10 +2215,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -9147175252959861503,
-      "Data2": -9041159965426804184,
-      "Data3": -5062436237316079081,
-      "Data4": 3095895595672030529
+      "Data1": 8092325359880587115,
+      "Data2": -7634704910005623456,
+      "Data3": 8271629437491950030,
+      "Data4": 618835727468252203
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.EditForm",
@@ -2309,7 +2233,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object> Microsoft.AspNetCore.Components.Forms.EditForm.AdditionalAttributes",
@@ -2319,7 +2242,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Forms.EditContext>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Forms.EditContext> Microsoft.AspNetCore.Components.Forms.EditForm.ChildContent",
@@ -2330,7 +2252,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "EditContext",
         "TypeName": "Microsoft.AspNetCore.Components.Forms.EditContext",
         "DisplayName": "Microsoft.AspNetCore.Components.Forms.EditContext Microsoft.AspNetCore.Components.Forms.EditForm.EditContext",
@@ -2340,7 +2261,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Model",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Forms.EditForm.Model",
@@ -2350,7 +2270,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "OnInvalidSubmit",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext> Microsoft.AspNetCore.Components.Forms.EditForm.OnInvalidSubmit",
@@ -2361,7 +2280,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "OnSubmit",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext> Microsoft.AspNetCore.Components.Forms.EditForm.OnSubmit",
@@ -2372,7 +2290,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "OnValidSubmit",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext> Microsoft.AspNetCore.Components.Forms.EditForm.OnValidSubmit",
@@ -2383,7 +2300,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.EditForm.Context",
@@ -2401,10 +2317,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 9087857042127226684,
-      "Data2": 2831567244589303482,
-      "Data3": -7243507314367014217,
-      "Data4": 9152807272014312665
+      "Data1": 8558291180034136600,
+      "Data2": -2046829648109259570,
+      "Data3": 8467746721847731417,
+      "Data4": 1201176721737430987
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.EditForm",
@@ -2419,7 +2335,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object> Microsoft.AspNetCore.Components.Forms.EditForm.AdditionalAttributes",
@@ -2429,7 +2344,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Forms.EditContext>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Forms.EditContext> Microsoft.AspNetCore.Components.Forms.EditForm.ChildContent",
@@ -2440,7 +2354,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "EditContext",
         "TypeName": "Microsoft.AspNetCore.Components.Forms.EditContext",
         "DisplayName": "Microsoft.AspNetCore.Components.Forms.EditContext Microsoft.AspNetCore.Components.Forms.EditForm.EditContext",
@@ -2450,7 +2363,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Model",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Forms.EditForm.Model",
@@ -2460,7 +2372,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "OnInvalidSubmit",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext> Microsoft.AspNetCore.Components.Forms.EditForm.OnInvalidSubmit",
@@ -2471,7 +2382,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "OnSubmit",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext> Microsoft.AspNetCore.Components.Forms.EditForm.OnSubmit",
@@ -2482,7 +2392,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "OnValidSubmit",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext> Microsoft.AspNetCore.Components.Forms.EditForm.OnValidSubmit",
@@ -2493,7 +2402,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.EditForm.Context",
@@ -2512,10 +2420,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4390305146195636884,
-      "Data2": -6528711746510981033,
-      "Data3": 1566379681180222045,
-      "Data4": 8038373845032057845
+      "Data1": 7112546644852289368,
+      "Data2": 1824489335670129097,
+      "Data3": -5311357937356600204,
+      "Data4": 4198436961710571214
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Forms.EditForm.ChildContent",
@@ -2531,7 +2439,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.EditForm.ChildContent.Context",
@@ -2550,10 +2457,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3364489552607396692,
-      "Data2": 6756888759249473444,
-      "Data3": -8692504653364370078,
-      "Data4": -5456380025076217211
+      "Data1": 5076108600303419702,
+      "Data2": 8720032802453869806,
+      "Data3": -7457944825556420394,
+      "Data4": 3355499876685492714
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Forms.EditForm.ChildContent",
@@ -2569,7 +2476,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.EditForm.ChildContent.Context",
@@ -2589,10 +2495,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7605674613043601699,
-      "Data2": -7198784793237451227,
-      "Data3": 52139714512194300,
-      "Data4": 4690968937784293901
+      "Data1": 2335660786758866335,
+      "Data2": 8266357583289166516,
+      "Data3": -5621101939758034507,
+      "Data4": 3765593744438105595
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputCheckbox",
@@ -2607,7 +2513,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object> Microsoft.AspNetCore.Components.Forms.InputCheckbox.AdditionalAttributes",
@@ -2617,7 +2522,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "System.Boolean",
         "DisplayName": "bool Microsoft.AspNetCore.Components.Forms.InputCheckbox.Value",
@@ -2627,7 +2531,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.Boolean>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.Boolean> Microsoft.AspNetCore.Components.Forms.InputCheckbox.ValueChanged",
@@ -2638,7 +2541,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<System.Boolean>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<System.Boolean>> Microsoft.AspNetCore.Components.Forms.InputCheckbox.ValueExpression",
@@ -2655,10 +2557,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8180363982902160014,
-      "Data2": 2678498882862487355,
-      "Data3": -8486455943660870138,
-      "Data4": -4800420563276733548
+      "Data1": 1407346463502316688,
+      "Data2": 6818374773701062142,
+      "Data3": -6388646280177114004,
+      "Data4": -7323715624043314059
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputCheckbox",
@@ -2673,7 +2575,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object> Microsoft.AspNetCore.Components.Forms.InputCheckbox.AdditionalAttributes",
@@ -2683,7 +2584,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "System.Boolean",
         "DisplayName": "bool Microsoft.AspNetCore.Components.Forms.InputCheckbox.Value",
@@ -2693,7 +2593,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.Boolean>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.Boolean> Microsoft.AspNetCore.Components.Forms.InputCheckbox.ValueChanged",
@@ -2704,7 +2603,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<System.Boolean>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<System.Boolean>> Microsoft.AspNetCore.Components.Forms.InputCheckbox.ValueExpression",
@@ -2722,10 +2620,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8297139150566641522,
-      "Data2": 5983969040662176316,
-      "Data3": -3217603456170181487,
-      "Data4": 4160526703050720265
+      "Data1": -5511028356310153365,
+      "Data2": -274404497412260976,
+      "Data3": 7917679103265650368,
+      "Data4": -8954458970430417684
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputDate<TValue>",
@@ -2740,7 +2638,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TValue",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.TValue",
@@ -2751,7 +2648,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ParsingErrorMessage",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.ParsingErrorMessage",
@@ -2761,7 +2657,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object> Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.AdditionalAttributes",
@@ -2771,7 +2666,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "TValue",
         "DisplayName": "TValue Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.Value",
@@ -2782,7 +2676,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.ValueChanged",
@@ -2794,7 +2687,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.ValueExpression",
@@ -2813,10 +2705,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6400082238264250421,
-      "Data2": 782232194501302904,
-      "Data3": 7033830231827257302,
-      "Data4": 6544353769852657552
+      "Data1": 5538367537707870523,
+      "Data2": 7027669079089590007,
+      "Data3": -5336388236475938024,
+      "Data4": -5036334443410120834
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputDate<TValue>",
@@ -2831,7 +2723,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TValue",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.TValue",
@@ -2842,7 +2733,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ParsingErrorMessage",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.ParsingErrorMessage",
@@ -2852,7 +2742,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object> Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.AdditionalAttributes",
@@ -2862,7 +2751,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "TValue",
         "DisplayName": "TValue Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.Value",
@@ -2873,7 +2761,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.ValueChanged",
@@ -2885,7 +2772,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.ValueExpression",
@@ -2905,10 +2791,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 109851219133615220,
-      "Data2": 5290536766698745054,
-      "Data3": 8925742810957175752,
-      "Data4": 8728469837436627882
+      "Data1": 3816462919513650228,
+      "Data2": 5686446606139804945,
+      "Data3": -7251539150568141951,
+      "Data4": 7625606997428509098
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>",
@@ -2923,7 +2809,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TValue",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.TValue",
@@ -2934,7 +2819,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ParsingErrorMessage",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.ParsingErrorMessage",
@@ -2944,7 +2828,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object> Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.AdditionalAttributes",
@@ -2954,7 +2837,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "TValue",
         "DisplayName": "TValue Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.Value",
@@ -2965,7 +2847,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.ValueChanged",
@@ -2977,7 +2858,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.ValueExpression",
@@ -2996,10 +2876,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8518700168161382355,
-      "Data2": -4314969032990032012,
-      "Data3": 8265788334793347431,
-      "Data4": 9220930051166399352
+      "Data1": 7764794534729894221,
+      "Data2": 528453651816711974,
+      "Data3": 8338016567698206164,
+      "Data4": -242139818257503769
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>",
@@ -3014,7 +2894,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TValue",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.TValue",
@@ -3025,7 +2904,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ParsingErrorMessage",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.ParsingErrorMessage",
@@ -3035,7 +2913,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object> Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.AdditionalAttributes",
@@ -3045,7 +2922,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "TValue",
         "DisplayName": "TValue Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.Value",
@@ -3056,7 +2932,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.ValueChanged",
@@ -3068,7 +2943,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.ValueExpression",
@@ -3088,10 +2962,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2382873856095312854,
-      "Data2": 1853008898282121152,
-      "Data3": 2643377737850329532,
-      "Data4": 5100368420377431267
+      "Data1": 3219136445039322255,
+      "Data2": 144629572895404944,
+      "Data3": 4848934041181370519,
+      "Data4": -1876214345596587032
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>",
@@ -3106,7 +2980,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TValue",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.TValue",
@@ -3117,7 +2990,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.ChildContent",
@@ -3128,7 +3000,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object> Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.AdditionalAttributes",
@@ -3138,7 +3009,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "TValue",
         "DisplayName": "TValue Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.Value",
@@ -3149,7 +3019,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.ValueChanged",
@@ -3161,7 +3030,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.ValueExpression",
@@ -3180,10 +3048,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1817379208066635798,
-      "Data2": 2075989457255427347,
-      "Data3": -1266016033873955060,
-      "Data4": -8696662160425996977
+      "Data1": 1233820762599944113,
+      "Data2": -2736785469091721913,
+      "Data3": -6818179859881364085,
+      "Data4": 5327331065499352246
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>",
@@ -3198,7 +3066,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TValue",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.TValue",
@@ -3209,7 +3076,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.ChildContent",
@@ -3220,7 +3086,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object> Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.AdditionalAttributes",
@@ -3230,7 +3095,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "TValue",
         "DisplayName": "TValue Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.Value",
@@ -3241,7 +3105,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.ValueChanged",
@@ -3253,7 +3116,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.ValueExpression",
@@ -3324,10 +3186,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3916321850198626368,
-      "Data2": -8778806347095449895,
-      "Data3": 8685718172595492964,
-      "Data4": -4514587133887660479
+      "Data1": 9032544301023068216,
+      "Data2": -7760262543807735458,
+      "Data3": 6075037851905404255,
+      "Data4": -1204782234086299715
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputText",
@@ -3342,7 +3204,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object> Microsoft.AspNetCore.Components.Forms.InputText.AdditionalAttributes",
@@ -3352,7 +3213,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputText.Value",
@@ -3362,7 +3222,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.String>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.String> Microsoft.AspNetCore.Components.Forms.InputText.ValueChanged",
@@ -3373,7 +3232,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<System.String>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<System.String>> Microsoft.AspNetCore.Components.Forms.InputText.ValueExpression",
@@ -3390,10 +3248,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -711194281107868378,
-      "Data2": 8319811869247148923,
-      "Data3": 4983778364208632722,
-      "Data4": -7879123195054200030
+      "Data1": -6250776878488694728,
+      "Data2": -8564165059677791946,
+      "Data3": 1933146703094381337,
+      "Data4": -2021510093122288667
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputText",
@@ -3408,7 +3266,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object> Microsoft.AspNetCore.Components.Forms.InputText.AdditionalAttributes",
@@ -3418,7 +3275,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputText.Value",
@@ -3428,7 +3284,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.String>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.String> Microsoft.AspNetCore.Components.Forms.InputText.ValueChanged",
@@ -3439,7 +3294,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<System.String>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<System.String>> Microsoft.AspNetCore.Components.Forms.InputText.ValueExpression",
@@ -3457,10 +3311,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2340289955582300439,
-      "Data2": 8684985959372100313,
-      "Data3": 6496594173857069059,
-      "Data4": 7669507987714355223
+      "Data1": 3772839331453584639,
+      "Data2": -4838985988303287704,
+      "Data3": 3684674040352973877,
+      "Data4": -7972180753009459428
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputTextArea",
@@ -3475,7 +3329,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object> Microsoft.AspNetCore.Components.Forms.InputTextArea.AdditionalAttributes",
@@ -3485,7 +3338,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputTextArea.Value",
@@ -3495,7 +3347,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.String>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.String> Microsoft.AspNetCore.Components.Forms.InputTextArea.ValueChanged",
@@ -3506,7 +3357,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<System.String>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<System.String>> Microsoft.AspNetCore.Components.Forms.InputTextArea.ValueExpression",
@@ -3523,10 +3373,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4502064740360434248,
-      "Data2": -6062045387698948010,
-      "Data3": 3452600347179235109,
-      "Data4": -6185570771687542139
+      "Data1": -7133876180665901392,
+      "Data2": 867725535421524795,
+      "Data3": 9055298258548306484,
+      "Data4": -8169908624295096230
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputTextArea",
@@ -3541,7 +3391,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object> Microsoft.AspNetCore.Components.Forms.InputTextArea.AdditionalAttributes",
@@ -3551,7 +3400,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputTextArea.Value",
@@ -3561,7 +3409,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.String>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.String> Microsoft.AspNetCore.Components.Forms.InputTextArea.ValueChanged",
@@ -3572,7 +3419,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<System.String>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<System.String>> Microsoft.AspNetCore.Components.Forms.InputTextArea.ValueExpression",
@@ -3590,10 +3436,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 287749942823017074,
-      "Data2": -1482613306843375334,
-      "Data3": 4358495334242857568,
-      "Data4": -2827299442215245027
+      "Data1": -7233322400121288297,
+      "Data2": -6831273436642167155,
+      "Data3": -6148257844466328462,
+      "Data4": -4875475476958847532
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>",
@@ -3608,7 +3454,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TValue",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.TValue",
@@ -3619,7 +3464,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object> Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.AdditionalAttributes",
@@ -3629,7 +3473,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "For",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.For",
@@ -3648,10 +3491,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5040195526422134802,
-      "Data2": 2396745476687379473,
-      "Data3": 2305639319750862827,
-      "Data4": -183777995694358243
+      "Data1": 7966365519327798181,
+      "Data2": 8957938188291496080,
+      "Data3": 1566782462701229656,
+      "Data4": -523066649848829633
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>",
@@ -3666,7 +3509,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TValue",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.TValue",
@@ -3677,7 +3519,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object> Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.AdditionalAttributes",
@@ -3687,7 +3528,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "For",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.For",
@@ -3707,10 +3547,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5282662275274904781,
-      "Data2": 3471058309330685976,
-      "Data3": 4599093496764562443,
-      "Data4": 5147736050398804258
+      "Data1": -5377288203371174378,
+      "Data2": -5643462258230389770,
+      "Data3": -8824501511643692224,
+      "Data4": -6456555932937645357
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.ValidationSummary",
@@ -3725,7 +3565,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object> Microsoft.AspNetCore.Components.Forms.ValidationSummary.AdditionalAttributes",
@@ -3735,7 +3574,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Model",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Forms.ValidationSummary.Model",
@@ -3752,10 +3590,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4150409193074783492,
-      "Data2": 5136556941925401110,
-      "Data3": 1133901748069537888,
-      "Data4": 4348420139028914200
+      "Data1": -937348444949585752,
+      "Data2": 1092604483017636498,
+      "Data3": 3607146572481242656,
+      "Data4": -2688107600204775497
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.ValidationSummary",
@@ -3770,7 +3608,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object> Microsoft.AspNetCore.Components.Forms.ValidationSummary.AdditionalAttributes",
@@ -3780,7 +3617,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Model",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Forms.ValidationSummary.Model",
@@ -3798,10 +3634,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6935474680051380507,
-      "Data2": 7246536675529626443,
-      "Data3": 1865914036555114796,
-      "Data4": -3436925643414107905
+      "Data1": -1567162861432409573,
+      "Data2": 8736624622707993527,
+      "Data3": 4425644377414812448,
+      "Data4": 432486510237431197
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Routing.NavLink",
@@ -3816,7 +3652,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "ActiveClass",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Routing.NavLink.ActiveClass",
@@ -3826,7 +3661,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object> Microsoft.AspNetCore.Components.Routing.NavLink.AdditionalAttributes",
@@ -3836,7 +3670,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Routing.NavLink.ChildContent",
@@ -3847,7 +3680,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Match",
         "TypeName": "Microsoft.AspNetCore.Components.Routing.NavLinkMatch",
         "IsEnum": true,
@@ -3865,10 +3697,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7402698225902500521,
-      "Data2": -2296280371628386164,
-      "Data3": -7758244178097197297,
-      "Data4": -2607360141407241303
+      "Data1": -8950329049760888190,
+      "Data2": 9203006945621079730,
+      "Data3": -3519232032874364259,
+      "Data4": 5099474292102303125
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Routing.NavLink",
@@ -3883,7 +3715,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "ActiveClass",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Routing.NavLink.ActiveClass",
@@ -3893,7 +3724,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String,System.Object> Microsoft.AspNetCore.Components.Routing.NavLink.AdditionalAttributes",
@@ -3903,7 +3733,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Routing.NavLink.ChildContent",
@@ -3914,7 +3743,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Match",
         "TypeName": "Microsoft.AspNetCore.Components.Routing.NavLinkMatch",
         "IsEnum": true,
@@ -3984,10 +3812,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3369443405112860396,
-      "Data2": 3046097734821200829,
-      "Data3": -896897866579515934,
-      "Data4": 7373654384212824488
+      "Data1": -4545064052966077203,
+      "Data2": 5281744655842642689,
+      "Data3": -1736328996792404140,
+      "Data4": -8420568105166294591
     },
     "Kind": "Components.EventHandler",
     "Name": "onabort",
@@ -4035,7 +3863,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "preventDefault",
         "TypeName": "System.Boolean",
         "DisplayName": "preventDefault",
@@ -4057,7 +3884,6 @@
         ]
       },
       {
-        "Kind": "Components.EventHandler",
         "Name": "stopPropagation",
         "TypeName": "System.Boolean",
         "DisplayName": "stopPropagation",

--- a/src/Shared/files/Tooling/BlazorServerApp.TagHelpers.json
+++ b/src/Shared/files/Tooling/BlazorServerApp.TagHelpers.json
@@ -50,10 +50,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5132844681732630669,
-      "Data2": 2744273515306874229,
-      "Data3": 6173709233393781665,
-      "Data4": -584821476446434095
+      "Data1": 3662885567730227038,
+      "Data2": 6902190633032295593,
+      "Data3": 8718695875121991857,
+      "Data4": 6758118747432356557
     },
     "Kind": "Components.Component",
     "Name": "BlazorApp1.Shared.MainLayout",
@@ -67,7 +67,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "Body",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment BlazorApp1.Shared.MainLayout.Body",
@@ -88,10 +87,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7642774603381578576,
-      "Data2": -5551463728660387324,
-      "Data3": -6174362726655406342,
-      "Data4": 6530647603889737968
+      "Data1": 4552648523719428031,
+      "Data2": -7673086539595136663,
+      "Data3": 8186998928032923763,
+      "Data4": -5463173960500715119
     },
     "Kind": "Components.Component",
     "Name": "BlazorApp1.Shared.MainLayout",
@@ -105,7 +104,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "Body",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment BlazorApp1.Shared.MainLayout.Body",
@@ -231,10 +229,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5367674102157473401,
-      "Data2": -2792358546765559142,
-      "Data3": -566162226018705879,
-      "Data4": -6279714792608394507
+      "Data1": -5986462016061013442,
+      "Data2": 8499345075435355765,
+      "Data3": -5909788913345949889,
+      "Data4": 4151538218393109301
     },
     "Kind": "Components.Component",
     "Name": "BlazorApp1.Shared.SurveyPrompt",
@@ -248,7 +246,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "Title",
         "TypeName": "System.String",
         "DisplayName": "string BlazorApp1.Shared.SurveyPrompt.Title",
@@ -267,10 +264,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1596196128814268679,
-      "Data2": 1048194155269884460,
-      "Data3": 7335236384155318705,
-      "Data4": 2443528171745734786
+      "Data1": 5320866854641645274,
+      "Data2": -8937187627020749406,
+      "Data3": -8186364632835802656,
+      "Data4": -3956827425255237521
     },
     "Kind": "Components.Component",
     "Name": "BlazorApp1.Shared.SurveyPrompt",
@@ -284,7 +281,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "Title",
         "TypeName": "System.String",
         "DisplayName": "string BlazorApp1.Shared.SurveyPrompt.Title",
@@ -451,10 +447,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8763129550808725669,
-      "Data2": 8440347814648453328,
-      "Data3": -1495006013913634270,
-      "Data4": 3395259123047580365
+      "Data1": -7147353276491116458,
+      "Data2": 6432692024824594445,
+      "Data3": -5507047461889932739,
+      "Data4": 4524262424151747645
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView",
@@ -469,7 +465,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "NotAuthorized",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState> Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.NotAuthorized",
@@ -481,7 +476,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Authorizing",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.Authorizing",
@@ -493,7 +487,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Resource",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.Resource",
@@ -504,7 +497,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "RouteData",
         "TypeName": "Microsoft.AspNetCore.Components.RouteData",
         "DisplayName": "Microsoft.AspNetCore.Components.RouteData Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.RouteData",
@@ -516,7 +508,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "DefaultLayout",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.DefaultLayout",
@@ -527,7 +518,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.Context",
@@ -549,10 +539,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1126820336252066546,
-      "Data2": 2062211342647697663,
-      "Data3": 8016395908811423407,
-      "Data4": -9083134338239884034
+      "Data1": -5281460079632916680,
+      "Data2": -3575616995328524668,
+      "Data3": 5459903551991397317,
+      "Data4": 8243840343740981444
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView",
@@ -567,7 +557,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "NotAuthorized",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState> Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.NotAuthorized",
@@ -579,7 +568,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Authorizing",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.Authorizing",
@@ -591,7 +579,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Resource",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.Resource",
@@ -602,7 +589,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "RouteData",
         "TypeName": "Microsoft.AspNetCore.Components.RouteData",
         "DisplayName": "Microsoft.AspNetCore.Components.RouteData Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.RouteData",
@@ -614,7 +600,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "DefaultLayout",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.DefaultLayout",
@@ -625,7 +610,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.Context",
@@ -648,10 +632,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3488398355339662872,
-      "Data2": -8344262365856710599,
-      "Data3": 2203914251255903202,
-      "Data4": -549283059369327803
+      "Data1": -7787146324806788383,
+      "Data2": 1254988015343075869,
+      "Data3": 4788626951628670401,
+      "Data4": -8761000559287791563
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.NotAuthorized",
@@ -667,7 +651,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.NotAuthorized.Context",
@@ -693,10 +676,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8974977729823506722,
-      "Data2": -7624693699004013925,
-      "Data3": 6334444031807957260,
-      "Data4": -7477599851432545018
+      "Data1": 889687606777654353,
+      "Data2": 7662308356908755433,
+      "Data3": -22857935475341154,
+      "Data4": 8858728138159217789
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.NotAuthorized",
@@ -712,7 +695,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.NotAuthorized.Context",
@@ -794,10 +776,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3429174736135457823,
-      "Data2": 1359026430171826729,
-      "Data3": 5789336515782671394,
-      "Data4": -7141973529948150278
+      "Data1": -6451237602958568557,
+      "Data2": -7243034507197153253,
+      "Data3": -385568170196002739,
+      "Data4": 8009879172833705981
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeView",
@@ -812,7 +794,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "Policy",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Policy",
@@ -823,7 +804,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Roles",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Roles",
@@ -834,7 +814,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState> Microsoft.AspNetCore.Components.Authorization.AuthorizeView.ChildContent",
@@ -846,7 +825,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "NotAuthorized",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState> Microsoft.AspNetCore.Components.Authorization.AuthorizeView.NotAuthorized",
@@ -858,7 +836,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Authorized",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState> Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Authorized",
@@ -870,7 +847,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Authorizing",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Authorizing",
@@ -882,7 +858,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Resource",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Resource",
@@ -893,7 +868,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Context",
@@ -915,10 +889,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4076162487340942279,
-      "Data2": 38494143145235419,
-      "Data3": 1770899250837084767,
-      "Data4": -5731216382025977688
+      "Data1": 2932948779645652585,
+      "Data2": -1745786594373474567,
+      "Data3": -7375399539609342040,
+      "Data4": 660481651632201421
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeView",
@@ -933,7 +907,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "Policy",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Policy",
@@ -944,7 +917,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Roles",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Roles",
@@ -955,7 +927,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState> Microsoft.AspNetCore.Components.Authorization.AuthorizeView.ChildContent",
@@ -967,7 +938,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "NotAuthorized",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState> Microsoft.AspNetCore.Components.Authorization.AuthorizeView.NotAuthorized",
@@ -979,7 +949,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Authorized",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState> Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Authorized",
@@ -991,7 +960,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Authorizing",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Authorizing",
@@ -1003,7 +971,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Resource",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Resource",
@@ -1014,7 +981,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Context",
@@ -1037,10 +1003,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1054974347256619987,
-      "Data2": -2840325723997861834,
-      "Data3": 642976044333426267,
-      "Data4": 8915713283713928034
+      "Data1": -5036326241969501033,
+      "Data2": -8303319670757809915,
+      "Data3": 6570162258178062642,
+      "Data4": 1236715346809368361
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeView.ChildContent",
@@ -1056,7 +1022,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.ChildContent.Context",
@@ -1082,10 +1047,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7647723278018591681,
-      "Data2": 2104210306329917784,
-      "Data3": -2453041780994961145,
-      "Data4": 2251289738597512163
+      "Data1": -8220968510310002990,
+      "Data2": 7947841464092175832,
+      "Data3": -8315532755571368679,
+      "Data4": 1897483445115538903
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeView.ChildContent",
@@ -1101,7 +1066,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.ChildContent.Context",
@@ -1128,10 +1092,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1256654829718035504,
-      "Data2": 6176331583798799807,
-      "Data3": 2735777182756055709,
-      "Data4": 8258612773221362239
+      "Data1": 2189089888015075285,
+      "Data2": -8708115664506123281,
+      "Data3": 2826836350162102027,
+      "Data4": -6715812681754448153
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeView.NotAuthorized",
@@ -1147,7 +1111,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.NotAuthorized.Context",
@@ -1173,10 +1136,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6825185546786896001,
-      "Data2": 7842384322328390413,
-      "Data3": 8729699594286724263,
-      "Data4": -7984488084425419062
+      "Data1": 2145507231932459144,
+      "Data2": 6581160123697536692,
+      "Data3": 7865632943586280253,
+      "Data4": -1428889073216629460
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeView.NotAuthorized",
@@ -1192,7 +1155,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.NotAuthorized.Context",
@@ -1219,10 +1181,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4896319727897810395,
-      "Data2": -5937122031597645414,
-      "Data3": 5830494489755099766,
-      "Data4": 4075248029398980667
+      "Data1": 7339088469656198157,
+      "Data2": -8176943981293038456,
+      "Data3": 7518251656789152334,
+      "Data4": -8085315569025266406
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Authorized",
@@ -1238,7 +1200,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Authorized.Context",
@@ -1264,10 +1225,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 928643252168344305,
-      "Data2": 2738096222007397976,
-      "Data3": 7694624462705259661,
-      "Data4": -9092372737483223080
+      "Data1": -4382118423792880633,
+      "Data2": -4560742304801835180,
+      "Data3": -5682951334484011331,
+      "Data4": 4556721915951319946
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Authorized",
@@ -1283,7 +1244,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Authorized.Context",
@@ -1365,10 +1325,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -576041239627392457,
-      "Data2": 8201378603604506401,
-      "Data3": 2520610336752314436,
-      "Data4": -7200396900823791274
+      "Data1": 6775321457570018583,
+      "Data2": 346780315556510682,
+      "Data3": -3273086557825765316,
+      "Data4": -7803983172711800872
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Authorization.CascadingAuthenticationState",
@@ -1382,7 +1342,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Authorization.CascadingAuthenticationState.ChildContent",
@@ -1403,10 +1362,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8235365834910926769,
-      "Data2": 6694312252349350718,
-      "Data3": 5143715084207989652,
-      "Data4": 428090287477119526
+      "Data1": 5816574591754248056,
+      "Data2": 4163658553149173647,
+      "Data3": 1304462035204613787,
+      "Data4": 1980077022974195139
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Authorization.CascadingAuthenticationState",
@@ -1420,7 +1379,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Authorization.CascadingAuthenticationState.ChildContent",
@@ -1497,10 +1455,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2939941643516732002,
-      "Data2": -1216194779081055621,
-      "Data3": 1667946559397228020,
-      "Data4": 5824969354985129430
+      "Data1": -7108864112794867764,
+      "Data2": -1080935693928084382,
+      "Data3": -4225301256617136360,
+      "Data4": 2184616829127088514
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.CascadingValue<TValue>",
@@ -1515,7 +1473,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TValue",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.CascadingValue<TValue>.TValue",
@@ -1533,7 +1490,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.CascadingValue<TValue>.ChildContent",
@@ -1545,7 +1501,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "TValue",
         "DisplayName": "TValue Microsoft.AspNetCore.Components.CascadingValue<TValue>.Value",
@@ -1557,7 +1512,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Name",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.CascadingValue<TValue>.Name",
@@ -1568,7 +1522,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "IsFixed",
         "TypeName": "System.Boolean",
         "DisplayName": "bool Microsoft.AspNetCore.Components.CascadingValue<TValue>.IsFixed",
@@ -1589,10 +1542,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7679833204236774100,
-      "Data2": 63559635700121060,
-      "Data3": -986925736960264831,
-      "Data4": -8689859966039105595
+      "Data1": 7777348493945611274,
+      "Data2": 4106298764668849968,
+      "Data3": 4536383461631781189,
+      "Data4": -3271790299767503461
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.CascadingValue<TValue>",
@@ -1607,7 +1560,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TValue",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.CascadingValue<TValue>.TValue",
@@ -1625,7 +1577,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.CascadingValue<TValue>.ChildContent",
@@ -1637,7 +1588,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "TValue",
         "DisplayName": "TValue Microsoft.AspNetCore.Components.CascadingValue<TValue>.Value",
@@ -1649,7 +1599,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Name",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.CascadingValue<TValue>.Name",
@@ -1660,7 +1609,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "IsFixed",
         "TypeName": "System.Boolean",
         "DisplayName": "bool Microsoft.AspNetCore.Components.CascadingValue<TValue>.IsFixed",
@@ -1737,10 +1685,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5731302864841358952,
-      "Data2": -8981471926612505981,
-      "Data3": -4403247565854984028,
-      "Data4": -6387829014248849351
+      "Data1": 5007361071530070695,
+      "Data2": 5035323468407207337,
+      "Data3": -8766419681334191127,
+      "Data4": -809871829753529897
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.DynamicComponent",
@@ -1755,7 +1703,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "Type",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.DynamicComponent.Type",
@@ -1767,7 +1714,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Parameters",
         "TypeName": "System.Collections.Generic.IDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.DynamicComponent.Parameters",
@@ -1787,10 +1733,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7110698932307731208,
-      "Data2": -1569536967984684798,
-      "Data3": -3992574793600979564,
-      "Data4": 4055446559830609435
+      "Data1": 271866231282066964,
+      "Data2": 7955106179573504884,
+      "Data3": -4412443524163318756,
+      "Data4": 4432087761114836447
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.DynamicComponent",
@@ -1805,7 +1751,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "Type",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.DynamicComponent.Type",
@@ -1817,7 +1762,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Parameters",
         "TypeName": "System.Collections.Generic.IDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.DynamicComponent.Parameters",
@@ -1838,10 +1782,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5647725014167321797,
-      "Data2": -552944172644708731,
-      "Data3": -3815279164226980465,
-      "Data4": 7388613562141534977
+      "Data1": -7281482219010996664,
+      "Data2": -441266699990708811,
+      "Data3": 4157689698312044533,
+      "Data4": 7547624965947796830
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.LayoutView",
@@ -1856,7 +1800,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.LayoutView.ChildContent",
@@ -1868,7 +1811,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Layout",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.LayoutView.Layout",
@@ -1888,10 +1830,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1361411529474496483,
-      "Data2": -739982539966889227,
-      "Data3": -977459276069733025,
-      "Data4": -225334187807638369
+      "Data1": -6686451252056518095,
+      "Data2": 8617225997519403546,
+      "Data3": 2937266975765250804,
+      "Data4": 545395739780900630
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.LayoutView",
@@ -1906,7 +1848,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.LayoutView.ChildContent",
@@ -1918,7 +1859,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Layout",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.LayoutView.Layout",
@@ -1994,10 +1934,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4217022035368751388,
-      "Data2": -4067929904648929838,
-      "Data3": 6526259014377304754,
-      "Data4": 9187030806021014627
+      "Data1": 1924599423855430719,
+      "Data2": 2179294029579839705,
+      "Data3": -4467829975871137036,
+      "Data4": -7570974867706953158
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.RouteView",
@@ -2012,7 +1952,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "RouteData",
         "TypeName": "Microsoft.AspNetCore.Components.RouteData",
         "DisplayName": "Microsoft.AspNetCore.Components.RouteData Microsoft.AspNetCore.Components.RouteView.RouteData",
@@ -2024,7 +1963,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "DefaultLayout",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.RouteView.DefaultLayout",
@@ -2044,10 +1982,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3181917166860484265,
-      "Data2": 5592830598254929166,
-      "Data3": 6332203196792038142,
-      "Data4": 1705581486661393550
+      "Data1": -17954501693325446,
+      "Data2": 6916083157872748623,
+      "Data3": -5204389908929341771,
+      "Data4": -5570070410625117682
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.RouteView",
@@ -2062,7 +2000,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "RouteData",
         "TypeName": "Microsoft.AspNetCore.Components.RouteData",
         "DisplayName": "Microsoft.AspNetCore.Components.RouteData Microsoft.AspNetCore.Components.RouteView.RouteData",
@@ -2074,7 +2011,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "DefaultLayout",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.RouteView.DefaultLayout",
@@ -2095,10 +2031,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1065865949068824216,
-      "Data2": 5992357818554971059,
-      "Data3": -5474552193129438454,
-      "Data4": -2540487500587233647
+      "Data1": -5162395411937989705,
+      "Data2": -4539898811497083807,
+      "Data3": 9138104933560021452,
+      "Data4": -8531971225519157687
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Routing.Router",
@@ -2113,7 +2049,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "AppAssembly",
         "TypeName": "System.Reflection.Assembly",
         "DisplayName": "System.Reflection.Assembly Microsoft.AspNetCore.Components.Routing.Router.AppAssembly",
@@ -2125,7 +2060,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAssemblies",
         "TypeName": "System.Collections.Generic.IEnumerable<System.Reflection.Assembly>",
         "DisplayName": "System.Collections.Generic.IEnumerable<System.Reflection.Assembly> Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblies",
@@ -2136,7 +2070,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "NotFound",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Routing.Router.NotFound",
@@ -2149,7 +2082,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Found",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.RouteData>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.RouteData> Microsoft.AspNetCore.Components.Routing.Router.Found",
@@ -2162,7 +2094,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Navigating",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Routing.Router.Navigating",
@@ -2174,7 +2105,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "OnNavigateAsync",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Routing.NavigationContext>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Routing.NavigationContext> Microsoft.AspNetCore.Components.Routing.Router.OnNavigateAsync",
@@ -2186,7 +2116,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "PreferExactMatches",
         "TypeName": "System.Boolean",
         "DisplayName": "bool Microsoft.AspNetCore.Components.Routing.Router.PreferExactMatches",
@@ -2197,7 +2126,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Routing.Router.Context",
@@ -2219,10 +2147,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3280662649738157413,
-      "Data2": -3435747272199950955,
-      "Data3": 93864075351459690,
-      "Data4": 1782415312587554142
+      "Data1": -3382417770010292070,
+      "Data2": -746705036808522892,
+      "Data3": -7933365887112651878,
+      "Data4": -196003208049433703
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Routing.Router",
@@ -2237,7 +2165,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "AppAssembly",
         "TypeName": "System.Reflection.Assembly",
         "DisplayName": "System.Reflection.Assembly Microsoft.AspNetCore.Components.Routing.Router.AppAssembly",
@@ -2249,7 +2176,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAssemblies",
         "TypeName": "System.Collections.Generic.IEnumerable<System.Reflection.Assembly>",
         "DisplayName": "System.Collections.Generic.IEnumerable<System.Reflection.Assembly> Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblies",
@@ -2260,7 +2186,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "NotFound",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Routing.Router.NotFound",
@@ -2273,7 +2198,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Found",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.RouteData>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.RouteData> Microsoft.AspNetCore.Components.Routing.Router.Found",
@@ -2286,7 +2210,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Navigating",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Routing.Router.Navigating",
@@ -2298,7 +2221,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "OnNavigateAsync",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Routing.NavigationContext>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Routing.NavigationContext> Microsoft.AspNetCore.Components.Routing.Router.OnNavigateAsync",
@@ -2310,7 +2232,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "PreferExactMatches",
         "TypeName": "System.Boolean",
         "DisplayName": "bool Microsoft.AspNetCore.Components.Routing.Router.PreferExactMatches",
@@ -2321,7 +2242,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Routing.Router.Context",
@@ -2399,10 +2319,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 997777688699634274,
-      "Data2": -284251513568491132,
-      "Data3": 135580316298199262,
-      "Data4": 362626749714483680
+      "Data1": 8481356021292146879,
+      "Data2": -493185515804375030,
+      "Data3": -8854908829230477766,
+      "Data4": -9168455048101246234
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Routing.Router.Found",
@@ -2418,7 +2338,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Routing.Router.Found.Context",
@@ -2444,10 +2363,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 417637872835683764,
-      "Data2": -8076763885613547699,
-      "Data3": -9098266231859602864,
-      "Data4": 857792143088992320
+      "Data1": 6814149873008043691,
+      "Data2": -5204816224704905583,
+      "Data3": 5608076737930719263,
+      "Data4": 5943635189355884583
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Routing.Router.Found",
@@ -2463,7 +2382,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Routing.Router.Found.Context",
@@ -2545,10 +2463,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8573805794810384742,
-      "Data2": 3190260025099912483,
-      "Data3": 286211946971728597,
-      "Data4": 2235639381601190169
+      "Data1": 6839566192935583739,
+      "Data2": -587421570422136381,
+      "Data3": -3845953024322289989,
+      "Data4": -2804193461439083962
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.EditForm",
@@ -2563,7 +2481,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.EditForm.AdditionalAttributes",
@@ -2574,7 +2491,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "EditContext",
         "TypeName": "Microsoft.AspNetCore.Components.Forms.EditContext",
         "DisplayName": "Microsoft.AspNetCore.Components.Forms.EditContext Microsoft.AspNetCore.Components.Forms.EditForm.EditContext",
@@ -2585,7 +2501,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Model",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Forms.EditForm.Model",
@@ -2596,7 +2511,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Forms.EditContext>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Forms.EditContext> Microsoft.AspNetCore.Components.Forms.EditForm.ChildContent",
@@ -2608,7 +2522,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "OnSubmit",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext> Microsoft.AspNetCore.Components.Forms.EditForm.OnSubmit",
@@ -2620,7 +2533,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "OnValidSubmit",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext> Microsoft.AspNetCore.Components.Forms.EditForm.OnValidSubmit",
@@ -2632,7 +2544,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "OnInvalidSubmit",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext> Microsoft.AspNetCore.Components.Forms.EditForm.OnInvalidSubmit",
@@ -2644,7 +2555,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.EditForm.Context",
@@ -2666,10 +2576,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4416280976354102043,
-      "Data2": -3760434688580255632,
-      "Data3": -5285723401744202602,
-      "Data4": -8971075941582462424
+      "Data1": 2861933497038381881,
+      "Data2": 519723098274917255,
+      "Data3": -963873860087518763,
+      "Data4": 132417499078989304
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.EditForm",
@@ -2684,7 +2594,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.EditForm.AdditionalAttributes",
@@ -2695,7 +2604,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "EditContext",
         "TypeName": "Microsoft.AspNetCore.Components.Forms.EditContext",
         "DisplayName": "Microsoft.AspNetCore.Components.Forms.EditContext Microsoft.AspNetCore.Components.Forms.EditForm.EditContext",
@@ -2706,7 +2614,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Model",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Forms.EditForm.Model",
@@ -2717,7 +2624,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Forms.EditContext>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Forms.EditContext> Microsoft.AspNetCore.Components.Forms.EditForm.ChildContent",
@@ -2729,7 +2635,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "OnSubmit",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext> Microsoft.AspNetCore.Components.Forms.EditForm.OnSubmit",
@@ -2741,7 +2646,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "OnValidSubmit",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext> Microsoft.AspNetCore.Components.Forms.EditForm.OnValidSubmit",
@@ -2753,7 +2657,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "OnInvalidSubmit",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext> Microsoft.AspNetCore.Components.Forms.EditForm.OnInvalidSubmit",
@@ -2765,7 +2668,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.EditForm.Context",
@@ -2788,10 +2690,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8981596313203451455,
-      "Data2": 1294755070007482779,
-      "Data3": -8669452550379814980,
-      "Data4": -7950528233039134052
+      "Data1": 2575274794613348103,
+      "Data2": 7221489516900898562,
+      "Data3": 8445955983404358268,
+      "Data4": -6726876879946765836
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Forms.EditForm.ChildContent",
@@ -2807,7 +2709,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.EditForm.ChildContent.Context",
@@ -2833,10 +2734,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6286417777505078195,
-      "Data2": -3485072285495963737,
-      "Data3": 4330826567266810052,
-      "Data4": -321605847845400593
+      "Data1": 8876606713189028816,
+      "Data2": 3789689721382064808,
+      "Data3": 3444559347012485003,
+      "Data4": 7745757552312267392
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Forms.EditForm.ChildContent",
@@ -2852,7 +2753,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.EditForm.ChildContent.Context",
@@ -2879,10 +2779,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6187584435325857626,
-      "Data2": 167589322083600774,
-      "Data3": 5705629187949551463,
-      "Data4": -5960037433306373421
+      "Data1": -5518885861169390573,
+      "Data2": -1405394925609427005,
+      "Data3": -6584141123504825542,
+      "Data4": 8654637415588530568
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputCheckbox",
@@ -2897,7 +2797,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputCheckbox.AdditionalAttributes",
@@ -2908,7 +2807,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "System.Boolean",
         "DisplayName": "bool Microsoft.AspNetCore.Components.Forms.InputCheckbox.Value",
@@ -2919,7 +2817,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.Boolean>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.Boolean> Microsoft.AspNetCore.Components.Forms.InputCheckbox.ValueChanged",
@@ -2931,7 +2828,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<System.Boolean>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<System.Boolean>> Microsoft.AspNetCore.Components.Forms.InputCheckbox.ValueExpression",
@@ -2942,7 +2838,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "DisplayName",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputCheckbox.DisplayName",
@@ -2962,10 +2857,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4146236444580142722,
-      "Data2": 5030192670004756898,
-      "Data3": -7372726565557631228,
-      "Data4": 2856541690275313358
+      "Data1": 4793736010908711003,
+      "Data2": -3196163899451845432,
+      "Data3": 4163544943599488762,
+      "Data4": 7751701445821654497
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputCheckbox",
@@ -2980,7 +2875,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputCheckbox.AdditionalAttributes",
@@ -2991,7 +2885,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "System.Boolean",
         "DisplayName": "bool Microsoft.AspNetCore.Components.Forms.InputCheckbox.Value",
@@ -3002,7 +2895,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.Boolean>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.Boolean> Microsoft.AspNetCore.Components.Forms.InputCheckbox.ValueChanged",
@@ -3014,7 +2906,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<System.Boolean>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<System.Boolean>> Microsoft.AspNetCore.Components.Forms.InputCheckbox.ValueExpression",
@@ -3025,7 +2916,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "DisplayName",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputCheckbox.DisplayName",
@@ -3046,10 +2936,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1228906755754688927,
-      "Data2": -5318654479202899585,
-      "Data3": -3463282059115261949,
-      "Data4": 7703747975973445142
+      "Data1": -6872363402144521399,
+      "Data2": -7590642701620376137,
+      "Data3": -6483236763411546831,
+      "Data4": -8286250409558123978
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputDate<TValue>",
@@ -3064,7 +2954,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TValue",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.TValue",
@@ -3082,7 +2971,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Type",
         "TypeName": "Microsoft.AspNetCore.Components.Forms.InputDateType",
         "IsEnum": true,
@@ -3094,7 +2982,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ParsingErrorMessage",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.ParsingErrorMessage",
@@ -3105,7 +2992,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.AdditionalAttributes",
@@ -3116,7 +3002,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "TValue",
         "DisplayName": "TValue Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.Value",
@@ -3128,7 +3013,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.ValueChanged",
@@ -3141,7 +3025,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.ValueExpression",
@@ -3153,7 +3036,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "DisplayName",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.DisplayName",
@@ -3174,10 +3056,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7840331994028869918,
-      "Data2": -3802876581885721243,
-      "Data3": -2334812786506549364,
-      "Data4": -3278621492621492256
+      "Data1": -1667468125912122152,
+      "Data2": -7665729907337910336,
+      "Data3": -1632540070653444757,
+      "Data4": -5177833745385877997
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputDate<TValue>",
@@ -3192,7 +3074,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TValue",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.TValue",
@@ -3210,7 +3091,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Type",
         "TypeName": "Microsoft.AspNetCore.Components.Forms.InputDateType",
         "IsEnum": true,
@@ -3222,7 +3102,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ParsingErrorMessage",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.ParsingErrorMessage",
@@ -3233,7 +3112,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.AdditionalAttributes",
@@ -3244,7 +3122,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "TValue",
         "DisplayName": "TValue Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.Value",
@@ -3256,7 +3133,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.ValueChanged",
@@ -3269,7 +3145,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.ValueExpression",
@@ -3281,7 +3156,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "DisplayName",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.DisplayName",
@@ -3303,10 +3177,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4796468856128707353,
-      "Data2": 6018478287849707548,
-      "Data3": -69398322114761356,
-      "Data4": -5671204785369491357
+      "Data1": 921115900372858860,
+      "Data2": 4413416511534510696,
+      "Data3": 5759116936989490955,
+      "Data4": -3530739741039117264
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputFile",
@@ -3321,7 +3195,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "OnChange",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.InputFileChangeEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.InputFileChangeEventArgs> Microsoft.AspNetCore.Components.Forms.InputFile.OnChange",
@@ -3333,7 +3206,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputFile.AdditionalAttributes",
@@ -3353,10 +3225,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2851344421610587549,
-      "Data2": -8253885058954965608,
-      "Data3": 2253047349172282888,
-      "Data4": 6183884232706389432
+      "Data1": 8587999910924699243,
+      "Data2": 4104672561306630202,
+      "Data3": 5844050795253278236,
+      "Data4": 9135331131802692507
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputFile",
@@ -3371,7 +3243,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "OnChange",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.InputFileChangeEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.InputFileChangeEventArgs> Microsoft.AspNetCore.Components.Forms.InputFile.OnChange",
@@ -3383,7 +3254,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputFile.AdditionalAttributes",
@@ -3404,10 +3274,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3980074744483278973,
-      "Data2": 1326625528494469073,
-      "Data3": -6904959133428587702,
-      "Data4": -8044718618287349359
+      "Data1": -4489901433013746363,
+      "Data2": -8635272385981292292,
+      "Data3": -5696110936059348120,
+      "Data4": -757041219153908740
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>",
@@ -3422,7 +3292,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TValue",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.TValue",
@@ -3440,7 +3309,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ParsingErrorMessage",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.ParsingErrorMessage",
@@ -3451,7 +3319,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.AdditionalAttributes",
@@ -3462,7 +3329,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "TValue",
         "DisplayName": "TValue Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.Value",
@@ -3474,7 +3340,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.ValueChanged",
@@ -3487,7 +3352,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.ValueExpression",
@@ -3499,7 +3363,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "DisplayName",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.DisplayName",
@@ -3520,10 +3383,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6183677447586594150,
-      "Data2": 2955628431327958784,
-      "Data3": 2686326169988694506,
-      "Data4": -7678600250330349587
+      "Data1": 8302248936411949578,
+      "Data2": -732167559380144556,
+      "Data3": 8549142426481036471,
+      "Data4": 6437150755116141371
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>",
@@ -3538,7 +3401,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TValue",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.TValue",
@@ -3556,7 +3418,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ParsingErrorMessage",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.ParsingErrorMessage",
@@ -3567,7 +3428,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.AdditionalAttributes",
@@ -3578,7 +3438,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "TValue",
         "DisplayName": "TValue Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.Value",
@@ -3590,7 +3449,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.ValueChanged",
@@ -3603,7 +3461,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.ValueExpression",
@@ -3615,7 +3472,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "DisplayName",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.DisplayName",
@@ -3637,10 +3493,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6962000952834850936,
-      "Data2": 8086149865075863129,
-      "Data3": -979942818319618291,
-      "Data4": -6754850214328841521
+      "Data1": 1900626726981823967,
+      "Data2": 8982949522707069311,
+      "Data3": 5490907335473063084,
+      "Data4": -4398711622545385363
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputRadio<TValue>",
@@ -3655,7 +3511,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TValue",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.InputRadio<TValue>.TValue",
@@ -3673,7 +3528,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputRadio<TValue>.AdditionalAttributes",
@@ -3684,7 +3538,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "TValue",
         "DisplayName": "TValue Microsoft.AspNetCore.Components.Forms.InputRadio<TValue>.Value",
@@ -3696,7 +3549,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Name",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputRadio<TValue>.Name",
@@ -3717,10 +3569,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6723092100417738000,
-      "Data2": 68278938014999267,
-      "Data3": -3172674951308760976,
-      "Data4": -8612851921988760702
+      "Data1": 6675502745638815877,
+      "Data2": 4595810127762345818,
+      "Data3": -512174897920601536,
+      "Data4": -2210262314430142148
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputRadio<TValue>",
@@ -3735,7 +3587,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TValue",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.InputRadio<TValue>.TValue",
@@ -3753,7 +3604,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputRadio<TValue>.AdditionalAttributes",
@@ -3764,7 +3614,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "TValue",
         "DisplayName": "TValue Microsoft.AspNetCore.Components.Forms.InputRadio<TValue>.Value",
@@ -3776,7 +3625,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Name",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputRadio<TValue>.Name",
@@ -3798,10 +3646,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5938157798000805913,
-      "Data2": 1424891236530968759,
-      "Data3": -8084624530189606525,
-      "Data4": 536175735094239168
+      "Data1": -7405239856564519414,
+      "Data2": 1025022487582963253,
+      "Data3": 3266641185280730288,
+      "Data4": -2202937839760365038
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>",
@@ -3816,7 +3664,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TValue",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.TValue",
@@ -3834,7 +3681,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.ChildContent",
@@ -3846,7 +3692,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Name",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.Name",
@@ -3857,7 +3702,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.AdditionalAttributes",
@@ -3868,7 +3712,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "TValue",
         "DisplayName": "TValue Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.Value",
@@ -3880,7 +3723,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.ValueChanged",
@@ -3893,7 +3735,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.ValueExpression",
@@ -3905,7 +3746,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "DisplayName",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.DisplayName",
@@ -3926,10 +3766,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1343944536014529469,
-      "Data2": -5694369823368609398,
-      "Data3": -2200377365782445289,
-      "Data4": -72805778816656697
+      "Data1": 7568271451736061841,
+      "Data2": 2209036448580380024,
+      "Data3": 277890349144237257,
+      "Data4": 9094456012279511203
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>",
@@ -3944,7 +3784,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TValue",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.TValue",
@@ -3962,7 +3801,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.ChildContent",
@@ -3974,7 +3812,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Name",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.Name",
@@ -3985,7 +3822,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.AdditionalAttributes",
@@ -3996,7 +3832,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "TValue",
         "DisplayName": "TValue Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.Value",
@@ -4008,7 +3843,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.ValueChanged",
@@ -4021,7 +3855,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.ValueExpression",
@@ -4033,7 +3866,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "DisplayName",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.DisplayName",
@@ -4110,10 +3942,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2781946253822678563,
-      "Data2": 1738200853640120005,
-      "Data3": -7953344209652671421,
-      "Data4": -3684910699624766328
+      "Data1": 8017924984099254577,
+      "Data2": -4184115831936360403,
+      "Data3": -1689790425914967501,
+      "Data4": -2715107937407794592
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>",
@@ -4128,7 +3960,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TValue",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.TValue",
@@ -4146,7 +3977,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.ChildContent",
@@ -4158,7 +3988,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.AdditionalAttributes",
@@ -4169,7 +3998,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "TValue",
         "DisplayName": "TValue Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.Value",
@@ -4181,7 +4009,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.ValueChanged",
@@ -4194,7 +4021,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.ValueExpression",
@@ -4206,7 +4032,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "DisplayName",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.DisplayName",
@@ -4227,10 +4052,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2251377545967591838,
-      "Data2": 18405769407960497,
-      "Data3": -4505800118385142463,
-      "Data4": -1561503781308974382
+      "Data1": -6112857038830817485,
+      "Data2": -3606124720275110332,
+      "Data3": 7030251145009405419,
+      "Data4": -3092154850495134413
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>",
@@ -4245,7 +4070,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TValue",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.TValue",
@@ -4263,7 +4087,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.ChildContent",
@@ -4275,7 +4098,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.AdditionalAttributes",
@@ -4286,7 +4108,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "TValue",
         "DisplayName": "TValue Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.Value",
@@ -4298,7 +4119,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.ValueChanged",
@@ -4311,7 +4131,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.ValueExpression",
@@ -4323,7 +4142,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "DisplayName",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.DisplayName",
@@ -4400,10 +4218,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5266961133227009334,
-      "Data2": 7069408624431995958,
-      "Data3": -7904567687459931970,
-      "Data4": -4223639896610183728
+      "Data1": 3148077617251934240,
+      "Data2": -3367266374268449266,
+      "Data3": -3110897653757607936,
+      "Data4": -2689757055105376754
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputText",
@@ -4418,7 +4236,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputText.AdditionalAttributes",
@@ -4429,7 +4246,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputText.Value",
@@ -4440,7 +4256,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.String>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.String> Microsoft.AspNetCore.Components.Forms.InputText.ValueChanged",
@@ -4452,7 +4267,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<System.String>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<System.String>> Microsoft.AspNetCore.Components.Forms.InputText.ValueExpression",
@@ -4463,7 +4277,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "DisplayName",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputText.DisplayName",
@@ -4483,10 +4296,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3255411392688198602,
-      "Data2": 6369426529646532600,
-      "Data3": -1880525005011952246,
-      "Data4": -2696033573673097348
+      "Data1": -3526625320652058162,
+      "Data2": -3856489842264968788,
+      "Data3": 8990154170415489185,
+      "Data4": -4433718929097448282
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputText",
@@ -4501,7 +4314,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputText.AdditionalAttributes",
@@ -4512,7 +4324,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputText.Value",
@@ -4523,7 +4334,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.String>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.String> Microsoft.AspNetCore.Components.Forms.InputText.ValueChanged",
@@ -4535,7 +4345,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<System.String>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<System.String>> Microsoft.AspNetCore.Components.Forms.InputText.ValueExpression",
@@ -4546,7 +4355,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "DisplayName",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputText.DisplayName",
@@ -4567,10 +4375,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8131600848271715753,
-      "Data2": 5352651226290887985,
-      "Data3": -963108624152572302,
-      "Data4": 2401880409617977689
+      "Data1": 4985709555591756868,
+      "Data2": -1120420670147671228,
+      "Data3": -8442003000503889811,
+      "Data4": -8576581054673569601
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputTextArea",
@@ -4585,7 +4393,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputTextArea.AdditionalAttributes",
@@ -4596,7 +4403,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputTextArea.Value",
@@ -4607,7 +4413,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.String>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.String> Microsoft.AspNetCore.Components.Forms.InputTextArea.ValueChanged",
@@ -4619,7 +4424,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<System.String>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<System.String>> Microsoft.AspNetCore.Components.Forms.InputTextArea.ValueExpression",
@@ -4630,7 +4434,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "DisplayName",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputTextArea.DisplayName",
@@ -4650,10 +4453,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -836317901742063985,
-      "Data2": 7629847914134898471,
-      "Data3": 7906853128765055422,
-      "Data4": 8449800879468097797
+      "Data1": 5738948770673151910,
+      "Data2": 5785200214068201469,
+      "Data3": 2495009488536454131,
+      "Data4": -9158620638600201676
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputTextArea",
@@ -4668,7 +4471,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputTextArea.AdditionalAttributes",
@@ -4679,7 +4481,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputTextArea.Value",
@@ -4690,7 +4491,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueChanged",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.String>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.String> Microsoft.AspNetCore.Components.Forms.InputTextArea.ValueChanged",
@@ -4702,7 +4502,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ValueExpression",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<System.String>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<System.String>> Microsoft.AspNetCore.Components.Forms.InputTextArea.ValueExpression",
@@ -4713,7 +4512,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "DisplayName",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputTextArea.DisplayName",
@@ -4734,10 +4532,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -657523363270798859,
-      "Data2": 6006145276722035970,
-      "Data3": -5368716738219495178,
-      "Data4": 7729072236187588205
+      "Data1": 1756158587890272676,
+      "Data2": -8667008366164725315,
+      "Data3": -3529605769033386298,
+      "Data4": 384358881761349407
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>",
@@ -4752,7 +4550,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TValue",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.TValue",
@@ -4770,7 +4567,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.AdditionalAttributes",
@@ -4781,7 +4577,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "For",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.For",
@@ -4803,10 +4598,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6969290110093745382,
-      "Data2": 4486222785458242217,
-      "Data3": -5300838879534075157,
-      "Data4": -8244008189902187920
+      "Data1": -4074050555370015180,
+      "Data2": -2973822149386169842,
+      "Data3": 6006627248329373004,
+      "Data4": -1369780042976776301
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>",
@@ -4821,7 +4616,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TValue",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.TValue",
@@ -4839,7 +4633,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.AdditionalAttributes",
@@ -4850,7 +4643,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "For",
         "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
         "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.For",
@@ -4873,10 +4665,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2679323449636127492,
-      "Data2": 7372491348027668297,
-      "Data3": -97011653695442052,
-      "Data4": -3017903512336013466
+      "Data1": -3890423152889206347,
+      "Data2": 2873018345440896476,
+      "Data3": -5656021458528105297,
+      "Data4": 8743454888953495050
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.ValidationSummary",
@@ -4891,7 +4683,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "Model",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Forms.ValidationSummary.Model",
@@ -4902,7 +4693,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.ValidationSummary.AdditionalAttributes",
@@ -4922,10 +4712,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2728909145337604665,
-      "Data2": -2036286347850716288,
-      "Data3": -6143115957433341905,
-      "Data4": -5929085004096954415
+      "Data1": 7769613614186158005,
+      "Data2": -6857414409530928503,
+      "Data3": 8962377858620860524,
+      "Data4": 4486438530637386910
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Forms.ValidationSummary",
@@ -4940,7 +4730,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "Model",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Forms.ValidationSummary.Model",
@@ -4951,7 +4740,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.ValidationSummary.AdditionalAttributes",
@@ -4972,10 +4760,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7682595428045860027,
-      "Data2": 3732976448010917183,
-      "Data3": -8061381699924970167,
-      "Data4": -5315533547263143033
+      "Data1": -52508942261311658,
+      "Data2": -2913125649298394138,
+      "Data3": 4548064829075120765,
+      "Data4": -8673133226926367898
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Routing.FocusOnNavigate",
@@ -4990,7 +4778,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "RouteData",
         "TypeName": "Microsoft.AspNetCore.Components.RouteData",
         "DisplayName": "Microsoft.AspNetCore.Components.RouteData Microsoft.AspNetCore.Components.Routing.FocusOnNavigate.RouteData",
@@ -5001,7 +4788,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Selector",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Routing.FocusOnNavigate.Selector",
@@ -5021,10 +4807,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5183413515272351814,
-      "Data2": -6012188184945270530,
-      "Data3": -3103210565056525924,
-      "Data4": 3381279242650094694
+      "Data1": 1910922600379580013,
+      "Data2": -3216388360066128173,
+      "Data3": -3089610772648313404,
+      "Data4": 1493581795363121499
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Routing.FocusOnNavigate",
@@ -5039,7 +4825,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "RouteData",
         "TypeName": "Microsoft.AspNetCore.Components.RouteData",
         "DisplayName": "Microsoft.AspNetCore.Components.RouteData Microsoft.AspNetCore.Components.Routing.FocusOnNavigate.RouteData",
@@ -5050,7 +4835,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Selector",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Routing.FocusOnNavigate.Selector",
@@ -5071,10 +4855,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6075053072669349455,
-      "Data2": 1116981275961837673,
-      "Data3": 6701534713590423367,
-      "Data4": -9209269012870764728
+      "Data1": 3359284231331578695,
+      "Data2": 3869177589531227799,
+      "Data3": 919140938980667888,
+      "Data4": 8359183396151582796
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Routing.NavLink",
@@ -5089,7 +4873,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "ActiveClass",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Routing.NavLink.ActiveClass",
@@ -5100,7 +4883,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Routing.NavLink.AdditionalAttributes",
@@ -5111,7 +4893,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Routing.NavLink.ChildContent",
@@ -5123,7 +4904,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Match",
         "TypeName": "Microsoft.AspNetCore.Components.Routing.NavLinkMatch",
         "IsEnum": true,
@@ -5144,10 +4924,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4425655137957744125,
-      "Data2": -1739911580685482942,
-      "Data3": 1176393779720623314,
-      "Data4": 5866617672483009240
+      "Data1": 5679885813081306006,
+      "Data2": -732293214913680941,
+      "Data3": -3268572034544503992,
+      "Data4": 4803725140722547311
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Routing.NavLink",
@@ -5162,7 +4942,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "ActiveClass",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Routing.NavLink.ActiveClass",
@@ -5173,7 +4952,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "AdditionalAttributes",
         "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
         "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Routing.NavLink.AdditionalAttributes",
@@ -5184,7 +4962,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Routing.NavLink.ChildContent",
@@ -5196,7 +4973,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Match",
         "TypeName": "Microsoft.AspNetCore.Components.Routing.NavLinkMatch",
         "IsEnum": true,
@@ -5273,10 +5049,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4338109109745620331,
-      "Data2": 1122288490760957248,
-      "Data3": 672951010100216705,
-      "Data4": -371817035841035436
+      "Data1": -6354638673769010393,
+      "Data2": 890173904220144315,
+      "Data3": 2877278247239270102,
+      "Data4": 7900533668852890900
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Web.HeadContent",
@@ -5291,7 +5067,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Web.HeadContent.ChildContent",
@@ -5312,10 +5087,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8778205530880997027,
-      "Data2": 561032384787948903,
-      "Data3": 3510161547344710101,
-      "Data4": 320285587052186776
+      "Data1": -8335674099849810948,
+      "Data2": 8324731442806945388,
+      "Data3": 7249200240653551494,
+      "Data4": 4404361552765598128
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Web.HeadContent",
@@ -5330,7 +5105,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Web.HeadContent.ChildContent",
@@ -5458,10 +5232,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4986704518340286913,
-      "Data2": 3941299843850945798,
-      "Data3": 8081730510459249779,
-      "Data4": 6829746023478172654
+      "Data1": 3742325200940645832,
+      "Data2": -8545483363586623218,
+      "Data3": 242431087173610816,
+      "Data4": -7391741280285516049
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Web.PageTitle",
@@ -5476,7 +5250,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Web.PageTitle.ChildContent",
@@ -5497,10 +5270,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1785309280486218875,
-      "Data2": 2538793686351442420,
-      "Data3": 3487399189204682320,
-      "Data4": -3590425704578969524
+      "Data1": 6711457227184686631,
+      "Data2": 2020114191179075386,
+      "Data3": -6507988531532328546,
+      "Data4": 6824737470920768809
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Web.PageTitle",
@@ -5515,7 +5288,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Web.PageTitle.ChildContent",
@@ -5592,10 +5364,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6915406746208842857,
-      "Data2": -6842483676820310163,
-      "Data3": -3588240388182261951,
-      "Data4": 6590627877874627896
+      "Data1": 4414008983769081340,
+      "Data2": -4043217653070966412,
+      "Data3": -990661926952215983,
+      "Data4": 819514524701423998
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Web.ErrorBoundary",
@@ -5610,7 +5382,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Web.ErrorBoundary.ChildContent",
@@ -5622,7 +5393,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ErrorContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<System.Exception>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<System.Exception> Microsoft.AspNetCore.Components.Web.ErrorBoundary.ErrorContent",
@@ -5634,7 +5404,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "MaximumErrorCount",
         "TypeName": "System.Int32",
         "DisplayName": "int Microsoft.AspNetCore.Components.Web.ErrorBoundary.MaximumErrorCount",
@@ -5645,7 +5414,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.ErrorBoundary.Context",
@@ -5667,10 +5435,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -23553981914542077,
-      "Data2": 3273965855492279329,
-      "Data3": -6810468509776494695,
-      "Data4": -2696351285898800655
+      "Data1": -4295186305907616510,
+      "Data2": -7946507045110813449,
+      "Data3": 2671527087952054422,
+      "Data4": -1652746405163160996
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Web.ErrorBoundary",
@@ -5685,7 +5453,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Web.ErrorBoundary.ChildContent",
@@ -5697,7 +5464,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ErrorContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<System.Exception>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<System.Exception> Microsoft.AspNetCore.Components.Web.ErrorBoundary.ErrorContent",
@@ -5709,7 +5475,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "MaximumErrorCount",
         "TypeName": "System.Int32",
         "DisplayName": "int Microsoft.AspNetCore.Components.Web.ErrorBoundary.MaximumErrorCount",
@@ -5720,7 +5485,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.ErrorBoundary.Context",
@@ -5798,10 +5562,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1772731680796811281,
-      "Data2": -4259965488492657216,
-      "Data3": -6182093730501710886,
-      "Data4": 5764102814695146909
+      "Data1": 4996376786189116717,
+      "Data2": 1930591883021162586,
+      "Data3": -265897973326004697,
+      "Data4": 6640680423206462829
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Web.ErrorBoundary.ErrorContent",
@@ -5817,7 +5581,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.ErrorBoundary.ErrorContent.Context",
@@ -5843,10 +5606,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4513947692556941465,
-      "Data2": 5506766730592619299,
-      "Data3": 58899035330653046,
-      "Data4": -4875340000723879674
+      "Data1": 3000838120951935369,
+      "Data2": 8878463581630134060,
+      "Data3": -8246762925281159229,
+      "Data4": -8341490803346804126
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Web.ErrorBoundary.ErrorContent",
@@ -5862,7 +5625,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.ErrorBoundary.ErrorContent.Context",
@@ -5889,10 +5651,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3681651678190627926,
-      "Data2": -8580866191960272727,
-      "Data3": 6485903226492823851,
-      "Data4": 1341368588767960373
+      "Data1": 3782140288572079524,
+      "Data2": -1526798711660406151,
+      "Data3": -7836000540424434379,
+      "Data4": -2854510414499923441
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>",
@@ -5907,7 +5669,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TItem",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.TItem",
@@ -5925,7 +5686,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<TItem>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<TItem> Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.ChildContent",
@@ -5938,7 +5698,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ItemContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<TItem>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<TItem> Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.ItemContent",
@@ -5951,7 +5710,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Placeholder",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Web.Virtualization.PlaceholderContext>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Web.Virtualization.PlaceholderContext> Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.Placeholder",
@@ -5963,7 +5721,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ItemSize",
         "TypeName": "System.Single",
         "DisplayName": "float Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.ItemSize",
@@ -5974,7 +5731,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ItemsProvider",
         "TypeName": "Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderDelegate<TItem>",
         "DisplayName": "Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderDelegate<TItem> Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.ItemsProvider",
@@ -5988,7 +5744,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Items",
         "TypeName": "System.Collections.Generic.ICollection<TItem>",
         "DisplayName": "System.Collections.Generic.ICollection<TItem> Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.Items",
@@ -6000,7 +5755,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "OverscanCount",
         "TypeName": "System.Int32",
         "DisplayName": "int Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.OverscanCount",
@@ -6011,7 +5765,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.Context",
@@ -6034,10 +5787,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2586205075779444869,
-      "Data2": -4941152039865785001,
-      "Data3": 189869701730070714,
-      "Data4": -3522210530396683919
+      "Data1": 9108165581938105417,
+      "Data2": 3252503236164306560,
+      "Data3": -1053320960960565341,
+      "Data4": -2552309721911381949
     },
     "Kind": "Components.Component",
     "Name": "Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>",
@@ -6052,7 +5805,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Component",
         "Name": "TItem",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.TItem",
@@ -6070,7 +5822,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ChildContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<TItem>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<TItem> Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.ChildContent",
@@ -6083,7 +5834,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ItemContent",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<TItem>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<TItem> Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.ItemContent",
@@ -6096,7 +5846,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Placeholder",
         "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Web.Virtualization.PlaceholderContext>",
         "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Web.Virtualization.PlaceholderContext> Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.Placeholder",
@@ -6108,7 +5857,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ItemSize",
         "TypeName": "System.Single",
         "DisplayName": "float Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.ItemSize",
@@ -6119,7 +5867,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "ItemsProvider",
         "TypeName": "Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderDelegate<TItem>",
         "DisplayName": "Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderDelegate<TItem> Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.ItemsProvider",
@@ -6133,7 +5880,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Items",
         "TypeName": "System.Collections.Generic.ICollection<TItem>",
         "DisplayName": "System.Collections.Generic.ICollection<TItem> Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.Items",
@@ -6145,7 +5891,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "OverscanCount",
         "TypeName": "System.Int32",
         "DisplayName": "int Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.OverscanCount",
@@ -6156,7 +5901,6 @@
         }
       },
       {
-        "Kind": "Components.Component",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.Context",
@@ -6180,10 +5924,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4027964292680823987,
-      "Data2": 3974005073829405726,
-      "Data3": -7657880675495470420,
-      "Data4": -956985580441269397
+      "Data1": 1955150872222979426,
+      "Data2": -6696453347077526393,
+      "Data3": -3071840023513935804,
+      "Data4": -1744459278756944883
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.ChildContent",
@@ -6199,7 +5943,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.ChildContent.Context",
@@ -6225,10 +5968,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6871186772144139341,
-      "Data2": -8601975393708269847,
-      "Data3": -2713930677707310714,
-      "Data4": -4070839205329473916
+      "Data1": -6853599835616678186,
+      "Data2": -5419719838223581307,
+      "Data3": -8860331648724162114,
+      "Data4": -6982221888949101691
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.ChildContent",
@@ -6244,7 +5987,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.ChildContent.Context",
@@ -6271,10 +6013,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4142771421165254483,
-      "Data2": 8761630999637721741,
-      "Data3": -4101865705450619985,
-      "Data4": -1734775619149773112
+      "Data1": 7789617679932160676,
+      "Data2": 2686884177646469541,
+      "Data3": -6957574851986820374,
+      "Data4": -1543023968280958030
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.ItemContent",
@@ -6290,7 +6032,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.ItemContent.Context",
@@ -6316,10 +6057,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8332850925818767768,
-      "Data2": -6134036516721835209,
-      "Data3": -2474637664612969283,
-      "Data4": 1818530609925179876
+      "Data1": -7548091642035492805,
+      "Data2": 7107329874114005981,
+      "Data3": 5977851095977904138,
+      "Data4": -3996813976112089928
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.ItemContent",
@@ -6335,7 +6076,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.ItemContent.Context",
@@ -6362,10 +6102,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 225841614895279300,
-      "Data2": -536324825955586340,
-      "Data3": 3217746200518935606,
-      "Data4": -5047897611996435442
+      "Data1": -863693222368636936,
+      "Data2": 1247856828227029100,
+      "Data3": -242193873145712919,
+      "Data4": -445524591387854149
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.Placeholder",
@@ -6381,7 +6121,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.Placeholder.Context",
@@ -6407,10 +6146,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 652657129004374084,
-      "Data2": 3384095448265786142,
-      "Data3": 815342030637094586,
-      "Data4": 1446427640863059907
+      "Data1": 4433745718686033174,
+      "Data2": 4457753751063089675,
+      "Data3": -1807156716181855382,
+      "Data4": 5342590456237836048
     },
     "Kind": "Components.ChildContent",
     "Name": "Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.Placeholder",
@@ -6426,7 +6165,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.ChildContent",
         "Name": "Context",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.Placeholder.Context",
@@ -6504,10 +6242,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5351300379667848409,
-      "Data2": -1461512055425147285,
-      "Data3": 3136611176404308644,
-      "Data4": -3432168561438087691
+      "Data1": 6047026887317017772,
+      "Data2": -4508084249633088946,
+      "Data3": -5927311961329022405,
+      "Data4": 9035981505318525756
     },
     "Kind": "Components.EventHandler",
     "Name": "onfocus",
@@ -6561,7 +6299,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onfocus",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.FocusEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.FocusEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onfocus",
@@ -6574,7 +6311,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -6589,7 +6325,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -6623,10 +6358,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -615547795233809783,
-      "Data2": 3987041314292262575,
-      "Data3": -3318050046796264542,
-      "Data4": -73098373540379624
+      "Data1": 7332788971497905640,
+      "Data2": -8541963829760085535,
+      "Data3": 1430468808176028699,
+      "Data4": 1419625672529866908
     },
     "Kind": "Components.EventHandler",
     "Name": "onblur",
@@ -6680,7 +6415,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onblur",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.FocusEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.FocusEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onblur",
@@ -6693,7 +6427,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -6708,7 +6441,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -6742,10 +6474,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 117954352140851134,
-      "Data2": -188410966897241029,
-      "Data3": -8650797257680801674,
-      "Data4": 5288100060005991965
+      "Data1": -5781133336234525322,
+      "Data2": 3719151934547428160,
+      "Data3": 5406025833203121897,
+      "Data4": -1476178686617567973
     },
     "Kind": "Components.EventHandler",
     "Name": "onfocusin",
@@ -6799,7 +6531,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onfocusin",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.FocusEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.FocusEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onfocusin",
@@ -6812,7 +6543,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -6827,7 +6557,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -6861,10 +6590,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7377010514070621156,
-      "Data2": 5634975098078865878,
-      "Data3": -8611246014870660249,
-      "Data4": -6753028966613548978
+      "Data1": -1693134630263997206,
+      "Data2": -533288755180455703,
+      "Data3": 2719322161973441581,
+      "Data4": 5318341378063528532
     },
     "Kind": "Components.EventHandler",
     "Name": "onfocusout",
@@ -6918,7 +6647,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onfocusout",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.FocusEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.FocusEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onfocusout",
@@ -6931,7 +6659,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -6946,7 +6673,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -6980,10 +6706,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2073978050323080834,
-      "Data2": -7848475563703445214,
-      "Data3": -3801559739119536839,
-      "Data4": -4837685906092313132
+      "Data1": -2607626939905438992,
+      "Data2": -1036478999287336737,
+      "Data3": 8144846070015279171,
+      "Data4": -6084546997573366169
     },
     "Kind": "Components.EventHandler",
     "Name": "onmouseover",
@@ -7037,7 +6763,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onmouseover",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onmouseover",
@@ -7050,7 +6775,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -7065,7 +6789,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -7099,10 +6822,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6464840731937542928,
-      "Data2": -1419769325375941523,
-      "Data3": 2598317926684901998,
-      "Data4": -7121098715144903875
+      "Data1": 2496264225608889538,
+      "Data2": 1835166405042331793,
+      "Data3": -2805646357002840381,
+      "Data4": -3740422317011027010
     },
     "Kind": "Components.EventHandler",
     "Name": "onmouseout",
@@ -7156,7 +6879,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onmouseout",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onmouseout",
@@ -7169,7 +6891,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -7184,7 +6905,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -7218,10 +6938,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6447007615837883898,
-      "Data2": 6295133039209319388,
-      "Data3": -7561802739044143393,
-      "Data4": -8375984156534524762
+      "Data1": 2665527030597264325,
+      "Data2": 442339100000135636,
+      "Data3": 7742313068710279026,
+      "Data4": -4554407899484104843
     },
     "Kind": "Components.EventHandler",
     "Name": "onmousemove",
@@ -7275,7 +6995,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onmousemove",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onmousemove",
@@ -7288,7 +7007,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -7303,7 +7021,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -7337,10 +7054,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3211808323951221318,
-      "Data2": -5473721555806551009,
-      "Data3": -869745075687316122,
-      "Data4": -2379119347131222078
+      "Data1": -3245687421161492477,
+      "Data2": 481036742404428755,
+      "Data3": -8499383570115558517,
+      "Data4": -4009137393771576123
     },
     "Kind": "Components.EventHandler",
     "Name": "onmousedown",
@@ -7394,7 +7111,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onmousedown",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onmousedown",
@@ -7407,7 +7123,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -7422,7 +7137,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -7456,10 +7170,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 497316606846678183,
-      "Data2": -1424313457203621544,
-      "Data3": 5663418385266105551,
-      "Data4": 2568333417120066574
+      "Data1": 6811149048034138543,
+      "Data2": 9055346314194565790,
+      "Data3": 6218743337272204781,
+      "Data4": 494487771164003491
     },
     "Kind": "Components.EventHandler",
     "Name": "onmouseup",
@@ -7513,7 +7227,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onmouseup",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onmouseup",
@@ -7526,7 +7239,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -7541,7 +7253,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -7575,10 +7286,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4359424368639693710,
-      "Data2": 4474829667136509025,
-      "Data3": 4627659280900147474,
-      "Data4": -3947012987463314147
+      "Data1": -5216193914736213729,
+      "Data2": 7300246371238740720,
+      "Data3": -323831195702061987,
+      "Data4": -5814794816245574342
     },
     "Kind": "Components.EventHandler",
     "Name": "onclick",
@@ -7632,7 +7343,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onclick",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onclick",
@@ -7645,7 +7355,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -7660,7 +7369,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -7694,10 +7402,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8245537782336108601,
-      "Data2": 5489488771500653639,
-      "Data3": -5955759002153749172,
-      "Data4": -5193149686862079176
+      "Data1": 6968566271842145395,
+      "Data2": -17883870018577415,
+      "Data3": 208023758140888935,
+      "Data4": 2290473049761130632
     },
     "Kind": "Components.EventHandler",
     "Name": "ondblclick",
@@ -7751,7 +7459,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@ondblclick",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ondblclick",
@@ -7764,7 +7471,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -7779,7 +7485,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -7813,10 +7518,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7704857524007596994,
-      "Data2": -3682413880850059948,
-      "Data3": -8362240684847056848,
-      "Data4": 178582981266851200
+      "Data1": -6832266313703754952,
+      "Data2": 8424878414357466395,
+      "Data3": -3630942783497325528,
+      "Data4": -8688959150094885914
     },
     "Kind": "Components.EventHandler",
     "Name": "onwheel",
@@ -7870,7 +7575,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onwheel",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.WheelEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.WheelEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onwheel",
@@ -7883,7 +7587,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -7898,7 +7601,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -7932,10 +7634,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3211048839862926622,
-      "Data2": 5766766204462751207,
-      "Data3": 1455838567865416223,
-      "Data4": -3183881831437734183
+      "Data1": 4728781118904122511,
+      "Data2": -1283512924236747993,
+      "Data3": -3466031805110974420,
+      "Data4": 5339080886917887668
     },
     "Kind": "Components.EventHandler",
     "Name": "onmousewheel",
@@ -7989,7 +7691,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onmousewheel",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.WheelEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.WheelEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onmousewheel",
@@ -8002,7 +7703,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -8017,7 +7717,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -8051,10 +7750,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2873997378438397831,
-      "Data2": -7204485881285791939,
-      "Data3": -2367440257779926811,
-      "Data4": -6354207022227490185
+      "Data1": 8023485693772935410,
+      "Data2": -1364693856223591523,
+      "Data3": -1379191194653808512,
+      "Data4": 7011513567773879467
     },
     "Kind": "Components.EventHandler",
     "Name": "oncontextmenu",
@@ -8108,7 +7807,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@oncontextmenu",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.oncontextmenu",
@@ -8121,7 +7819,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -8136,7 +7833,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -8170,10 +7866,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4194996018436823764,
-      "Data2": 6596247298540496881,
-      "Data3": 6473860952812161882,
-      "Data4": -1812272783021600087
+      "Data1": -2181225571089942960,
+      "Data2": 8259409794359197167,
+      "Data3": 3031186878260122362,
+      "Data4": 5383033199240539373
     },
     "Kind": "Components.EventHandler",
     "Name": "ondrag",
@@ -8227,7 +7923,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@ondrag",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ondrag",
@@ -8240,7 +7935,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -8255,7 +7949,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -8289,10 +7982,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1146568475308170183,
-      "Data2": -7480557993098715235,
-      "Data3": -7884567469172956231,
-      "Data4": -1240271150577497083
+      "Data1": -4811802129701968717,
+      "Data2": -4681333014681454993,
+      "Data3": 4456880278066877224,
+      "Data4": -9006292183047762700
     },
     "Kind": "Components.EventHandler",
     "Name": "ondragend",
@@ -8346,7 +8039,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@ondragend",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ondragend",
@@ -8359,7 +8051,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -8374,7 +8065,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -8408,10 +8098,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3925612309087041417,
-      "Data2": 4439275886204180910,
-      "Data3": -3075664218466495482,
-      "Data4": 5242536124103466756
+      "Data1": -6654574822456750620,
+      "Data2": 8046154493035059423,
+      "Data3": -3112448663427061050,
+      "Data4": 5399061999628553092
     },
     "Kind": "Components.EventHandler",
     "Name": "ondragenter",
@@ -8465,7 +8155,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@ondragenter",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ondragenter",
@@ -8478,7 +8167,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -8493,7 +8181,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -8527,10 +8214,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2553772456952153556,
-      "Data2": 7432648664730872675,
-      "Data3": 1896825466928915981,
-      "Data4": -3387763131690108163
+      "Data1": -1577873322971605981,
+      "Data2": -2169806260402290491,
+      "Data3": -6410392401845890237,
+      "Data4": -2951589261288399266
     },
     "Kind": "Components.EventHandler",
     "Name": "ondragleave",
@@ -8584,7 +8271,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@ondragleave",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ondragleave",
@@ -8597,7 +8283,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -8612,7 +8297,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -8646,10 +8330,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8350824022229549553,
-      "Data2": 8001515432653245799,
-      "Data3": -5843552528502240905,
-      "Data4": -4404123900256168657
+      "Data1": -2608174897690276432,
+      "Data2": 2038599822250087783,
+      "Data3": 3254757248611194109,
+      "Data4": 2243603005428566409
     },
     "Kind": "Components.EventHandler",
     "Name": "ondragover",
@@ -8703,7 +8387,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@ondragover",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ondragover",
@@ -8716,7 +8399,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -8731,7 +8413,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -8765,10 +8446,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7591640687483059320,
-      "Data2": 5936061562286176089,
-      "Data3": -5356648448836853347,
-      "Data4": 8030520875750672311
+      "Data1": -6094446339351077495,
+      "Data2": -8160353778039689611,
+      "Data3": -3485188431078549341,
+      "Data4": 8855134020084022660
     },
     "Kind": "Components.EventHandler",
     "Name": "ondragstart",
@@ -8822,7 +8503,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@ondragstart",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ondragstart",
@@ -8835,7 +8515,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -8850,7 +8529,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -8884,10 +8562,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 274486520224370270,
-      "Data2": 289651982307389251,
-      "Data3": -902327893590679537,
-      "Data4": 2912656876688575099
+      "Data1": 6768543876078749417,
+      "Data2": -7653673437507506953,
+      "Data3": 3832452929334985725,
+      "Data4": -8024435062539759732
     },
     "Kind": "Components.EventHandler",
     "Name": "ondrop",
@@ -8941,7 +8619,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@ondrop",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ondrop",
@@ -8954,7 +8631,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -8969,7 +8645,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -9003,10 +8678,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5004801748082106616,
-      "Data2": 6793467452384071653,
-      "Data3": -2368494026413543095,
-      "Data4": 2901474569640951908
+      "Data1": -904106963592523608,
+      "Data2": -2479391200992788997,
+      "Data3": -3125341680503857394,
+      "Data4": -4495946951115286801
     },
     "Kind": "Components.EventHandler",
     "Name": "onkeydown",
@@ -9060,7 +8735,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onkeydown",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.KeyboardEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.KeyboardEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onkeydown",
@@ -9073,7 +8747,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -9088,7 +8761,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -9122,10 +8794,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2743975341354322875,
-      "Data2": 8724663952781465005,
-      "Data3": -5868229869244622691,
-      "Data4": 321559815815692679
+      "Data1": -2762540601503860190,
+      "Data2": 6537596651685718742,
+      "Data3": -4968777981327903699,
+      "Data4": 5445638825637714351
     },
     "Kind": "Components.EventHandler",
     "Name": "onkeyup",
@@ -9179,7 +8851,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onkeyup",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.KeyboardEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.KeyboardEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onkeyup",
@@ -9192,7 +8863,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -9207,7 +8877,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -9241,10 +8910,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 802343072890082968,
-      "Data2": 2158998876898196197,
-      "Data3": 833446023029685726,
-      "Data4": 8290429553499204194
+      "Data1": -3150386372233545282,
+      "Data2": 3872706444740851607,
+      "Data3": -5003909694691906593,
+      "Data4": 2767105148129643530
     },
     "Kind": "Components.EventHandler",
     "Name": "onkeypress",
@@ -9298,7 +8967,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onkeypress",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.KeyboardEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.KeyboardEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onkeypress",
@@ -9311,7 +8979,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -9326,7 +8993,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -9360,10 +9026,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -962933332690981818,
-      "Data2": 6729191155144550467,
-      "Data3": -7957713024911070146,
-      "Data4": -3829955028153489269
+      "Data1": -5739078806659387639,
+      "Data2": 6990517037142761482,
+      "Data3": 3255874663260615120,
+      "Data4": -536866768904251924
     },
     "Kind": "Components.EventHandler",
     "Name": "onchange",
@@ -9417,7 +9083,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onchange",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onchange",
@@ -9430,7 +9095,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -9445,7 +9109,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -9479,10 +9142,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5601757914301694318,
-      "Data2": 2784484491800823086,
-      "Data3": 6063991173134626481,
-      "Data4": -2800420576948050377
+      "Data1": 20872680784986129,
+      "Data2": -1280628360868871018,
+      "Data3": 4599508431640933635,
+      "Data4": 5310881484231576393
     },
     "Kind": "Components.EventHandler",
     "Name": "oninput",
@@ -9536,7 +9199,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@oninput",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.oninput",
@@ -9549,7 +9211,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -9564,7 +9225,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -9598,10 +9258,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8127799217406725838,
-      "Data2": 1477472712683714997,
-      "Data3": -652080936231482559,
-      "Data4": 1198986255414282004
+      "Data1": -2398474118270879716,
+      "Data2": 1941517868360774955,
+      "Data3": 6049640605823773064,
+      "Data4": 884354251738426809
     },
     "Kind": "Components.EventHandler",
     "Name": "oninvalid",
@@ -9655,7 +9315,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@oninvalid",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.oninvalid",
@@ -9668,7 +9327,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -9683,7 +9341,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -9717,10 +9374,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1709328709107585860,
-      "Data2": 9173563480165795352,
-      "Data3": -2031898660102378722,
-      "Data4": -8801613372658974643
+      "Data1": -2354917177562196159,
+      "Data2": -3044088487990651744,
+      "Data3": 8886614317634031584,
+      "Data4": -4727253319280409082
     },
     "Kind": "Components.EventHandler",
     "Name": "onreset",
@@ -9774,7 +9431,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onreset",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onreset",
@@ -9787,7 +9443,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -9802,7 +9457,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -9836,10 +9490,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 949091261908421142,
-      "Data2": 5425560699961372779,
-      "Data3": -5324543913855361470,
-      "Data4": 2496205306346953971
+      "Data1": -1058526240597162816,
+      "Data2": 532131020924320221,
+      "Data3": 1602963208656305535,
+      "Data4": 1088787240367428204
     },
     "Kind": "Components.EventHandler",
     "Name": "onselect",
@@ -9893,7 +9547,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onselect",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onselect",
@@ -9906,7 +9559,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -9921,7 +9573,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -9955,10 +9606,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7941208173584087691,
-      "Data2": -2717643351583685229,
-      "Data3": -4670799730269417240,
-      "Data4": -171305483809261515
+      "Data1": 3093537362408529852,
+      "Data2": -6813613706441731119,
+      "Data3": 5163333025208264432,
+      "Data4": 2321339005933797191
     },
     "Kind": "Components.EventHandler",
     "Name": "onselectstart",
@@ -10012,7 +9663,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onselectstart",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onselectstart",
@@ -10025,7 +9675,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -10040,7 +9689,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -10074,10 +9722,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2425429935029991286,
-      "Data2": -7622567107885912864,
-      "Data3": -982853318250532356,
-      "Data4": -194766976894382777
+      "Data1": -6247529119239298926,
+      "Data2": -4063912787643106663,
+      "Data3": 2756237083891577198,
+      "Data4": 6432983232027926564
     },
     "Kind": "Components.EventHandler",
     "Name": "onselectionchange",
@@ -10131,7 +9779,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onselectionchange",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onselectionchange",
@@ -10144,7 +9791,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -10159,7 +9805,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -10193,10 +9838,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5765889314039560124,
-      "Data2": -8854222768188706736,
-      "Data3": 5894529864546343019,
-      "Data4": -8551892886412886687
+      "Data1": 5544819165240136666,
+      "Data2": -7799328468831322369,
+      "Data3": 4122373302443374790,
+      "Data4": -3513063458097030914
     },
     "Kind": "Components.EventHandler",
     "Name": "onsubmit",
@@ -10250,7 +9895,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onsubmit",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onsubmit",
@@ -10263,7 +9907,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -10278,7 +9921,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -10312,10 +9954,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5179223059066885950,
-      "Data2": -7078430271468979316,
-      "Data3": -3658175840511546241,
-      "Data4": -4952787210502332682
+      "Data1": 5290056762375420873,
+      "Data2": -419029537866716364,
+      "Data3": -2345555909528925902,
+      "Data4": 5919307106818556317
     },
     "Kind": "Components.EventHandler",
     "Name": "onbeforecopy",
@@ -10369,7 +10011,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onbeforecopy",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onbeforecopy",
@@ -10382,7 +10023,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -10397,7 +10037,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -10431,10 +10070,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2615683460735417797,
-      "Data2": -5398960593294972731,
-      "Data3": 1255193079180842873,
-      "Data4": 3948053283530260883
+      "Data1": 4761396429330858649,
+      "Data2": -1598036257954584694,
+      "Data3": -5117456029749091660,
+      "Data4": 6309486742728624793
     },
     "Kind": "Components.EventHandler",
     "Name": "onbeforecut",
@@ -10488,7 +10127,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onbeforecut",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onbeforecut",
@@ -10501,7 +10139,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -10516,7 +10153,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -10550,10 +10186,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5138802839706601204,
-      "Data2": -4224295188898362120,
-      "Data3": -6863510088215784061,
-      "Data4": 4297732834923304896
+      "Data1": 1029372928366886531,
+      "Data2": 8104661957776323837,
+      "Data3": 1509677230915956677,
+      "Data4": -6355782764987233093
     },
     "Kind": "Components.EventHandler",
     "Name": "onbeforepaste",
@@ -10607,7 +10243,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onbeforepaste",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onbeforepaste",
@@ -10620,7 +10255,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -10635,7 +10269,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -10669,10 +10302,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3340737132851683938,
-      "Data2": 8990707703276882902,
-      "Data3": 240346875832336953,
-      "Data4": 4109991562008650336
+      "Data1": -7705251047584511333,
+      "Data2": 8002701997274286947,
+      "Data3": -1676600895832769461,
+      "Data4": 2245694104751163838
     },
     "Kind": "Components.EventHandler",
     "Name": "oncopy",
@@ -10726,7 +10359,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@oncopy",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ClipboardEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ClipboardEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.oncopy",
@@ -10739,7 +10371,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -10754,7 +10385,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -10788,10 +10418,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2997485877502562809,
-      "Data2": -8883963797227328277,
-      "Data3": 6726575553017488568,
-      "Data4": -5121622411964113444
+      "Data1": -7416992712423089233,
+      "Data2": 4449370565921709650,
+      "Data3": -6437785349582923886,
+      "Data4": -2801190639824190532
     },
     "Kind": "Components.EventHandler",
     "Name": "oncut",
@@ -10845,7 +10475,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@oncut",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ClipboardEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ClipboardEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.oncut",
@@ -10858,7 +10487,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -10873,7 +10501,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -10907,10 +10534,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 9208346134344975056,
-      "Data2": 8958622337690106913,
-      "Data3": 1465641255840392265,
-      "Data4": 2575712874589609095
+      "Data1": 1330559035022496075,
+      "Data2": -4460978051811237857,
+      "Data3": 4695250384772663299,
+      "Data4": -7717757570830372855
     },
     "Kind": "Components.EventHandler",
     "Name": "onpaste",
@@ -10964,7 +10591,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onpaste",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ClipboardEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ClipboardEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onpaste",
@@ -10977,7 +10603,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -10992,7 +10617,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -11026,10 +10650,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -533615659397593537,
-      "Data2": -630860927965330819,
-      "Data3": -6342670562823535960,
-      "Data4": 3835064171110204950
+      "Data1": -5305018988864397513,
+      "Data2": -7056861188320643127,
+      "Data3": 4138462206631949520,
+      "Data4": 1287681477163409205
     },
     "Kind": "Components.EventHandler",
     "Name": "ontouchcancel",
@@ -11083,7 +10707,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@ontouchcancel",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ontouchcancel",
@@ -11096,7 +10719,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -11111,7 +10733,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -11145,10 +10766,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5093295676287565708,
-      "Data2": -1179906617383907570,
-      "Data3": -6729693933840363053,
-      "Data4": -329869676945505153
+      "Data1": 564116037820298704,
+      "Data2": -1057279746178053957,
+      "Data3": 9014585644924556968,
+      "Data4": -387530969364403907
     },
     "Kind": "Components.EventHandler",
     "Name": "ontouchend",
@@ -11202,7 +10823,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@ontouchend",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ontouchend",
@@ -11215,7 +10835,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -11230,7 +10849,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -11264,10 +10882,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3732735953292616174,
-      "Data2": -4024204819204617893,
-      "Data3": 7449402514623180422,
-      "Data4": -8015932370286930950
+      "Data1": -8675233277290799136,
+      "Data2": -5643826883035093936,
+      "Data3": -6576035289012049613,
+      "Data4": -8251539618503399646
     },
     "Kind": "Components.EventHandler",
     "Name": "ontouchmove",
@@ -11321,7 +10939,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@ontouchmove",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ontouchmove",
@@ -11334,7 +10951,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -11349,7 +10965,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -11383,10 +10998,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2802664826483113274,
-      "Data2": -1882703497726176658,
-      "Data3": 429163152994320840,
-      "Data4": 1822645448401442679
+      "Data1": -3443756728771598432,
+      "Data2": 2835526665684590414,
+      "Data3": 8274112597837107412,
+      "Data4": 9084919052569765732
     },
     "Kind": "Components.EventHandler",
     "Name": "ontouchstart",
@@ -11440,7 +11055,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@ontouchstart",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ontouchstart",
@@ -11453,7 +11067,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -11468,7 +11081,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -11502,10 +11114,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2257414082075030065,
-      "Data2": -8275191628919111620,
-      "Data3": 8256191097129305461,
-      "Data4": -7987934691122664025
+      "Data1": 6827428511433383785,
+      "Data2": 4880809401438293803,
+      "Data3": -6694443512408380021,
+      "Data4": -2704006860198456434
     },
     "Kind": "Components.EventHandler",
     "Name": "ontouchenter",
@@ -11559,7 +11171,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@ontouchenter",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ontouchenter",
@@ -11572,7 +11183,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -11587,7 +11197,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -11621,10 +11230,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 9215581793582197344,
-      "Data2": 505277034879344089,
-      "Data3": 2026500637878686356,
-      "Data4": -528669526665491261
+      "Data1": 1680911349423367456,
+      "Data2": -304063173116270662,
+      "Data3": -379129983034387056,
+      "Data4": 81003187346916834
     },
     "Kind": "Components.EventHandler",
     "Name": "ontouchleave",
@@ -11678,7 +11287,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@ontouchleave",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ontouchleave",
@@ -11691,7 +11299,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -11706,7 +11313,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -11740,10 +11346,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1104148711772645567,
-      "Data2": -5609622526099218408,
-      "Data3": 7858395960972841108,
-      "Data4": -755862997088296235
+      "Data1": 3425892492955859449,
+      "Data2": -580168571579207205,
+      "Data3": 7599035357894044036,
+      "Data4": 679416671753898484
     },
     "Kind": "Components.EventHandler",
     "Name": "ongotpointercapture",
@@ -11797,7 +11403,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@ongotpointercapture",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ongotpointercapture",
@@ -11810,7 +11415,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -11825,7 +11429,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -11859,10 +11462,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3616381731847356554,
-      "Data2": 4850697250368039413,
-      "Data3": 6711913271392752512,
-      "Data4": 4506212933615135472
+      "Data1": -4474978641456041565,
+      "Data2": -5110195079129352476,
+      "Data3": -4645550538575791547,
+      "Data4": -6291765634598000623
     },
     "Kind": "Components.EventHandler",
     "Name": "onlostpointercapture",
@@ -11916,7 +11519,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onlostpointercapture",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onlostpointercapture",
@@ -11929,7 +11531,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -11944,7 +11545,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -11978,10 +11578,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1732289724498454843,
-      "Data2": 3872968259012210384,
-      "Data3": -5406233438985367850,
-      "Data4": -5945371242466138562
+      "Data1": 1379338898289528175,
+      "Data2": 2585187423364263082,
+      "Data3": -6325028203201766155,
+      "Data4": -6309337970068528705
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointercancel",
@@ -12035,7 +11635,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onpointercancel",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onpointercancel",
@@ -12048,7 +11647,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -12063,7 +11661,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -12097,10 +11694,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6999307024462496915,
-      "Data2": 8412775557398951450,
-      "Data3": -6757802248086834514,
-      "Data4": 5484298787091916676
+      "Data1": -2553259661874421168,
+      "Data2": -4493759146170282767,
+      "Data3": -4168597998860204671,
+      "Data4": -4969987990483598350
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointerdown",
@@ -12154,7 +11751,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onpointerdown",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onpointerdown",
@@ -12167,7 +11763,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -12182,7 +11777,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -12216,10 +11810,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4543223893398994025,
-      "Data2": -5869776523767665255,
-      "Data3": -2616588965630736129,
-      "Data4": -4797143221281967317
+      "Data1": 2700463498781894171,
+      "Data2": -6602539361139634558,
+      "Data3": 7558205690610402624,
+      "Data4": 2496123374629508907
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointerenter",
@@ -12273,7 +11867,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onpointerenter",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onpointerenter",
@@ -12286,7 +11879,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -12301,7 +11893,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -12335,10 +11926,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2112826889462271447,
-      "Data2": 8668766176168878442,
-      "Data3": 8834495388431050581,
-      "Data4": -8996097830483353942
+      "Data1": 5539970425595830600,
+      "Data2": 7021769284836871079,
+      "Data3": 7611456839823976789,
+      "Data4": -5944920644924701866
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointerleave",
@@ -12392,7 +11983,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onpointerleave",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onpointerleave",
@@ -12405,7 +11995,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -12420,7 +12009,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -12454,10 +12042,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 936591815786186805,
-      "Data2": -6699711567892676748,
-      "Data3": -8631966015933168351,
-      "Data4": -3979948168318013642
+      "Data1": -711564165081807438,
+      "Data2": 4520308147072737518,
+      "Data3": 5103176159753468431,
+      "Data4": 4251400873142575344
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointermove",
@@ -12511,7 +12099,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onpointermove",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onpointermove",
@@ -12524,7 +12111,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -12539,7 +12125,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -12573,10 +12158,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3087444779371249221,
-      "Data2": 8382504798981898589,
-      "Data3": 547023768829580388,
-      "Data4": 4361500619069694134
+      "Data1": 1001738969538072012,
+      "Data2": -5378665257954222229,
+      "Data3": -136768412375561435,
+      "Data4": -7659708495786581435
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointerout",
@@ -12630,7 +12215,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onpointerout",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onpointerout",
@@ -12643,7 +12227,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -12658,7 +12241,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -12692,10 +12274,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7839879209437779748,
-      "Data2": -1822601981837070874,
-      "Data3": 6366559709346712812,
-      "Data4": -2610441297820476321
+      "Data1": 2031745077191260163,
+      "Data2": 2836951590382653926,
+      "Data3": 106896774618161384,
+      "Data4": -1429047874143825742
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointerover",
@@ -12749,7 +12331,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onpointerover",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onpointerover",
@@ -12762,7 +12343,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -12777,7 +12357,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -12811,10 +12390,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3500402837723948198,
-      "Data2": -8610770318445689803,
-      "Data3": 1063723547803923827,
-      "Data4": 85285834336375616
+      "Data1": 6117797937985479587,
+      "Data2": 1424717631174450395,
+      "Data3": -8923540287425087243,
+      "Data4": 8680250377133975669
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointerup",
@@ -12868,7 +12447,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onpointerup",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onpointerup",
@@ -12881,7 +12459,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -12896,7 +12473,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -12930,10 +12506,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7712612098112485659,
-      "Data2": -5850226865480675892,
-      "Data3": -7643191267657884306,
-      "Data4": 149527134745516907
+      "Data1": -259997514739446311,
+      "Data2": -3949862888780372812,
+      "Data3": -1971540590833930834,
+      "Data4": -4446709509104956028
     },
     "Kind": "Components.EventHandler",
     "Name": "oncanplay",
@@ -12987,7 +12563,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@oncanplay",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.oncanplay",
@@ -13000,7 +12575,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -13015,7 +12589,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -13049,10 +12622,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8159778931361874412,
-      "Data2": 3545588800470870248,
-      "Data3": -3657378793962418553,
-      "Data4": 1472776023955399652
+      "Data1": 3415187253573544380,
+      "Data2": 1357066540771817265,
+      "Data3": 1192668042235496698,
+      "Data4": 3365234440120081810
     },
     "Kind": "Components.EventHandler",
     "Name": "oncanplaythrough",
@@ -13106,7 +12679,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@oncanplaythrough",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.oncanplaythrough",
@@ -13119,7 +12691,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -13134,7 +12705,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -13168,10 +12738,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8679639972946391461,
-      "Data2": 6613563368606417780,
-      "Data3": -3868940928223982705,
-      "Data4": 2046326155799651880
+      "Data1": -6859297001923222178,
+      "Data2": 3763702373718469321,
+      "Data3": -6884798471578659041,
+      "Data4": -2690915798969206765
     },
     "Kind": "Components.EventHandler",
     "Name": "oncuechange",
@@ -13225,7 +12795,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@oncuechange",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.oncuechange",
@@ -13238,7 +12807,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -13253,7 +12821,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -13287,10 +12854,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 297825506464903212,
-      "Data2": 7223634705880556494,
-      "Data3": 8099899704402567631,
-      "Data4": 4471915895687962482
+      "Data1": 5748964994866444353,
+      "Data2": 289142820514211902,
+      "Data3": 1928142390738088083,
+      "Data4": -896830889325628076
     },
     "Kind": "Components.EventHandler",
     "Name": "ondurationchange",
@@ -13344,7 +12911,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@ondurationchange",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ondurationchange",
@@ -13357,7 +12923,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -13372,7 +12937,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -13406,10 +12970,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4993706230146446469,
-      "Data2": -7151492966260145558,
-      "Data3": 1959208296726526326,
-      "Data4": -2449506534524386672
+      "Data1": 5343605566184879157,
+      "Data2": -822614450025992430,
+      "Data3": 8858745392590378920,
+      "Data4": -3759863122199772294
     },
     "Kind": "Components.EventHandler",
     "Name": "onemptied",
@@ -13463,7 +13027,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onemptied",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onemptied",
@@ -13476,7 +13039,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -13491,7 +13053,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -13525,10 +13086,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1832072026291605495,
-      "Data2": 1272460451920667759,
-      "Data3": -666057469639937878,
-      "Data4": -2356273857280572653
+      "Data1": 7587005031887781748,
+      "Data2": -6184883583454133435,
+      "Data3": -2165535750005891386,
+      "Data4": 6217643653631035442
     },
     "Kind": "Components.EventHandler",
     "Name": "onpause",
@@ -13582,7 +13143,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onpause",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onpause",
@@ -13595,7 +13155,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -13610,7 +13169,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -13644,10 +13202,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2344908307903121946,
-      "Data2": 5688680462156281571,
-      "Data3": 4153143221703987068,
-      "Data4": 5980063120226327172
+      "Data1": -16286162747959751,
+      "Data2": -333266593655239970,
+      "Data3": -102706316696374390,
+      "Data4": -5520149497265258515
     },
     "Kind": "Components.EventHandler",
     "Name": "onplay",
@@ -13701,7 +13259,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onplay",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onplay",
@@ -13714,7 +13271,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -13729,7 +13285,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -13763,10 +13318,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5164677581748914877,
-      "Data2": 6129985961945773657,
-      "Data3": 3572225713192007717,
-      "Data4": 8196921868550740012
+      "Data1": -8529626627709558402,
+      "Data2": 8502471872827500829,
+      "Data3": 112137623713716468,
+      "Data4": 8107506951097989756
     },
     "Kind": "Components.EventHandler",
     "Name": "onplaying",
@@ -13820,7 +13375,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onplaying",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onplaying",
@@ -13833,7 +13387,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -13848,7 +13401,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -13882,10 +13434,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7449447492587767594,
-      "Data2": 5672226485940186441,
-      "Data3": -2103550131030507155,
-      "Data4": -5771502977679369180
+      "Data1": -2243716971781356261,
+      "Data2": -2243486428670620248,
+      "Data3": 5247634082025144206,
+      "Data4": 6442960578843050166
     },
     "Kind": "Components.EventHandler",
     "Name": "onratechange",
@@ -13939,7 +13491,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onratechange",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onratechange",
@@ -13952,7 +13503,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -13967,7 +13517,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -14001,10 +13550,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7279312515272354377,
-      "Data2": 5233016119824288201,
-      "Data3": -4665765354757752375,
-      "Data4": 2547700041597212943
+      "Data1": -7383429162636503294,
+      "Data2": -9136049703297292967,
+      "Data3": -1049917215045597375,
+      "Data4": -6144955766809190361
     },
     "Kind": "Components.EventHandler",
     "Name": "onseeked",
@@ -14058,7 +13607,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onseeked",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onseeked",
@@ -14071,7 +13619,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -14086,7 +13633,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -14120,10 +13666,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1952784752678637027,
-      "Data2": 1019115943905989462,
-      "Data3": -8461891447316179568,
-      "Data4": -1108571293447082526
+      "Data1": -7994337040615910904,
+      "Data2": -5885834839292246813,
+      "Data3": 2173347610538860248,
+      "Data4": 1840799941117240830
     },
     "Kind": "Components.EventHandler",
     "Name": "onseeking",
@@ -14177,7 +13723,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onseeking",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onseeking",
@@ -14190,7 +13735,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -14205,7 +13749,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -14239,10 +13782,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3027576115421453408,
-      "Data2": 2820341636917560093,
-      "Data3": -7546633547173855554,
-      "Data4": 2963675139885053077
+      "Data1": 7623752215529251708,
+      "Data2": 823946282868141714,
+      "Data3": -6532523101154722281,
+      "Data4": 2265115827492901297
     },
     "Kind": "Components.EventHandler",
     "Name": "onstalled",
@@ -14296,7 +13839,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onstalled",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onstalled",
@@ -14309,7 +13851,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -14324,7 +13865,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -14358,10 +13898,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8257316539375507739,
-      "Data2": -6792282317226804694,
-      "Data3": 8172872579754756008,
-      "Data4": 1416453327442492752
+      "Data1": 5351662504777831591,
+      "Data2": 5536226642137423374,
+      "Data3": 3476856708771627053,
+      "Data4": 4772002411136580981
     },
     "Kind": "Components.EventHandler",
     "Name": "onstop",
@@ -14415,7 +13955,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onstop",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onstop",
@@ -14428,7 +13967,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -14443,7 +13981,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -14477,10 +14014,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2390349563020137300,
-      "Data2": -5177798761251079928,
-      "Data3": -2259967909386590283,
-      "Data4": -2279273785600325691
+      "Data1": -3773134486102041151,
+      "Data2": -5303691755979948328,
+      "Data3": -7386228779843377892,
+      "Data4": 3207053949499221222
     },
     "Kind": "Components.EventHandler",
     "Name": "onsuspend",
@@ -14534,7 +14071,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onsuspend",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onsuspend",
@@ -14547,7 +14083,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -14562,7 +14097,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -14596,10 +14130,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3418099726954178386,
-      "Data2": 3946944657901115343,
-      "Data3": -8413646243028770863,
-      "Data4": 6079205889543279796
+      "Data1": 3312210782190908774,
+      "Data2": -8588219188621407725,
+      "Data3": -8109753740969381136,
+      "Data4": -2095251202158049885
     },
     "Kind": "Components.EventHandler",
     "Name": "ontimeupdate",
@@ -14653,7 +14187,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@ontimeupdate",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ontimeupdate",
@@ -14666,7 +14199,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -14681,7 +14213,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -14715,10 +14246,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2877869097864894140,
-      "Data2": 1856388641792332033,
-      "Data3": -7718158487701466197,
-      "Data4": -567368839853880319
+      "Data1": -7305069800047749179,
+      "Data2": -5172920902383206331,
+      "Data3": 391015758867023567,
+      "Data4": 8482441857296557730
     },
     "Kind": "Components.EventHandler",
     "Name": "onvolumechange",
@@ -14772,7 +14303,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onvolumechange",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onvolumechange",
@@ -14785,7 +14315,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -14800,7 +14329,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -14834,10 +14362,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -398423572364861591,
-      "Data2": 9002504862016228878,
-      "Data3": -7470102150566355150,
-      "Data4": -5231764708719023040
+      "Data1": 593709650915600685,
+      "Data2": -307312212565857477,
+      "Data3": 6758294691376472510,
+      "Data4": -1572201468609100345
     },
     "Kind": "Components.EventHandler",
     "Name": "onwaiting",
@@ -14891,7 +14419,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onwaiting",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onwaiting",
@@ -14904,7 +14431,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -14919,7 +14445,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -14953,10 +14478,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8929827588288136093,
-      "Data2": -8400874963122735891,
-      "Data3": -4507560167268253451,
-      "Data4": -547742576928183470
+      "Data1": 7882452388634032889,
+      "Data2": -3444398838505225659,
+      "Data3": 4799736048752651083,
+      "Data4": 1874463589560151822
     },
     "Kind": "Components.EventHandler",
     "Name": "onloadstart",
@@ -15010,7 +14535,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onloadstart",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onloadstart",
@@ -15023,7 +14547,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -15038,7 +14561,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -15072,10 +14594,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5424308112065516622,
-      "Data2": 6501875278121520281,
-      "Data3": 1006203906092705174,
-      "Data4": -6440032364345164706
+      "Data1": -3208865689752618202,
+      "Data2": -6039060768647787701,
+      "Data3": -6323819805002739290,
+      "Data4": -7064853970937689756
     },
     "Kind": "Components.EventHandler",
     "Name": "ontimeout",
@@ -15129,7 +14651,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@ontimeout",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ontimeout",
@@ -15142,7 +14663,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -15157,7 +14677,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -15191,10 +14710,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7192040055529930084,
-      "Data2": 7165279519394608334,
-      "Data3": 6215195827440889398,
-      "Data4": -7740631994529642775
+      "Data1": 5517286596914179561,
+      "Data2": -230880993724126423,
+      "Data3": -4985188932476363437,
+      "Data4": -7924261506718931601
     },
     "Kind": "Components.EventHandler",
     "Name": "onabort",
@@ -15248,7 +14767,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onabort",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onabort",
@@ -15261,7 +14779,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -15276,7 +14793,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -15310,10 +14826,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4496435197070037688,
-      "Data2": 6321152213958440174,
-      "Data3": -6345685915763095713,
-      "Data4": 1736098694332016877
+      "Data1": 2640248037925490589,
+      "Data2": -389935676788374942,
+      "Data3": 7348422703346238091,
+      "Data4": 950949472204027613
     },
     "Kind": "Components.EventHandler",
     "Name": "onload",
@@ -15367,7 +14883,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onload",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onload",
@@ -15380,7 +14895,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -15395,7 +14909,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -15429,10 +14942,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3914688266671147338,
-      "Data2": 8401663220961937621,
-      "Data3": -7221942368663452904,
-      "Data4": -6853607222049204037
+      "Data1": 6361780924464596780,
+      "Data2": -1804182222262416346,
+      "Data3": 5584007445419305339,
+      "Data4": 2464241323453385090
     },
     "Kind": "Components.EventHandler",
     "Name": "onloadend",
@@ -15486,7 +14999,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onloadend",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onloadend",
@@ -15499,7 +15011,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -15514,7 +15025,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -15548,10 +15058,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1822862229016325819,
-      "Data2": 2057192743121572605,
-      "Data3": 5950369453629954220,
-      "Data4": -7426154456865412401
+      "Data1": -3987842527220306591,
+      "Data2": -6472666418911948201,
+      "Data3": 4474144720116591146,
+      "Data4": -4977092847955973775
     },
     "Kind": "Components.EventHandler",
     "Name": "onprogress",
@@ -15605,7 +15115,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onprogress",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onprogress",
@@ -15618,7 +15127,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -15633,7 +15141,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -15667,10 +15174,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -220438797101273707,
-      "Data2": -7606286464670217895,
-      "Data3": -9044736843568815986,
-      "Data4": 3177375815455335352
+      "Data1": 5480734986078559925,
+      "Data2": -9186361750575766070,
+      "Data3": 1258461978763052951,
+      "Data4": -2466887559970426836
     },
     "Kind": "Components.EventHandler",
     "Name": "onerror",
@@ -15724,7 +15231,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onerror",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ErrorEventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ErrorEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onerror",
@@ -15737,7 +15243,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -15752,7 +15257,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -15786,10 +15290,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8588741516852728311,
-      "Data2": -5271367012371921736,
-      "Data3": -7685394681804264855,
-      "Data4": 8407039182688190185
+      "Data1": -3803670477853102010,
+      "Data2": -3353912797114447522,
+      "Data3": 3887447057752885684,
+      "Data4": -7871759346705495936
     },
     "Kind": "Components.EventHandler",
     "Name": "onactivate",
@@ -15843,7 +15347,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onactivate",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onactivate",
@@ -15856,7 +15359,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -15871,7 +15373,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -15905,10 +15406,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7507851421384276626,
-      "Data2": -31899192569855276,
-      "Data3": -5837852458452465167,
-      "Data4": -6932616106494642781
+      "Data1": 8805204294556538525,
+      "Data2": -2356897028422896907,
+      "Data3": -8312013638718554443,
+      "Data4": -7994810128451906235
     },
     "Kind": "Components.EventHandler",
     "Name": "onbeforeactivate",
@@ -15962,7 +15463,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onbeforeactivate",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onbeforeactivate",
@@ -15975,7 +15475,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -15990,7 +15489,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -16024,10 +15522,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4042894824237713652,
-      "Data2": 488543493533371758,
-      "Data3": 3261753787437772466,
-      "Data4": 1444782523179050702
+      "Data1": -8611419312725385816,
+      "Data2": -4139870421362047494,
+      "Data3": 4973600697304848632,
+      "Data4": 2472479503276106655
     },
     "Kind": "Components.EventHandler",
     "Name": "onbeforedeactivate",
@@ -16081,7 +15579,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onbeforedeactivate",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onbeforedeactivate",
@@ -16094,7 +15591,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -16109,7 +15605,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -16143,10 +15638,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7323093890902836974,
-      "Data2": 783068847275273661,
-      "Data3": 4835679226348530511,
-      "Data4": 4952156269779860909
+      "Data1": 4791236511695847760,
+      "Data2": 312516141702812934,
+      "Data3": 8237704925604603450,
+      "Data4": -3937672952356560506
     },
     "Kind": "Components.EventHandler",
     "Name": "ondeactivate",
@@ -16200,7 +15695,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@ondeactivate",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ondeactivate",
@@ -16213,7 +15707,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -16228,7 +15721,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -16262,10 +15754,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1551032782579347738,
-      "Data2": 4238496237460356300,
-      "Data3": -5552525842626464319,
-      "Data4": 5632935349436654401
+      "Data1": 1936349161302817158,
+      "Data2": 2271322694401344492,
+      "Data3": -8339908410001989826,
+      "Data4": 7546429217263541845
     },
     "Kind": "Components.EventHandler",
     "Name": "onended",
@@ -16319,7 +15811,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onended",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onended",
@@ -16332,7 +15823,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -16347,7 +15837,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -16381,10 +15870,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8717014493593454143,
-      "Data2": -1559400026274503862,
-      "Data3": 2767706358234588254,
-      "Data4": -5384048549397103827
+      "Data1": -5680030528602112438,
+      "Data2": -6320129605653645803,
+      "Data3": -7255378352851181249,
+      "Data4": -6002392956716526008
     },
     "Kind": "Components.EventHandler",
     "Name": "onfullscreenchange",
@@ -16438,7 +15927,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onfullscreenchange",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onfullscreenchange",
@@ -16451,7 +15939,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -16466,7 +15953,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -16500,10 +15986,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 123664188982797468,
-      "Data2": -6928559108024341310,
-      "Data3": -1839089998928256021,
-      "Data4": -4701508995312759573
+      "Data1": 4781388477919751940,
+      "Data2": 8601929763457414002,
+      "Data3": -5778004181091268115,
+      "Data4": -1287845292857900007
     },
     "Kind": "Components.EventHandler",
     "Name": "onfullscreenerror",
@@ -16557,7 +16043,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onfullscreenerror",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onfullscreenerror",
@@ -16570,7 +16055,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -16585,7 +16069,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -16619,10 +16102,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6786190908258939842,
-      "Data2": -5978457412558494111,
-      "Data3": -2248780315898693237,
-      "Data4": -6903902338040314312
+      "Data1": -911870474655330118,
+      "Data2": -1405496868336768916,
+      "Data3": 8390996053480263818,
+      "Data4": 5248373465439382189
     },
     "Kind": "Components.EventHandler",
     "Name": "onloadeddata",
@@ -16676,7 +16159,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onloadeddata",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onloadeddata",
@@ -16689,7 +16171,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -16704,7 +16185,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -16738,10 +16218,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 828939466476271035,
-      "Data2": -1092712901000028682,
-      "Data3": 8499801067723505984,
-      "Data4": 7833765363891516498
+      "Data1": 8370334749715402415,
+      "Data2": 8554880655860903061,
+      "Data3": -4476024602383204342,
+      "Data4": 3651343592203203583
     },
     "Kind": "Components.EventHandler",
     "Name": "onloadedmetadata",
@@ -16795,7 +16275,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onloadedmetadata",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onloadedmetadata",
@@ -16808,7 +16287,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -16823,7 +16301,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -16857,10 +16334,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2511885330541986604,
-      "Data2": -7366217250048717791,
-      "Data3": 7421308684685969740,
-      "Data4": 315189690263516050
+      "Data1": -341901047023207503,
+      "Data2": -8495994002760927968,
+      "Data3": 261394283688568312,
+      "Data4": 315966696347312304
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointerlockchange",
@@ -16914,7 +16391,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onpointerlockchange",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onpointerlockchange",
@@ -16927,7 +16403,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -16942,7 +16417,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -16976,10 +16450,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3641172961562810068,
-      "Data2": -4256947160702093367,
-      "Data3": 110270307828729941,
-      "Data4": 1898939720802028009
+      "Data1": -1900113584630384717,
+      "Data2": -2180580021106248266,
+      "Data3": -5265969542243742196,
+      "Data4": 2572919969243757125
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointerlockerror",
@@ -17033,7 +16507,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onpointerlockerror",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onpointerlockerror",
@@ -17046,7 +16519,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -17061,7 +16533,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -17095,10 +16566,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2951168152828468342,
-      "Data2": -2642725369379987855,
-      "Data3": 1851868294962451010,
-      "Data4": -3556084688694998633
+      "Data1": 4837019075015193591,
+      "Data2": 7087602864750864527,
+      "Data3": 4805132055039542629,
+      "Data4": 2766956913945018243
     },
     "Kind": "Components.EventHandler",
     "Name": "onreadystatechange",
@@ -17152,7 +16623,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onreadystatechange",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onreadystatechange",
@@ -17165,7 +16635,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -17180,7 +16649,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -17214,10 +16682,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 235156993229212938,
-      "Data2": 2592391107447408679,
-      "Data3": -7704547811289095141,
-      "Data4": -4494799550421980757
+      "Data1": 4149677710501796733,
+      "Data2": 36043277307705683,
+      "Data3": -4792850075748737341,
+      "Data4": 7875696479337195571
     },
     "Kind": "Components.EventHandler",
     "Name": "onscroll",
@@ -17271,7 +16739,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@onscroll",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onscroll",
@@ -17284,7 +16751,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -17299,7 +16765,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -17333,10 +16798,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6044311653820390298,
-      "Data2": 5309692616906113196,
-      "Data3": -5175408046628569521,
-      "Data4": 1303004489103343920
+      "Data1": 1140419827034931787,
+      "Data2": 6770507407134574405,
+      "Data3": -8001041985769797285,
+      "Data4": -7579531138963952213
     },
     "Kind": "Components.EventHandler",
     "Name": "ontoggle",
@@ -17390,7 +16855,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.EventHandler",
         "Name": "@ontoggle",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ontoggle",
@@ -17403,7 +16867,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "preventDefault",
             "TypeName": "System.Boolean",
             "DisplayName": ":preventDefault",
@@ -17418,7 +16881,6 @@
             }
           },
           {
-            "Kind": "Components.EventHandler",
             "Name": "stopPropagation",
             "TypeName": "System.Boolean",
             "DisplayName": ":stopPropagation",
@@ -17452,10 +16914,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6335232114432190568,
-      "Data2": -938926982775200059,
-      "Data3": 4371015718727354147,
-      "Data4": -3914018277547700314
+      "Data1": 2178206861261052325,
+      "Data2": -4365524651956538386,
+      "Data3": -8951170454315403632,
+      "Data4": -5065903433088102374
     },
     "Kind": "Components.Splat",
     "Name": "Attributes",
@@ -17481,7 +16943,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Splat",
         "Name": "@attributes",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Attributes.Attributes",
@@ -17503,10 +16964,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5382163423233359948,
-      "Data2": -301340728571566285,
-      "Data3": -5343795791836136098,
-      "Data4": -5858338761069172477
+      "Data1": -2691140916902589132,
+      "Data2": 5665331874949135993,
+      "Data3": 3532856183522419219,
+      "Data4": -8176119513396174649
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper",
@@ -17640,7 +17101,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "ITagHelper",
         "Name": "asp-action",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Action",
@@ -17651,7 +17111,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-controller",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Controller",
@@ -17662,7 +17121,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-area",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Area",
@@ -17673,7 +17131,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-page",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Page",
@@ -17684,7 +17141,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-page-handler",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.PageHandler",
@@ -17695,7 +17151,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-protocol",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Protocol",
@@ -17706,7 +17161,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-host",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Host",
@@ -17717,7 +17171,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-fragment",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Fragment",
@@ -17728,7 +17181,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-route",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Route",
@@ -17739,7 +17191,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-all-route-data",
         "TypeName": "System.Collections.Generic.IDictionary<System.String, System.String>",
         "HasIndexer": true,
@@ -17762,10 +17213,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8944030050369493903,
-      "Data2": -9050866697568121472,
-      "Data3": -2760021334495985468,
-      "Data4": -8867623003191737256
+      "Data1": 695363599902682699,
+      "Data2": -6800691529511549999,
+      "Data3": 7683545536402482633,
+      "Data4": -1172932580732311341
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper",
@@ -17781,7 +17232,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "ITagHelper",
         "Name": "priority",
         "TypeName": "Microsoft.Extensions.Caching.Memory.CacheItemPriority?",
         "DisplayName": "Microsoft.Extensions.Caching.Memory.CacheItemPriority? Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper.Priority",
@@ -17792,7 +17242,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "vary-by",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper.VaryBy",
@@ -17803,7 +17252,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "vary-by-header",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper.VaryByHeader",
@@ -17814,7 +17262,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "vary-by-query",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper.VaryByQuery",
@@ -17825,7 +17272,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "vary-by-route",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper.VaryByRoute",
@@ -17836,7 +17282,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "vary-by-cookie",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper.VaryByCookie",
@@ -17847,7 +17292,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "vary-by-user",
         "TypeName": "System.Boolean",
         "DisplayName": "bool Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper.VaryByUser",
@@ -17858,7 +17302,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "vary-by-culture",
         "TypeName": "System.Boolean",
         "DisplayName": "bool Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper.VaryByCulture",
@@ -17869,7 +17312,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "expires-on",
         "TypeName": "System.DateTimeOffset?",
         "DisplayName": "System.DateTimeOffset? Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper.ExpiresOn",
@@ -17880,7 +17322,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "expires-after",
         "TypeName": "System.TimeSpan?",
         "DisplayName": "System.TimeSpan? Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper.ExpiresAfter",
@@ -17891,7 +17332,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "expires-sliding",
         "TypeName": "System.TimeSpan?",
         "DisplayName": "System.TimeSpan? Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper.ExpiresSliding",
@@ -17902,7 +17342,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "enabled",
         "TypeName": "System.Boolean",
         "DisplayName": "bool Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper.Enabled",
@@ -17922,10 +17361,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8763551081546031216,
-      "Data2": 7333165342404970001,
-      "Data3": -4088372672822061929,
-      "Data4": -9022665045579012874
+      "Data1": -28348962335892839,
+      "Data2": 8275825483240517839,
+      "Data3": -7245295817226371666,
+      "Data4": 8863523217590278409
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.ComponentTagHelper",
@@ -17949,7 +17388,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "ITagHelper",
         "Name": "params",
         "TypeName": "System.Collections.Generic.IDictionary<System.String, System.Object>",
         "HasIndexer": true,
@@ -17963,7 +17401,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "type",
         "TypeName": "System.Type",
         "DisplayName": "System.Type Microsoft.AspNetCore.Mvc.TagHelpers.ComponentTagHelper.ComponentType",
@@ -17974,7 +17411,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "render-mode",
         "TypeName": "Microsoft.AspNetCore.Mvc.Rendering.RenderMode",
         "IsEnum": true,
@@ -17995,10 +17431,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5568213014710190206,
-      "Data2": -6423096233561394664,
-      "Data3": 6873893591696362794,
-      "Data4": -1131793544034934137
+      "Data1": -2016379775888796934,
+      "Data2": 2394947512120564749,
+      "Data3": -14359009586197013,
+      "Data4": -4693251594565665943
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper",
@@ -18021,7 +17457,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "ITagHelper",
         "Name": "name",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper.Name",
@@ -18032,7 +17467,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "vary-by",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper.VaryBy",
@@ -18043,7 +17477,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "vary-by-header",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper.VaryByHeader",
@@ -18054,7 +17487,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "vary-by-query",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper.VaryByQuery",
@@ -18065,7 +17497,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "vary-by-route",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper.VaryByRoute",
@@ -18076,7 +17507,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "vary-by-cookie",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper.VaryByCookie",
@@ -18087,7 +17517,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "vary-by-user",
         "TypeName": "System.Boolean",
         "DisplayName": "bool Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper.VaryByUser",
@@ -18098,7 +17527,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "vary-by-culture",
         "TypeName": "System.Boolean",
         "DisplayName": "bool Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper.VaryByCulture",
@@ -18109,7 +17537,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "expires-on",
         "TypeName": "System.DateTimeOffset?",
         "DisplayName": "System.DateTimeOffset? Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper.ExpiresOn",
@@ -18120,7 +17547,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "expires-after",
         "TypeName": "System.TimeSpan?",
         "DisplayName": "System.TimeSpan? Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper.ExpiresAfter",
@@ -18131,7 +17557,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "expires-sliding",
         "TypeName": "System.TimeSpan?",
         "DisplayName": "System.TimeSpan? Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper.ExpiresSliding",
@@ -18142,7 +17567,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "enabled",
         "TypeName": "System.Boolean",
         "DisplayName": "bool Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper.Enabled",
@@ -18162,10 +17586,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2985505521954061261,
-      "Data2": 7366372136387448031,
-      "Data3": 6552904402725855330,
-      "Data4": -7218595895374958838
+      "Data1": 4369646954423178969,
+      "Data2": 3128412053872760671,
+      "Data3": -6997776982648009496,
+      "Data4": 1840570578294440065
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.EnvironmentTagHelper",
@@ -18181,7 +17605,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "ITagHelper",
         "Name": "names",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.EnvironmentTagHelper.Names",
@@ -18192,7 +17615,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "include",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.EnvironmentTagHelper.Include",
@@ -18203,7 +17625,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "exclude",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.EnvironmentTagHelper.Exclude",
@@ -18223,10 +17644,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2193401636330917505,
-      "Data2": 4096256571696208256,
-      "Data3": -7825902628953818469,
-      "Data4": -1526078320928948661
+      "Data1": 3254066323727996177,
+      "Data2": 6820812766149563592,
+      "Data3": 4757886940421704990,
+      "Data4": -8002294065430606632
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.FormActionTagHelper",
@@ -18682,7 +18103,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "ITagHelper",
         "Name": "asp-action",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormActionTagHelper.Action",
@@ -18693,7 +18113,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-controller",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormActionTagHelper.Controller",
@@ -18704,7 +18123,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-area",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormActionTagHelper.Area",
@@ -18715,7 +18133,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-page",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormActionTagHelper.Page",
@@ -18726,7 +18143,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-page-handler",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormActionTagHelper.PageHandler",
@@ -18737,7 +18153,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-fragment",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormActionTagHelper.Fragment",
@@ -18748,7 +18163,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-route",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormActionTagHelper.Route",
@@ -18759,7 +18173,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-all-route-data",
         "TypeName": "System.Collections.Generic.IDictionary<System.String, System.String>",
         "HasIndexer": true,
@@ -18782,10 +18195,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3116505489740348477,
-      "Data2": 8450533897857285909,
-      "Data3": -2734342042192694058,
-      "Data4": -382232429141822516
+      "Data1": 3535480492489128461,
+      "Data2": 6727405502736066583,
+      "Data3": -7902576283092897041,
+      "Data4": -5294792057729812600
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.FormTagHelper",
@@ -18801,7 +18214,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "ITagHelper",
         "Name": "asp-action",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormTagHelper.Action",
@@ -18812,7 +18224,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-controller",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormTagHelper.Controller",
@@ -18823,7 +18234,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-area",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormTagHelper.Area",
@@ -18834,7 +18244,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-page",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormTagHelper.Page",
@@ -18845,7 +18254,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-page-handler",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormTagHelper.PageHandler",
@@ -18856,7 +18264,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-antiforgery",
         "TypeName": "System.Boolean?",
         "DisplayName": "System.Boolean? Microsoft.AspNetCore.Mvc.TagHelpers.FormTagHelper.Antiforgery",
@@ -18867,7 +18274,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-fragment",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormTagHelper.Fragment",
@@ -18878,7 +18284,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-route",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormTagHelper.Route",
@@ -18889,7 +18294,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-all-route-data",
         "TypeName": "System.Collections.Generic.IDictionary<System.String, System.String>",
         "HasIndexer": true,
@@ -18912,10 +18316,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2010234366520889400,
-      "Data2": -9162167909154813247,
-      "Data3": 3350833382048158890,
-      "Data4": -187506152129846501
+      "Data1": -9150069793068366952,
+      "Data2": -2076058506947748682,
+      "Data3": -6403108197295115992,
+      "Data4": 7774763828166874621
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.ImageTagHelper",
@@ -18944,7 +18348,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "ITagHelper",
         "Name": "src",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.ImageTagHelper.Src",
@@ -18955,7 +18358,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-append-version",
         "TypeName": "System.Boolean",
         "DisplayName": "bool Microsoft.AspNetCore.Mvc.TagHelpers.ImageTagHelper.AppendVersion",
@@ -18975,10 +18377,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5192340244580173146,
-      "Data2": -3243594609169824784,
-      "Data3": 7150690573022255809,
-      "Data4": 8882306416766820346
+      "Data1": -6998767517752929417,
+      "Data2": 6917972083269696653,
+      "Data3": -8936279983879531903,
+      "Data4": -3136776488981870098
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.InputTagHelper",
@@ -19002,7 +18404,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "ITagHelper",
         "Name": "asp-for",
         "TypeName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ModelExpression",
         "DisplayName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ModelExpression Microsoft.AspNetCore.Mvc.TagHelpers.InputTagHelper.For",
@@ -19013,7 +18414,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-format",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.InputTagHelper.Format",
@@ -19024,7 +18424,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "type",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.InputTagHelper.InputTypeName",
@@ -19035,7 +18434,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "name",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.InputTagHelper.Name",
@@ -19046,7 +18444,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.InputTagHelper.Value",
@@ -19066,10 +18463,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6799066715620530383,
-      "Data2": 7144248628368105545,
-      "Data3": -352434683236721331,
-      "Data4": -5462210378011518135
+      "Data1": -1957410200833230115,
+      "Data2": 7026930609365577114,
+      "Data3": 5200742074609957556,
+      "Data4": -1953559859184195059
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.LabelTagHelper",
@@ -19092,7 +18489,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "ITagHelper",
         "Name": "asp-for",
         "TypeName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ModelExpression",
         "DisplayName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ModelExpression Microsoft.AspNetCore.Mvc.TagHelpers.LabelTagHelper.For",
@@ -19112,10 +18508,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 9057036378714854767,
-      "Data2": 7061990359131109792,
-      "Data3": 3446744581334342026,
-      "Data4": -4352444792678576859
+      "Data1": -7440377698719679753,
+      "Data2": -1268101387052113757,
+      "Data3": -3050263543566606420,
+      "Data4": 6215374089723061786
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper",
@@ -19235,7 +18631,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "ITagHelper",
         "Name": "href",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper.Href",
@@ -19246,7 +18641,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-href-include",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper.HrefInclude",
@@ -19257,7 +18651,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-href-exclude",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper.HrefExclude",
@@ -19268,7 +18661,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-fallback-href",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper.FallbackHref",
@@ -19279,7 +18671,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-suppress-fallback-integrity",
         "TypeName": "System.Boolean",
         "DisplayName": "bool Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper.SuppressFallbackIntegrity",
@@ -19290,7 +18681,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-append-version",
         "TypeName": "System.Boolean?",
         "DisplayName": "System.Boolean? Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper.AppendVersion",
@@ -19301,7 +18691,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-fallback-href-include",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper.FallbackHrefInclude",
@@ -19312,7 +18701,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-fallback-href-exclude",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper.FallbackHrefExclude",
@@ -19323,7 +18711,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-fallback-test-class",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper.FallbackTestClass",
@@ -19334,7 +18721,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-fallback-test-property",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper.FallbackTestProperty",
@@ -19345,7 +18731,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-fallback-test-value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper.FallbackTestValue",
@@ -19365,10 +18750,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1548567717904225779,
-      "Data2": -5138065978056833963,
-      "Data3": 3016893068060650774,
-      "Data4": 3395222620686008424
+      "Data1": -5036948280793877287,
+      "Data2": -8432828701949711564,
+      "Data3": 3699679941431429847,
+      "Data4": 8322032632332533506
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.OptionTagHelper",
@@ -19384,7 +18769,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "ITagHelper",
         "Name": "value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.OptionTagHelper.Value",
@@ -19404,10 +18788,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7828821137440113188,
-      "Data2": -920148945739478025,
-      "Data3": -631939299662925720,
-      "Data4": -4971665814497090591
+      "Data1": 1517696761464252137,
+      "Data2": -3159673581201677384,
+      "Data3": 991705095752170857,
+      "Data4": -601937397079391106
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.PartialTagHelper",
@@ -19431,7 +18815,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "ITagHelper",
         "Name": "name",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.PartialTagHelper.Name",
@@ -19442,7 +18825,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "for",
         "TypeName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ModelExpression",
         "DisplayName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ModelExpression Microsoft.AspNetCore.Mvc.TagHelpers.PartialTagHelper.For",
@@ -19453,7 +18835,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "model",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Mvc.TagHelpers.PartialTagHelper.Model",
@@ -19464,7 +18845,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "optional",
         "TypeName": "System.Boolean",
         "DisplayName": "bool Microsoft.AspNetCore.Mvc.TagHelpers.PartialTagHelper.Optional",
@@ -19475,7 +18855,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "fallback-name",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.PartialTagHelper.FallbackName",
@@ -19486,7 +18865,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "view-data",
         "TypeName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary",
         "HasIndexer": true,
@@ -19509,10 +18887,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7015744733003198603,
-      "Data2": 3394077066165693914,
-      "Data3": 5295649563369853739,
-      "Data4": 8567139667125272586
+      "Data1": 3778860261854861440,
+      "Data2": 2958008348918129348,
+      "Data3": 8913507677249328980,
+      "Data4": -4426493367649989034
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.PersistComponentStateTagHelper",
@@ -19529,7 +18907,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "ITagHelper",
         "Name": "persist-mode",
         "TypeName": "Microsoft.AspNetCore.Mvc.TagHelpers.PersistenceMode?",
         "DisplayName": "Microsoft.AspNetCore.Mvc.TagHelpers.PersistenceMode? Microsoft.AspNetCore.Mvc.TagHelpers.PersistComponentStateTagHelper.PersistenceMode",
@@ -19549,10 +18926,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8879102875865159207,
-      "Data2": 8425022696916112277,
-      "Data3": -3508022818640239840,
-      "Data4": 4883750455999641065
+      "Data1": 6097127976709000527,
+      "Data2": 8994589850913287496,
+      "Data3": 5168171268406164167,
+      "Data4": 7786589343832471355
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.ScriptTagHelper",
@@ -19641,7 +19018,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "ITagHelper",
         "Name": "src",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.ScriptTagHelper.Src",
@@ -19652,7 +19028,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-src-include",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.ScriptTagHelper.SrcInclude",
@@ -19663,7 +19038,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-src-exclude",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.ScriptTagHelper.SrcExclude",
@@ -19674,7 +19048,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-fallback-src",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.ScriptTagHelper.FallbackSrc",
@@ -19685,7 +19058,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-suppress-fallback-integrity",
         "TypeName": "System.Boolean",
         "DisplayName": "bool Microsoft.AspNetCore.Mvc.TagHelpers.ScriptTagHelper.SuppressFallbackIntegrity",
@@ -19696,7 +19068,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-append-version",
         "TypeName": "System.Boolean?",
         "DisplayName": "System.Boolean? Microsoft.AspNetCore.Mvc.TagHelpers.ScriptTagHelper.AppendVersion",
@@ -19707,7 +19078,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-fallback-src-include",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.ScriptTagHelper.FallbackSrcInclude",
@@ -19718,7 +19088,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-fallback-src-exclude",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.ScriptTagHelper.FallbackSrcExclude",
@@ -19729,7 +19098,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-fallback-test",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.ScriptTagHelper.FallbackTestExpression",
@@ -19749,10 +19117,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 495753905791149408,
-      "Data2": -5128006272773580635,
-      "Data3": 4364804291585155103,
-      "Data4": 8527295846851459514
+      "Data1": -4854167366317579771,
+      "Data2": 2918566904182754138,
+      "Data3": 7713941763997143428,
+      "Data4": -3188734934031037136
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.SelectTagHelper",
@@ -19786,7 +19154,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "ITagHelper",
         "Name": "asp-for",
         "TypeName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ModelExpression",
         "DisplayName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ModelExpression Microsoft.AspNetCore.Mvc.TagHelpers.SelectTagHelper.For",
@@ -19797,7 +19164,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "asp-items",
         "TypeName": "System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Mvc.Rendering.SelectListItem>",
         "DisplayName": "System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Mvc.Rendering.SelectListItem> Microsoft.AspNetCore.Mvc.TagHelpers.SelectTagHelper.Items",
@@ -19808,7 +19174,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "name",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.SelectTagHelper.Name",
@@ -19828,10 +19193,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5343640275150715323,
-      "Data2": 7921768207261285923,
-      "Data3": -5907522581276048057,
-      "Data4": 1860347338512499588
+      "Data1": 456153802204140171,
+      "Data2": 3570126844946886368,
+      "Data3": -1678759803802258939,
+      "Data4": -4952702678738042897
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.TextAreaTagHelper",
@@ -19854,7 +19219,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "ITagHelper",
         "Name": "asp-for",
         "TypeName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ModelExpression",
         "DisplayName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ModelExpression Microsoft.AspNetCore.Mvc.TagHelpers.TextAreaTagHelper.For",
@@ -19865,7 +19229,6 @@
         }
       },
       {
-        "Kind": "ITagHelper",
         "Name": "name",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.TextAreaTagHelper.Name",
@@ -19885,10 +19248,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1303619295545170649,
-      "Data2": -8748687449408290236,
-      "Data3": 4905367779771839493,
-      "Data4": -7350044480605360893
+      "Data1": 122407907830255608,
+      "Data2": -700700567307428018,
+      "Data3": 3600322002542077017,
+      "Data4": 2776277471670448158
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.ValidationMessageTagHelper",
@@ -19911,7 +19274,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "ITagHelper",
         "Name": "asp-validation-for",
         "TypeName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ModelExpression",
         "DisplayName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ModelExpression Microsoft.AspNetCore.Mvc.TagHelpers.ValidationMessageTagHelper.For",
@@ -19931,10 +19293,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6804100096055898062,
-      "Data2": 8394633871235252914,
-      "Data3": -8812029692021752092,
-      "Data4": -8692429861398583685
+      "Data1": -324297431428773807,
+      "Data2": 9041312678384490421,
+      "Data3": -7983664825210767949,
+      "Data4": 8506289130510871423
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.ValidationSummaryTagHelper",
@@ -19957,7 +19319,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "ITagHelper",
         "Name": "asp-validation-summary",
         "TypeName": "Microsoft.AspNetCore.Mvc.Rendering.ValidationSummary",
         "IsEnum": true,
@@ -20388,10 +19749,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1358592335014465527,
-      "Data2": 8627244872992385979,
-      "Data3": 2511047367559632740,
-      "Data4": 5951939492454422664
+      "Data1": -4956411382073006453,
+      "Data2": 516732521478035673,
+      "Data3": 3816531986645240906,
+      "Data4": 604760014856119338
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -20418,7 +19779,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind-...",
         "TypeName": "System.Collections.Generic.Dictionary<string, object>",
         "HasIndexer": true,
@@ -20430,7 +19790,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "format",
             "TypeName": "System.String",
             "DisplayName": ":format",
@@ -20442,7 +19801,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "event",
             "TypeName": "System.String",
             "DisplayName": ":event",
@@ -20457,7 +19815,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "culture",
             "TypeName": "System.Globalization.CultureInfo",
             "DisplayName": ":culture",
@@ -20469,7 +19826,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -20482,7 +19838,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -20494,7 +19849,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -20524,10 +19878,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4002636027394834157,
-      "Data2": -5276990724841345094,
-      "Data3": 2730657289970645411,
-      "Data4": 4783686603879839174
+      "Data1": 7402027333053994539,
+      "Data2": -3446878997932190904,
+      "Data3": -3101521142354767554,
+      "Data4": -6760953170491785234
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -20576,7 +19930,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind",
@@ -20589,7 +19942,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "format",
             "TypeName": "System.String",
             "DisplayName": ":format",
@@ -20604,7 +19956,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "event",
             "TypeName": "System.String",
             "DisplayName": ":event",
@@ -20619,7 +19970,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "culture",
             "TypeName": "System.Globalization.CultureInfo",
             "DisplayName": ":culture",
@@ -20631,7 +19981,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -20644,7 +19993,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -20656,7 +20004,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -20674,7 +20021,6 @@
         }
       },
       {
-        "Kind": "Components.Bind",
         "Name": "format-value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -20704,10 +20050,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7200413232137332433,
-      "Data2": 4338649916014455023,
-      "Data3": -3110627702460890252,
-      "Data4": 3432502128751898967
+      "Data1": 8844774585541617356,
+      "Data2": 8658003120836766162,
+      "Data3": 4305185477720729866,
+      "Data4": 7023709757413983193
     },
     "Kind": "Components.Bind",
     "Name": "Bind_value",
@@ -20756,7 +20102,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind-value",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind_value",
@@ -20769,7 +20114,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "format",
             "TypeName": "System.String",
             "DisplayName": ":format",
@@ -20784,7 +20128,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "event",
             "TypeName": "System.String",
             "DisplayName": ":event",
@@ -20799,7 +20142,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "culture",
             "TypeName": "System.Globalization.CultureInfo",
             "DisplayName": ":culture",
@@ -20811,7 +20153,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -20824,7 +20165,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -20836,7 +20176,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -20854,7 +20193,6 @@
         }
       },
       {
-        "Kind": "Components.Bind",
         "Name": "format-value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -20884,10 +20222,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1721086346521710424,
-      "Data2": -3744183235058403268,
-      "Data3": -5153641274119959382,
-      "Data4": 3475855161529647481
+      "Data1": -6139627449151613019,
+      "Data2": 1628249431281193389,
+      "Data3": -802943671935024249,
+      "Data4": 648384761177778230
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -20948,7 +20286,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind",
@@ -20961,7 +20298,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "format",
             "TypeName": "System.String",
             "DisplayName": ":format",
@@ -20976,7 +20312,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "event",
             "TypeName": "System.String",
             "DisplayName": ":event",
@@ -20991,7 +20326,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "culture",
             "TypeName": "System.Globalization.CultureInfo",
             "DisplayName": ":culture",
@@ -21003,7 +20337,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -21016,7 +20349,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -21028,7 +20360,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -21046,7 +20377,6 @@
         }
       },
       {
-        "Kind": "Components.Bind",
         "Name": "format-checked",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_checked",
@@ -21077,10 +20407,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6675248694568745749,
-      "Data2": 6750034401287596854,
-      "Data3": 3672765987705228743,
-      "Data4": -256865287950732198
+      "Data1": 6068105800957731755,
+      "Data2": 1958126132282487755,
+      "Data3": 4852930634683786960,
+      "Data4": 3769138096448137878
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -21141,7 +20471,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind",
@@ -21154,7 +20483,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "format",
             "TypeName": "System.String",
             "DisplayName": ":format",
@@ -21169,7 +20497,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "event",
             "TypeName": "System.String",
             "DisplayName": ":event",
@@ -21184,7 +20511,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "culture",
             "TypeName": "System.Globalization.CultureInfo",
             "DisplayName": ":culture",
@@ -21196,7 +20522,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -21209,7 +20534,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -21221,7 +20545,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -21239,7 +20562,6 @@
         }
       },
       {
-        "Kind": "Components.Bind",
         "Name": "format-value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -21270,10 +20592,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7048897972038771877,
-      "Data2": 4194234136329106631,
-      "Data3": -3327779996700008522,
-      "Data4": 7246736422263437609
+      "Data1": -3192163379129342866,
+      "Data2": -908092289118660396,
+      "Data3": 8916901005292949522,
+      "Data4": -694254851830939888
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -21334,7 +20656,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind",
@@ -21347,7 +20668,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "format",
             "TypeName": "System.String",
             "DisplayName": ":format",
@@ -21362,7 +20682,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "event",
             "TypeName": "System.String",
             "DisplayName": ":event",
@@ -21377,7 +20696,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "culture",
             "TypeName": "System.Globalization.CultureInfo",
             "DisplayName": ":culture",
@@ -21389,7 +20707,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -21402,7 +20719,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -21414,7 +20730,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -21432,7 +20747,6 @@
         }
       },
       {
-        "Kind": "Components.Bind",
         "Name": "format-value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -21463,10 +20777,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2280326495410385185,
-      "Data2": -5548205434267583856,
-      "Data3": -1991034787606130032,
-      "Data4": -1012253451628560274
+      "Data1": 3657137836086790504,
+      "Data2": -8441360560393812229,
+      "Data3": 2083449763440333656,
+      "Data4": -7746762440594570849
     },
     "Kind": "Components.Bind",
     "Name": "Bind_value",
@@ -21527,7 +20841,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind-value",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind_value",
@@ -21540,7 +20853,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "format",
             "TypeName": "System.String",
             "DisplayName": ":format",
@@ -21555,7 +20867,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "event",
             "TypeName": "System.String",
             "DisplayName": ":event",
@@ -21570,7 +20881,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "culture",
             "TypeName": "System.Globalization.CultureInfo",
             "DisplayName": ":culture",
@@ -21582,7 +20892,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -21595,7 +20904,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -21607,7 +20915,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -21625,7 +20932,6 @@
         }
       },
       {
-        "Kind": "Components.Bind",
         "Name": "format-value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -21656,10 +20962,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4246469588483228585,
-      "Data2": -516068861061808627,
-      "Data3": 4075732351654180301,
-      "Data4": 5145881654853280358
+      "Data1": -7210429511237930730,
+      "Data2": 3700914488903705463,
+      "Data3": 1755174149562436174,
+      "Data4": 4654468164006271658
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -21720,7 +21026,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind",
@@ -21733,7 +21038,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "format",
             "TypeName": "System.String",
             "DisplayName": ":format",
@@ -21748,7 +21052,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "event",
             "TypeName": "System.String",
             "DisplayName": ":event",
@@ -21763,7 +21066,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "culture",
             "TypeName": "System.Globalization.CultureInfo",
             "DisplayName": ":culture",
@@ -21775,7 +21077,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -21788,7 +21089,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -21800,7 +21100,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -21818,7 +21117,6 @@
         }
       },
       {
-        "Kind": "Components.Bind",
         "Name": "format-value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -21849,10 +21147,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6189199045246256617,
-      "Data2": 4095059549944862,
-      "Data3": -7091325472647072996,
-      "Data4": 4557588365322302789
+      "Data1": 6520226159997619286,
+      "Data2": -3528059980413999827,
+      "Data3": 6463875126138844678,
+      "Data4": 455218432979510465
     },
     "Kind": "Components.Bind",
     "Name": "Bind_value",
@@ -21913,7 +21211,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind-value",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind_value",
@@ -21926,7 +21223,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "format",
             "TypeName": "System.String",
             "DisplayName": ":format",
@@ -21941,7 +21237,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "event",
             "TypeName": "System.String",
             "DisplayName": ":event",
@@ -21956,7 +21251,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "culture",
             "TypeName": "System.Globalization.CultureInfo",
             "DisplayName": ":culture",
@@ -21968,7 +21262,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -21981,7 +21274,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -21993,7 +21285,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -22011,7 +21302,6 @@
         }
       },
       {
-        "Kind": "Components.Bind",
         "Name": "format-value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -22042,10 +21332,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7808762381389443734,
-      "Data2": -7864569503770469521,
-      "Data3": 5926534793878472076,
-      "Data4": 707211783327412903
+      "Data1": -5265448538819468886,
+      "Data2": -5244566089296707730,
+      "Data3": 9114408832821437652,
+      "Data4": 6068985787287525837
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -22106,7 +21396,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind",
@@ -22119,7 +21408,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "format",
             "TypeName": "System.String",
             "DisplayName": ":format",
@@ -22134,7 +21422,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "event",
             "TypeName": "System.String",
             "DisplayName": ":event",
@@ -22149,7 +21436,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "culture",
             "TypeName": "System.Globalization.CultureInfo",
             "DisplayName": ":culture",
@@ -22161,7 +21447,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -22174,7 +21459,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -22186,7 +21470,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -22204,7 +21487,6 @@
         }
       },
       {
-        "Kind": "Components.Bind",
         "Name": "format-value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -22235,10 +21517,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4253308054877021601,
-      "Data2": 6594787185149837221,
-      "Data3": 9158630472902955590,
-      "Data4": 1052201836684803876
+      "Data1": 3101210583463877685,
+      "Data2": -8736249305119653430,
+      "Data3": -2164829316630798434,
+      "Data4": -4331253107632651662
     },
     "Kind": "Components.Bind",
     "Name": "Bind_value",
@@ -22299,7 +21581,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind-value",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind_value",
@@ -22312,7 +21593,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "format",
             "TypeName": "System.String",
             "DisplayName": ":format",
@@ -22327,7 +21607,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "event",
             "TypeName": "System.String",
             "DisplayName": ":event",
@@ -22342,7 +21621,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "culture",
             "TypeName": "System.Globalization.CultureInfo",
             "DisplayName": ":culture",
@@ -22354,7 +21632,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -22367,7 +21644,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -22379,7 +21655,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -22397,7 +21672,6 @@
         }
       },
       {
-        "Kind": "Components.Bind",
         "Name": "format-value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -22428,10 +21702,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2821292116131823338,
-      "Data2": -5968080011073150791,
-      "Data3": -3554851278604024371,
-      "Data4": -8355089073041313883
+      "Data1": -5189851214647459156,
+      "Data2": 6997728873791061517,
+      "Data3": -6652651042841705090,
+      "Data4": -2714701243441476264
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -22492,7 +21766,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind",
@@ -22505,7 +21778,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "format",
             "TypeName": "System.String",
             "DisplayName": ":format",
@@ -22520,7 +21792,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "event",
             "TypeName": "System.String",
             "DisplayName": ":event",
@@ -22535,7 +21806,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "culture",
             "TypeName": "System.Globalization.CultureInfo",
             "DisplayName": ":culture",
@@ -22547,7 +21817,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -22560,7 +21829,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -22572,7 +21840,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -22590,7 +21857,6 @@
         }
       },
       {
-        "Kind": "Components.Bind",
         "Name": "format-value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -22621,10 +21887,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1608301355126231397,
-      "Data2": -845746440912572549,
-      "Data3": -792583435008008761,
-      "Data4": -7719328561397802555
+      "Data1": 4666257921032366535,
+      "Data2": -2689373953497127477,
+      "Data3": 5820845103411567289,
+      "Data4": -1399037484187168549
     },
     "Kind": "Components.Bind",
     "Name": "Bind_value",
@@ -22685,7 +21951,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind-value",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind_value",
@@ -22698,7 +21963,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "format",
             "TypeName": "System.String",
             "DisplayName": ":format",
@@ -22713,7 +21977,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "event",
             "TypeName": "System.String",
             "DisplayName": ":event",
@@ -22728,7 +21991,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "culture",
             "TypeName": "System.Globalization.CultureInfo",
             "DisplayName": ":culture",
@@ -22740,7 +22002,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -22753,7 +22014,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -22765,7 +22025,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -22783,7 +22042,6 @@
         }
       },
       {
-        "Kind": "Components.Bind",
         "Name": "format-value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -22814,10 +22072,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5865028239867475329,
-      "Data2": 8633549336243359932,
-      "Data3": 1662732231407741292,
-      "Data4": -418418611858409857
+      "Data1": 3219901297506981950,
+      "Data2": -4399880091467860075,
+      "Data3": 9081026489297834595,
+      "Data4": 9194712501025302398
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -22878,7 +22136,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind",
@@ -22891,7 +22148,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "format",
             "TypeName": "System.String",
             "DisplayName": ":format",
@@ -22906,7 +22162,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "event",
             "TypeName": "System.String",
             "DisplayName": ":event",
@@ -22921,7 +22176,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "culture",
             "TypeName": "System.Globalization.CultureInfo",
             "DisplayName": ":culture",
@@ -22933,7 +22187,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -22946,7 +22199,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -22958,7 +22210,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -22976,7 +22227,6 @@
         }
       },
       {
-        "Kind": "Components.Bind",
         "Name": "format-value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -23007,10 +22257,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3602126020184219188,
-      "Data2": 4605850553583640460,
-      "Data3": 7724182352231032573,
-      "Data4": 3914473869101864700
+      "Data1": 3060167502699573182,
+      "Data2": 3516087094815481835,
+      "Data3": -6236246758717087683,
+      "Data4": 9206904560509313410
     },
     "Kind": "Components.Bind",
     "Name": "Bind_value",
@@ -23071,7 +22321,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind-value",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind_value",
@@ -23084,7 +22333,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "format",
             "TypeName": "System.String",
             "DisplayName": ":format",
@@ -23099,7 +22347,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "event",
             "TypeName": "System.String",
             "DisplayName": ":event",
@@ -23114,7 +22361,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "culture",
             "TypeName": "System.Globalization.CultureInfo",
             "DisplayName": ":culture",
@@ -23126,7 +22372,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -23139,7 +22384,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -23151,7 +22395,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -23169,7 +22412,6 @@
         }
       },
       {
-        "Kind": "Components.Bind",
         "Name": "format-value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -23200,10 +22442,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5005493372818563421,
-      "Data2": 7307525886012095591,
-      "Data3": -5250094594354383932,
-      "Data4": -6514478883099208635
+      "Data1": 8989652253133676506,
+      "Data2": -8892643895572038104,
+      "Data3": -6216481859063566605,
+      "Data4": -936080324882560203
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -23252,7 +22494,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind",
@@ -23265,7 +22506,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "format",
             "TypeName": "System.String",
             "DisplayName": ":format",
@@ -23280,7 +22520,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "event",
             "TypeName": "System.String",
             "DisplayName": ":event",
@@ -23295,7 +22534,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "culture",
             "TypeName": "System.Globalization.CultureInfo",
             "DisplayName": ":culture",
@@ -23307,7 +22545,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -23320,7 +22557,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -23332,7 +22568,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -23350,7 +22585,6 @@
         }
       },
       {
-        "Kind": "Components.Bind",
         "Name": "format-value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -23380,10 +22614,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -384127276242371580,
-      "Data2": 2400708221057326912,
-      "Data3": -3701354220214077389,
-      "Data4": -3533133195916389123
+      "Data1": 8267406816439511629,
+      "Data2": -8070515216210757972,
+      "Data3": 3797801915330303535,
+      "Data4": 8813063268165781585
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -23432,7 +22666,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind",
@@ -23445,7 +22678,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "format",
             "TypeName": "System.String",
             "DisplayName": ":format",
@@ -23460,7 +22692,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "event",
             "TypeName": "System.String",
             "DisplayName": ":event",
@@ -23475,7 +22706,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "culture",
             "TypeName": "System.Globalization.CultureInfo",
             "DisplayName": ":culture",
@@ -23487,7 +22717,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -23500,7 +22729,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -23512,7 +22740,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -23530,7 +22757,6 @@
         }
       },
       {
-        "Kind": "Components.Bind",
         "Name": "format-value",
         "TypeName": "System.String",
         "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -23560,10 +22786,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -162327884524518247,
-      "Data2": 3547443425853437108,
-      "Data3": -8865830174494763525,
-      "Data4": -6454910380248279658
+      "Data1": -960011711740559922,
+      "Data2": -8022787084652653840,
+      "Data3": -9059182930809321800,
+      "Data4": 3446386250744275939
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputCheckbox",
@@ -23612,7 +22838,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind-Value",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.Boolean>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.Boolean> Microsoft.AspNetCore.Components.Forms.InputCheckbox.Value",
@@ -23625,7 +22850,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -23638,7 +22862,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -23650,7 +22873,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -23681,10 +22903,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5431280927514296712,
-      "Data2": 4562711601134162231,
-      "Data3": 2369492899291591052,
-      "Data4": -5484890224838145565
+      "Data1": -1703059564437539489,
+      "Data2": -977913726472460743,
+      "Data3": -5654365996384152609,
+      "Data4": 3153774339147487699
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputCheckbox",
@@ -23733,7 +22955,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind-Value",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.Boolean>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.Boolean> Microsoft.AspNetCore.Components.Forms.InputCheckbox.Value",
@@ -23746,7 +22967,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -23759,7 +22979,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -23771,7 +22990,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -23803,10 +23021,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 133715153780179321,
-      "Data2": 8305438990944053938,
-      "Data3": 2207296677821207968,
-      "Data4": -324924628807964836
+      "Data1": 7843810788710194448,
+      "Data2": 4322325964591229058,
+      "Data3": 570175307709215678,
+      "Data4": 448364692654265271
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputDate<TValue>",
@@ -23855,7 +23073,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind-Value",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.Value",
@@ -23868,7 +23085,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -23881,7 +23097,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -23893,7 +23108,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -23924,10 +23138,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1850203605314629928,
-      "Data2": -7126857400556860702,
-      "Data3": -1765114162570923924,
-      "Data4": -3726874591371475153
+      "Data1": -6466330588814503818,
+      "Data2": 424735198563788609,
+      "Data3": -2612843300788331659,
+      "Data4": 491996349997901495
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputDate<TValue>",
@@ -23976,7 +23190,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind-Value",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.Value",
@@ -23989,7 +23202,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -24002,7 +23214,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -24014,7 +23225,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -24046,10 +23256,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4608797037836916582,
-      "Data2": 3548933466815354050,
-      "Data3": 5644678817553889090,
-      "Data4": -2965375159206425947
+      "Data1": -6286832222660170180,
+      "Data2": -916078296290814949,
+      "Data3": 7692715090507250587,
+      "Data4": -3464213187979528483
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>",
@@ -24098,7 +23308,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind-Value",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.Value",
@@ -24111,7 +23320,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -24124,7 +23332,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -24136,7 +23343,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -24167,10 +23373,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2193928491909409324,
-      "Data2": -6396112862872735395,
-      "Data3": 3435021540432051826,
-      "Data4": -7059599437489196088
+      "Data1": -3690200114443874820,
+      "Data2": 2777513507250896605,
+      "Data3": -73161014199470040,
+      "Data4": -5870339312383060886
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>",
@@ -24219,7 +23425,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind-Value",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.Value",
@@ -24232,7 +23437,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -24245,7 +23449,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -24257,7 +23460,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -24289,10 +23491,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3424314768121763113,
-      "Data2": 8581674042079665194,
-      "Data3": 6499403380379858822,
-      "Data4": 1904236188610301992
+      "Data1": -8268174122080178268,
+      "Data2": 6970402634146870399,
+      "Data3": 5727037980354914138,
+      "Data4": 411720478786037415
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>",
@@ -24341,7 +23543,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind-Value",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.Value",
@@ -24354,7 +23555,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -24367,7 +23567,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -24379,7 +23578,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -24410,10 +23608,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2680721226922586226,
-      "Data2": -7453666992090420039,
-      "Data3": -2903607850574016502,
-      "Data4": 2825963777753636670
+      "Data1": 7163771992523568394,
+      "Data2": -7437325150105231996,
+      "Data3": 734376592578972009,
+      "Data4": 7115028067981471260
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>",
@@ -24462,7 +23660,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind-Value",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.Value",
@@ -24475,7 +23672,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -24488,7 +23684,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -24500,7 +23695,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -24532,10 +23726,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6765575998871804296,
-      "Data2": 3965427095394488921,
-      "Data3": 685236745689310017,
-      "Data4": 2933531800649740073
+      "Data1": 5351108948226454620,
+      "Data2": -2954289968439605647,
+      "Data3": 3733221384548320271,
+      "Data4": -7705797846292557390
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>",
@@ -24584,7 +23778,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind-Value",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.Value",
@@ -24597,7 +23790,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -24610,7 +23802,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -24622,7 +23813,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -24653,10 +23843,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8973483734946215535,
-      "Data2": 5476671871432275795,
-      "Data3": 2803741873428823156,
-      "Data4": -803743045007094247
+      "Data1": -52112667549248369,
+      "Data2": 636326677130659578,
+      "Data3": -5684615603336029330,
+      "Data4": -9119613647709862212
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>",
@@ -24705,7 +23895,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind-Value",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.Value",
@@ -24718,7 +23907,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -24731,7 +23919,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -24743,7 +23930,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -24775,10 +23961,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4048321779581166700,
-      "Data2": -4444284846501714986,
-      "Data3": 7941686811123551065,
-      "Data4": -5498715226663539960
+      "Data1": 8169860100540165305,
+      "Data2": 8097607686873152988,
+      "Data3": 7300025027054631533,
+      "Data4": -7207419192900064047
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputText",
@@ -24827,7 +24013,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind-Value",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.String>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.String> Microsoft.AspNetCore.Components.Forms.InputText.Value",
@@ -24840,7 +24025,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -24853,7 +24037,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -24865,7 +24048,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -24896,10 +24078,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4696046756699853115,
-      "Data2": 7497917766690551777,
-      "Data3": 2075381432287003134,
-      "Data4": 2952702997429870536
+      "Data1": -6567775896921388091,
+      "Data2": 8108027945637834184,
+      "Data3": 291356362209817215,
+      "Data4": -9080380078428802894
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputText",
@@ -24948,7 +24130,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind-Value",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.String>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.String> Microsoft.AspNetCore.Components.Forms.InputText.Value",
@@ -24961,7 +24142,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -24974,7 +24154,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -24986,7 +24165,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -25018,10 +24196,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8620716872569518181,
-      "Data2": -4722831378235208129,
-      "Data3": -3300906252816240871,
-      "Data4": -5085577330781224745
+      "Data1": 5470880301241973659,
+      "Data2": 7006311831299753154,
+      "Data3": -6890578684808138809,
+      "Data4": -1483406253993667552
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputTextArea",
@@ -25070,7 +24248,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind-Value",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.String>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.String> Microsoft.AspNetCore.Components.Forms.InputTextArea.Value",
@@ -25083,7 +24260,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -25096,7 +24272,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -25108,7 +24283,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -25139,10 +24313,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8930621883034406091,
-      "Data2": -6658643635648755147,
-      "Data3": -7030412905974177815,
-      "Data4": -1170261418420070354
+      "Data1": -2375944316459808049,
+      "Data2": -2851744261248584751,
+      "Data3": -19476265537583022,
+      "Data4": 6745520080649124262
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputTextArea",
@@ -25191,7 +24365,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Bind",
         "Name": "@bind-Value",
         "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.String>",
         "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.String> Microsoft.AspNetCore.Components.Forms.InputTextArea.Value",
@@ -25204,7 +24377,6 @@
         },
         "BoundAttributeParameters": [
           {
-            "Kind": "Components.Bind",
             "Name": "get",
             "TypeName": "System.Object",
             "DisplayName": ":get",
@@ -25217,7 +24389,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "set",
             "TypeName": "System.Delegate",
             "DisplayName": ":set",
@@ -25229,7 +24400,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "after",
             "TypeName": "System.Delegate",
             "DisplayName": ":after",
@@ -25261,10 +24431,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8814807382415249073,
-      "Data2": 2126217236244498532,
-      "Data3": -7138374769769762122,
-      "Data4": 6135016900152955079
+      "Data1": -8471053076684220184,
+      "Data2": 733975027910313587,
+      "Data3": 2670013795459003691,
+      "Data4": 7517720934849557693
     },
     "Kind": "Components.Ref",
     "Name": "Ref",
@@ -25290,7 +24460,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Ref",
         "Name": "@ref",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Ref.Ref",
@@ -25312,10 +24481,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3804994244823094932,
-      "Data2": 6747339800015090685,
-      "Data3": -3495956806464305278,
-      "Data4": -5168540455783903192
+      "Data1": 1799122480488717236,
+      "Data2": -3037038074828170693,
+      "Data3": -6772261430420861497,
+      "Data4": -1932036478778670876
     },
     "Kind": "Components.Key",
     "Name": "Key",
@@ -25341,7 +24510,6 @@
     ],
     "BoundAttributes": [
       {
-        "Kind": "Components.Key",
         "Name": "@key",
         "TypeName": "System.Object",
         "DisplayName": "object Microsoft.AspNetCore.Components.Key.Key",

--- a/src/Shared/files/Tooling/project.razor.json
+++ b/src/Shared/files/Tooling/project.razor.json
@@ -1,5 +1,5 @@
 {
-  "__Version": 8,
+  "__Version": 9,
   "ProjectKey": "C:/Users/admin/location/blazorserver/obj/Debug/net7.0/",
   "FilePath": "C:\\Users\\admin\\location\\blazorserver\\blazorserver.csproj",
   "Configuration": {
@@ -14,10 +14,10 @@
     "TagHelpers": [
       {
         "__Checksum": {
-          "Data1": 6061286844381686595,
-          "Data2": -3509629645494075467,
-          "Data3": -4163220002725031508,
-          "Data4": 6551245822798953167
+          "Data1": 2205957666851139978,
+          "Data2": -4888434950107225596,
+          "Data3": 8123139536192065739,
+          "Data4": -4060780608673643358
         },
         "Kind": "Components.Component",
         "Name": "blazorserver.Shared.SurveyPrompt",
@@ -31,7 +31,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "Title",
             "TypeName": "System.String",
             "DisplayName": "string blazorserver.Shared.SurveyPrompt.Title",
@@ -47,10 +46,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -8272200124441055521,
-          "Data2": 3192507281882528461,
-          "Data3": -8617020033445918214,
-          "Data4": 6331033097455329509
+          "Data1": -79469885076750159,
+          "Data2": -1158568038725086650,
+          "Data3": 7896923813786661801,
+          "Data4": -222790907461896368
         },
         "Kind": "Components.Component",
         "Name": "blazorserver.Shared.SurveyPrompt",
@@ -64,7 +63,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "Title",
             "TypeName": "System.String",
             "DisplayName": "string blazorserver.Shared.SurveyPrompt.Title",
@@ -81,10 +79,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 5473644860093740029,
-          "Data2": 3217488933466884548,
-          "Data3": -6816397475916218368,
-          "Data4": -645218128108891421
+          "Data1": -5668828086699309293,
+          "Data2": 8875364557161627681,
+          "Data3": -7574779202237747653,
+          "Data4": -156268761638937756
         },
         "Kind": "Components.Component",
         "Name": "blazorserver.Shared.MainLayout",
@@ -98,7 +96,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "Body",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment blazorserver.Shared.MainLayout.Body",
@@ -116,10 +113,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -6848813730715217130,
-          "Data2": 5545076616194600016,
-          "Data3": -2454109550877469479,
-          "Data4": 2292136035305415854
+          "Data1": -2988513640991825446,
+          "Data2": 4665512476634930616,
+          "Data3": -2100760817611939880,
+          "Data4": 5159877061949332402
         },
         "Kind": "Components.Component",
         "Name": "blazorserver.Shared.MainLayout",
@@ -133,7 +130,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "Body",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment blazorserver.Shared.MainLayout.Body",
@@ -293,10 +289,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -5035068850645222280,
-          "Data2": -7456998929381694606,
-          "Data3": -8494087694553069315,
-          "Data4": 9020086816736217535
+          "Data1": 4394428402669290261,
+          "Data2": -7184744061172253856,
+          "Data3": 7133359203917500493,
+          "Data4": 2331629706134471381
         },
         "Kind": "Components.Component",
         "Name": "blazorserver.Pages.Counter",
@@ -310,7 +306,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "IncrementBy",
             "TypeName": "System.Int32",
             "DisplayName": "int blazorserver.Pages.Counter.IncrementBy",
@@ -326,10 +321,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 4666633979280896812,
-          "Data2": -2806734474025093473,
-          "Data3": 6515806450662697648,
-          "Data4": 8241173596894306299
+          "Data1": 8662847117615253607,
+          "Data2": -5213094298647183440,
+          "Data3": -4257241928234426726,
+          "Data4": 4826485033029399515
         },
         "Kind": "Components.Component",
         "Name": "blazorserver.Pages.Counter",
@@ -343,7 +338,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "IncrementBy",
             "TypeName": "System.Int32",
             "DisplayName": "int blazorserver.Pages.Counter.IncrementBy",
@@ -585,10 +579,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 8202385401340468578,
-          "Data2": -5375384859610881603,
-          "Data3": 8023325730577039621,
-          "Data4": -2733050515650400555
+          "Data1": -5565877197180427498,
+          "Data2": -1713213127484992881,
+          "Data3": 381905209103145549,
+          "Data4": 7124026978686376266
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.CascadingValue<TValue>",
@@ -603,7 +597,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "TValue",
             "TypeName": "System.Type",
             "DisplayName": "System.Type Microsoft.AspNetCore.Components.CascadingValue<TValue>.TValue",
@@ -614,7 +607,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ChildContent",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.CascadingValue<TValue>.ChildContent",
@@ -625,7 +617,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "IsFixed",
             "TypeName": "System.Boolean",
             "DisplayName": "bool Microsoft.AspNetCore.Components.CascadingValue<TValue>.IsFixed",
@@ -635,7 +626,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Name",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.CascadingValue<TValue>.Name",
@@ -645,7 +635,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Value",
             "TypeName": "TValue",
             "DisplayName": "TValue Microsoft.AspNetCore.Components.CascadingValue<TValue>.Value",
@@ -664,10 +653,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -7707091730837947080,
-          "Data2": 7450670912604120744,
-          "Data3": 3600463070597482016,
-          "Data4": -4136962515071990015
+          "Data1": 3087586368897461296,
+          "Data2": 7501669647663203425,
+          "Data3": 704643880938330420,
+          "Data4": -8748201275995255676
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.CascadingValue<TValue>",
@@ -682,7 +671,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "TValue",
             "TypeName": "System.Type",
             "DisplayName": "System.Type Microsoft.AspNetCore.Components.CascadingValue<TValue>.TValue",
@@ -693,7 +681,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ChildContent",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.CascadingValue<TValue>.ChildContent",
@@ -704,7 +691,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "IsFixed",
             "TypeName": "System.Boolean",
             "DisplayName": "bool Microsoft.AspNetCore.Components.CascadingValue<TValue>.IsFixed",
@@ -714,7 +700,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Name",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.CascadingValue<TValue>.Name",
@@ -724,7 +709,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Value",
             "TypeName": "TValue",
             "DisplayName": "TValue Microsoft.AspNetCore.Components.CascadingValue<TValue>.Value",
@@ -795,10 +779,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 7807273508622384831,
-          "Data2": -6182848553992728692,
-          "Data3": -2221154029164828221,
-          "Data4": -533104896711030138
+          "Data1": -7626197026129866567,
+          "Data2": -4390091261969247764,
+          "Data3": -7477737464379754703,
+          "Data4": 1925842161771153304
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.LayoutView",
@@ -813,7 +797,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "ChildContent",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.LayoutView.ChildContent",
@@ -824,7 +807,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Layout",
             "TypeName": "System.Type",
             "DisplayName": "System.Type Microsoft.AspNetCore.Components.LayoutView.Layout",
@@ -841,10 +823,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -1840302802335834317,
-          "Data2": -153782125956705247,
-          "Data3": 635657364706248751,
-          "Data4": -6984228628657005159
+          "Data1": -4303602763111166074,
+          "Data2": -5230155996334919796,
+          "Data3": 427331332625443029,
+          "Data4": -5473701466257906114
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.LayoutView",
@@ -859,7 +841,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "ChildContent",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.LayoutView.ChildContent",
@@ -870,7 +851,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Layout",
             "TypeName": "System.Type",
             "DisplayName": "System.Type Microsoft.AspNetCore.Components.LayoutView.Layout",
@@ -939,10 +919,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -1037125630132714602,
-          "Data2": -1616086300113703073,
-          "Data3": -6621449621467235371,
-          "Data4": 982352179040003102
+          "Data1": -3459271606563805346,
+          "Data2": 1373412039707756808,
+          "Data3": 4240892789132753087,
+          "Data4": -1912656426998882045
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.RouteView",
@@ -957,7 +937,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "DefaultLayout",
             "TypeName": "System.Type",
             "DisplayName": "System.Type Microsoft.AspNetCore.Components.RouteView.DefaultLayout",
@@ -967,7 +946,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "RouteData",
             "TypeName": "Microsoft.AspNetCore.Components.RouteData",
             "DisplayName": "Microsoft.AspNetCore.Components.RouteData Microsoft.AspNetCore.Components.RouteView.RouteData",
@@ -984,10 +962,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 4389540569880506364,
-          "Data2": -5286759962779157010,
-          "Data3": -1004751597676722787,
-          "Data4": -3455098002590143331
+          "Data1": -2774179990284993641,
+          "Data2": 3051342811462863152,
+          "Data3": 4041507345181915029,
+          "Data4": -1980605892336252429
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.RouteView",
@@ -1002,7 +980,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "DefaultLayout",
             "TypeName": "System.Type",
             "DisplayName": "System.Type Microsoft.AspNetCore.Components.RouteView.DefaultLayout",
@@ -1012,7 +989,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "RouteData",
             "TypeName": "Microsoft.AspNetCore.Components.RouteData",
             "DisplayName": "Microsoft.AspNetCore.Components.RouteData Microsoft.AspNetCore.Components.RouteView.RouteData",
@@ -1030,10 +1006,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -5933223569126938725,
-          "Data2": -1573557415743124863,
-          "Data3": 2876303273942590266,
-          "Data4": 6375742745589846309
+          "Data1": -6760499680491574951,
+          "Data2": 2651780240467781798,
+          "Data3": -8191742066418930113,
+          "Data4": -7391709124236922559
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Routing.Router",
@@ -1048,7 +1024,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "AdditionalAssemblies",
             "TypeName": "System.Collections.Generic.IEnumerable<System.Reflection.Assembly>",
             "DisplayName": "System.Collections.Generic.IEnumerable<System.Reflection.Assembly> Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblies",
@@ -1058,7 +1033,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "AppAssembly",
             "TypeName": "System.Reflection.Assembly",
             "DisplayName": "System.Reflection.Assembly Microsoft.AspNetCore.Components.Routing.Router.AppAssembly",
@@ -1068,7 +1042,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Found",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.RouteData>",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.RouteData> Microsoft.AspNetCore.Components.Routing.Router.Found",
@@ -1079,7 +1052,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "NotFound",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Routing.Router.NotFound",
@@ -1090,7 +1062,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Context",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Routing.Router.Context",
@@ -1108,10 +1079,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -6199653498951879289,
-          "Data2": 2496122067636292707,
-          "Data3": -4872984856248201395,
-          "Data4": -30417205116754427
+          "Data1": 2857666114203897708,
+          "Data2": 2410496654782619934,
+          "Data3": -1760385056733281406,
+          "Data4": -1211111533407368512
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Routing.Router",
@@ -1126,7 +1097,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "AdditionalAssemblies",
             "TypeName": "System.Collections.Generic.IEnumerable<System.Reflection.Assembly>",
             "DisplayName": "System.Collections.Generic.IEnumerable<System.Reflection.Assembly> Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblies",
@@ -1136,7 +1106,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "AppAssembly",
             "TypeName": "System.Reflection.Assembly",
             "DisplayName": "System.Reflection.Assembly Microsoft.AspNetCore.Components.Routing.Router.AppAssembly",
@@ -1146,7 +1115,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Found",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.RouteData>",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.RouteData> Microsoft.AspNetCore.Components.Routing.Router.Found",
@@ -1157,7 +1125,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "NotFound",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Routing.Router.NotFound",
@@ -1168,7 +1135,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Context",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Routing.Router.Context",
@@ -1187,10 +1153,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 5521593701390917117,
-          "Data2": 791628993588055764,
-          "Data3": 8974326650480668753,
-          "Data4": 1315803482646661826
+          "Data1": 7058980571054506207,
+          "Data2": 4559803075693692313,
+          "Data3": -7293023564291922001,
+          "Data4": -6098684290999080040
         },
         "Kind": "Components.ChildContent",
         "Name": "Microsoft.AspNetCore.Components.Routing.Router.Found",
@@ -1206,7 +1172,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.ChildContent",
             "Name": "Context",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Routing.Router.Found.Context",
@@ -1225,10 +1190,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -5166257849585688790,
-          "Data2": 2081610852434591674,
-          "Data3": -7754336283337295302,
-          "Data4": 3587555488027520311
+          "Data1": -6462700337655222361,
+          "Data2": -2634475478587958924,
+          "Data3": 2098051346531768716,
+          "Data4": -5338772039622499717
         },
         "Kind": "Components.ChildContent",
         "Name": "Microsoft.AspNetCore.Components.Routing.Router.Found",
@@ -1244,7 +1209,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.ChildContent",
             "Name": "Context",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Routing.Router.Found.Context",
@@ -1362,10 +1326,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -7906254189826351968,
-          "Data2": 8108708465171454379,
-          "Data3": 6887661408208474228,
-          "Data4": -2577730384082154720
+          "Data1": -4528052239242706063,
+          "Data2": -109203822841912835,
+          "Data3": 8821629915008811277,
+          "Data4": -1493102183666356355
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Forms.EditForm",
@@ -1380,7 +1344,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "AdditionalAttributes",
             "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
             "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.EditForm.AdditionalAttributes",
@@ -1390,7 +1353,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ChildContent",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Forms.EditContext>",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Forms.EditContext> Microsoft.AspNetCore.Components.Forms.EditForm.ChildContent",
@@ -1401,7 +1363,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "EditContext",
             "TypeName": "Microsoft.AspNetCore.Components.Forms.EditContext",
             "DisplayName": "Microsoft.AspNetCore.Components.Forms.EditContext Microsoft.AspNetCore.Components.Forms.EditForm.EditContext",
@@ -1411,7 +1372,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Model",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Components.Forms.EditForm.Model",
@@ -1421,7 +1381,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "OnInvalidSubmit",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext> Microsoft.AspNetCore.Components.Forms.EditForm.OnInvalidSubmit",
@@ -1432,7 +1391,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "OnSubmit",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext> Microsoft.AspNetCore.Components.Forms.EditForm.OnSubmit",
@@ -1443,7 +1401,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "OnValidSubmit",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext> Microsoft.AspNetCore.Components.Forms.EditForm.OnValidSubmit",
@@ -1454,7 +1411,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Context",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Forms.EditForm.Context",
@@ -1472,10 +1428,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -7173788782013791511,
-          "Data2": 3832482079522377255,
-          "Data3": -5438062843703250881,
-          "Data4": -6474824386152906838
+          "Data1": -3617158658172416900,
+          "Data2": -2348207643384115453,
+          "Data3": -8550314975978379726,
+          "Data4": 3690532382081952553
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Forms.EditForm",
@@ -1490,7 +1446,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "AdditionalAttributes",
             "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
             "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.EditForm.AdditionalAttributes",
@@ -1500,7 +1455,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ChildContent",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Forms.EditContext>",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Forms.EditContext> Microsoft.AspNetCore.Components.Forms.EditForm.ChildContent",
@@ -1511,7 +1465,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "EditContext",
             "TypeName": "Microsoft.AspNetCore.Components.Forms.EditContext",
             "DisplayName": "Microsoft.AspNetCore.Components.Forms.EditContext Microsoft.AspNetCore.Components.Forms.EditForm.EditContext",
@@ -1521,7 +1474,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Model",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Components.Forms.EditForm.Model",
@@ -1531,7 +1483,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "OnInvalidSubmit",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext> Microsoft.AspNetCore.Components.Forms.EditForm.OnInvalidSubmit",
@@ -1542,7 +1493,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "OnSubmit",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext> Microsoft.AspNetCore.Components.Forms.EditForm.OnSubmit",
@@ -1553,7 +1503,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "OnValidSubmit",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext> Microsoft.AspNetCore.Components.Forms.EditForm.OnValidSubmit",
@@ -1564,7 +1513,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Context",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Forms.EditForm.Context",
@@ -1583,10 +1531,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -2191739191753694722,
-          "Data2": 4317339690188826498,
-          "Data3": 2663111846541987276,
-          "Data4": -7826242693059002565
+          "Data1": 3331562061117141795,
+          "Data2": -8213073130700536458,
+          "Data3": -3782232259500455136,
+          "Data4": 851844239808169418
         },
         "Kind": "Components.ChildContent",
         "Name": "Microsoft.AspNetCore.Components.Forms.EditForm.ChildContent",
@@ -1602,7 +1550,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.ChildContent",
             "Name": "Context",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Forms.EditForm.ChildContent.Context",
@@ -1621,10 +1568,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -2135552822916027170,
-          "Data2": 3371645632847248075,
-          "Data3": -2534541211820044028,
-          "Data4": -7437493478965916397
+          "Data1": -1716361926042188688,
+          "Data2": -1902716598272165335,
+          "Data3": -5213501006218420104,
+          "Data4": -3694290382834179468
         },
         "Kind": "Components.ChildContent",
         "Name": "Microsoft.AspNetCore.Components.Forms.EditForm.ChildContent",
@@ -1640,7 +1587,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.ChildContent",
             "Name": "Context",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Forms.EditForm.ChildContent.Context",
@@ -1660,10 +1606,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -994772237188160001,
-          "Data2": 1911835594806758420,
-          "Data3": -623541827337558349,
-          "Data4": -3172812162084065786
+          "Data1": 1112851599993855985,
+          "Data2": 6302017601242539655,
+          "Data3": 4972390266179088336,
+          "Data4": 7771065077262376444
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputCheckbox",
@@ -1678,7 +1624,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "AdditionalAttributes",
             "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
             "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputCheckbox.AdditionalAttributes",
@@ -1688,7 +1633,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Value",
             "TypeName": "System.Boolean",
             "DisplayName": "bool Microsoft.AspNetCore.Components.Forms.InputCheckbox.Value",
@@ -1698,7 +1642,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ValueChanged",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.Boolean>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.Boolean> Microsoft.AspNetCore.Components.Forms.InputCheckbox.ValueChanged",
@@ -1709,7 +1652,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ValueExpression",
             "TypeName": "System.Linq.Expressions.Expression<System.Func<System.Boolean>>",
             "DisplayName": "System.Linq.Expressions.Expression<System.Func<System.Boolean>> Microsoft.AspNetCore.Components.Forms.InputCheckbox.ValueExpression",
@@ -1726,10 +1668,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -822023967113183563,
-          "Data2": 5090540507464855088,
-          "Data3": -2456693399029036915,
-          "Data4": -3303461604620183295
+          "Data1": -4421719026463313333,
+          "Data2": -3121784923221853076,
+          "Data3": 5629001748817309714,
+          "Data4": -3089240132522924285
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputCheckbox",
@@ -1744,7 +1686,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "AdditionalAttributes",
             "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
             "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputCheckbox.AdditionalAttributes",
@@ -1754,7 +1695,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Value",
             "TypeName": "System.Boolean",
             "DisplayName": "bool Microsoft.AspNetCore.Components.Forms.InputCheckbox.Value",
@@ -1764,7 +1704,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ValueChanged",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.Boolean>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.Boolean> Microsoft.AspNetCore.Components.Forms.InputCheckbox.ValueChanged",
@@ -1775,7 +1714,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ValueExpression",
             "TypeName": "System.Linq.Expressions.Expression<System.Func<System.Boolean>>",
             "DisplayName": "System.Linq.Expressions.Expression<System.Func<System.Boolean>> Microsoft.AspNetCore.Components.Forms.InputCheckbox.ValueExpression",
@@ -1793,10 +1731,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -4014488012542105858,
-          "Data2": -4911626289449194176,
-          "Data3": -5235297703911075720,
-          "Data4": -3218798648394218265
+          "Data1": -1878417912986129784,
+          "Data2": 8797822280754627464,
+          "Data3": 542882373970502730,
+          "Data4": -294031401483272361
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputDate<TValue>",
@@ -1811,7 +1749,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "TValue",
             "TypeName": "System.Type",
             "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.TValue",
@@ -1822,7 +1759,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ParsingErrorMessage",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.ParsingErrorMessage",
@@ -1832,7 +1768,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "AdditionalAttributes",
             "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
             "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.AdditionalAttributes",
@@ -1842,7 +1777,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Value",
             "TypeName": "TValue",
             "DisplayName": "TValue Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.Value",
@@ -1853,7 +1787,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ValueChanged",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.ValueChanged",
@@ -1865,7 +1798,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ValueExpression",
             "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
             "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.ValueExpression",
@@ -1884,10 +1816,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -1348188649515223903,
-          "Data2": -4516579446930703269,
-          "Data3": -109532054666873781,
-          "Data4": -2131723650399140374
+          "Data1": -3393880815908270001,
+          "Data2": 685953614237589899,
+          "Data3": 7754691956014213105,
+          "Data4": -2823985032795115254
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputDate<TValue>",
@@ -1902,7 +1834,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "TValue",
             "TypeName": "System.Type",
             "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.TValue",
@@ -1913,7 +1844,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ParsingErrorMessage",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.ParsingErrorMessage",
@@ -1923,7 +1853,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "AdditionalAttributes",
             "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
             "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.AdditionalAttributes",
@@ -1933,7 +1862,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Value",
             "TypeName": "TValue",
             "DisplayName": "TValue Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.Value",
@@ -1944,7 +1872,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ValueChanged",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.ValueChanged",
@@ -1956,7 +1883,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ValueExpression",
             "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
             "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.ValueExpression",
@@ -1976,10 +1902,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 6786574471546872590,
-          "Data2": 8504731209506744967,
-          "Data3": -1188062655633844511,
-          "Data4": 3710433465127081731
+          "Data1": 929803852637260487,
+          "Data2": 9222847544467499432,
+          "Data3": -387266781315817607,
+          "Data4": 1971572912529147352
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>",
@@ -1994,7 +1920,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "TValue",
             "TypeName": "System.Type",
             "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.TValue",
@@ -2005,7 +1930,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ParsingErrorMessage",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.ParsingErrorMessage",
@@ -2015,7 +1939,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "AdditionalAttributes",
             "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
             "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.AdditionalAttributes",
@@ -2025,7 +1948,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Value",
             "TypeName": "TValue",
             "DisplayName": "TValue Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.Value",
@@ -2036,7 +1958,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ValueChanged",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.ValueChanged",
@@ -2048,7 +1969,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ValueExpression",
             "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
             "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.ValueExpression",
@@ -2067,10 +1987,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -5665799265994518719,
-          "Data2": 8693226864600233243,
-          "Data3": 6860519463529833238,
-          "Data4": -2059076502700115477
+          "Data1": -2536303132150856332,
+          "Data2": -3060503368024729378,
+          "Data3": -2605512317130115369,
+          "Data4": -5428685823007244180
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>",
@@ -2085,7 +2005,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "TValue",
             "TypeName": "System.Type",
             "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.TValue",
@@ -2096,7 +2015,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ParsingErrorMessage",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.ParsingErrorMessage",
@@ -2106,7 +2024,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "AdditionalAttributes",
             "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
             "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.AdditionalAttributes",
@@ -2116,7 +2033,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Value",
             "TypeName": "TValue",
             "DisplayName": "TValue Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.Value",
@@ -2127,7 +2043,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ValueChanged",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.ValueChanged",
@@ -2139,7 +2054,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ValueExpression",
             "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
             "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.ValueExpression",
@@ -2159,10 +2073,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -5363634183252300361,
-          "Data2": -1104495869548237653,
-          "Data3": -4483454044428429270,
-          "Data4": -5842860476603866287
+          "Data1": 5284937739017253348,
+          "Data2": -2781889471601138276,
+          "Data3": 7233415902714343071,
+          "Data4": 2749566486894073723
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>",
@@ -2177,7 +2091,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "TValue",
             "TypeName": "System.Type",
             "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.TValue",
@@ -2188,7 +2101,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ChildContent",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.ChildContent",
@@ -2199,7 +2111,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "AdditionalAttributes",
             "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
             "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.AdditionalAttributes",
@@ -2209,7 +2120,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Value",
             "TypeName": "TValue",
             "DisplayName": "TValue Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.Value",
@@ -2220,7 +2130,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ValueChanged",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.ValueChanged",
@@ -2232,7 +2141,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ValueExpression",
             "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
             "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.ValueExpression",
@@ -2251,10 +2159,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -7792199865075843891,
-          "Data2": -7345028372434242890,
-          "Data3": -4867540506281309861,
-          "Data4": 2288799950907448315
+          "Data1": 1576485838685044901,
+          "Data2": -706046183072614225,
+          "Data3": 8947524270165714811,
+          "Data4": -112728465132983155
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>",
@@ -2269,7 +2177,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "TValue",
             "TypeName": "System.Type",
             "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.TValue",
@@ -2280,7 +2187,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ChildContent",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.ChildContent",
@@ -2291,7 +2197,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "AdditionalAttributes",
             "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
             "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.AdditionalAttributes",
@@ -2301,7 +2206,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Value",
             "TypeName": "TValue",
             "DisplayName": "TValue Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.Value",
@@ -2312,7 +2216,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ValueChanged",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.ValueChanged",
@@ -2324,7 +2227,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ValueExpression",
             "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
             "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.ValueExpression",
@@ -2395,10 +2297,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -1260245421057077116,
-          "Data2": -8647941844001529024,
-          "Data3": -9177010456434960776,
-          "Data4": 7882579543832870567
+          "Data1": -245706652032809211,
+          "Data2": 1240784826824413952,
+          "Data3": -6476785001297735711,
+          "Data4": -7277399732916756262
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputText",
@@ -2413,7 +2315,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "AdditionalAttributes",
             "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
             "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputText.AdditionalAttributes",
@@ -2423,7 +2324,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Value",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputText.Value",
@@ -2433,7 +2333,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ValueChanged",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.String>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.String> Microsoft.AspNetCore.Components.Forms.InputText.ValueChanged",
@@ -2444,7 +2343,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ValueExpression",
             "TypeName": "System.Linq.Expressions.Expression<System.Func<System.String>>",
             "DisplayName": "System.Linq.Expressions.Expression<System.Func<System.String>> Microsoft.AspNetCore.Components.Forms.InputText.ValueExpression",
@@ -2461,10 +2359,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -6815311664589827950,
-          "Data2": 6411302942994709170,
-          "Data3": -3937237211678035013,
-          "Data4": -5475257928288314773
+          "Data1": 6363180478798300051,
+          "Data2": 1629363277040245540,
+          "Data3": -7041400496966494684,
+          "Data4": -7629079903314163231
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputText",
@@ -2479,7 +2377,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "AdditionalAttributes",
             "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
             "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputText.AdditionalAttributes",
@@ -2489,7 +2386,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Value",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputText.Value",
@@ -2499,7 +2395,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ValueChanged",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.String>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.String> Microsoft.AspNetCore.Components.Forms.InputText.ValueChanged",
@@ -2510,7 +2405,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ValueExpression",
             "TypeName": "System.Linq.Expressions.Expression<System.Func<System.String>>",
             "DisplayName": "System.Linq.Expressions.Expression<System.Func<System.String>> Microsoft.AspNetCore.Components.Forms.InputText.ValueExpression",
@@ -2528,10 +2422,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -1677987126101442127,
-          "Data2": 2825050316355048928,
-          "Data3": 4962434039302466483,
-          "Data4": -7006060393034768342
+          "Data1": 4106233762938464219,
+          "Data2": 8542267803745352449,
+          "Data3": -2117659661014207510,
+          "Data4": 7918779881820810143
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputTextArea",
@@ -2546,7 +2440,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "AdditionalAttributes",
             "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
             "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputTextArea.AdditionalAttributes",
@@ -2556,7 +2449,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Value",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputTextArea.Value",
@@ -2566,7 +2458,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ValueChanged",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.String>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.String> Microsoft.AspNetCore.Components.Forms.InputTextArea.ValueChanged",
@@ -2577,7 +2468,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ValueExpression",
             "TypeName": "System.Linq.Expressions.Expression<System.Func<System.String>>",
             "DisplayName": "System.Linq.Expressions.Expression<System.Func<System.String>> Microsoft.AspNetCore.Components.Forms.InputTextArea.ValueExpression",
@@ -2594,10 +2484,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -1880816940356217106,
-          "Data2": -8586237978257251508,
-          "Data3": 7270063276236377202,
-          "Data4": 8054752571604463012
+          "Data1": 9185292233573707144,
+          "Data2": 1328609155858866771,
+          "Data3": 7480795925985302497,
+          "Data4": -1733733899311390205
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputTextArea",
@@ -2612,7 +2502,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "AdditionalAttributes",
             "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
             "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.InputTextArea.AdditionalAttributes",
@@ -2622,7 +2511,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Value",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Forms.InputTextArea.Value",
@@ -2632,7 +2520,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ValueChanged",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.String>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.String> Microsoft.AspNetCore.Components.Forms.InputTextArea.ValueChanged",
@@ -2643,7 +2530,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ValueExpression",
             "TypeName": "System.Linq.Expressions.Expression<System.Func<System.String>>",
             "DisplayName": "System.Linq.Expressions.Expression<System.Func<System.String>> Microsoft.AspNetCore.Components.Forms.InputTextArea.ValueExpression",
@@ -2661,10 +2547,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -4779493452979454058,
-          "Data2": -2922063454765557541,
-          "Data3": 1154252160895259457,
-          "Data4": -4963103672470905082
+          "Data1": -1998635663361294242,
+          "Data2": 7052971659955072742,
+          "Data3": 8021928100748038055,
+          "Data4": -6693831470370237438
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>",
@@ -2679,7 +2565,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "TValue",
             "TypeName": "System.Type",
             "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.TValue",
@@ -2690,7 +2575,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "AdditionalAttributes",
             "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
             "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.AdditionalAttributes",
@@ -2700,7 +2584,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "For",
             "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
             "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.For",
@@ -2719,10 +2602,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 7561654683586828361,
-          "Data2": -265600939287987706,
-          "Data3": 8787313017900664055,
-          "Data4": -6648064444371016639
+          "Data1": -7245233790982522648,
+          "Data2": 4260007114267372989,
+          "Data3": 8149211874406392518,
+          "Data4": -4903763035390753602
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>",
@@ -2737,7 +2620,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "TValue",
             "TypeName": "System.Type",
             "DisplayName": "System.Type Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.TValue",
@@ -2748,7 +2630,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "AdditionalAttributes",
             "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
             "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.AdditionalAttributes",
@@ -2758,7 +2639,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "For",
             "TypeName": "System.Linq.Expressions.Expression<System.Func<TValue>>",
             "DisplayName": "System.Linq.Expressions.Expression<System.Func<TValue>> Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.For",
@@ -2778,10 +2658,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 3268878861475968402,
-          "Data2": -3085768924318266765,
-          "Data3": -3737038958981691437,
-          "Data4": -583684553546549287
+          "Data1": -2461918249565140771,
+          "Data2": -7708735993970044436,
+          "Data3": -1408401530180349645,
+          "Data4": 564379093592188967
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Forms.ValidationSummary",
@@ -2796,7 +2676,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "AdditionalAttributes",
             "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
             "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.ValidationSummary.AdditionalAttributes",
@@ -2806,7 +2685,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Model",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Components.Forms.ValidationSummary.Model",
@@ -2823,10 +2701,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 6641744145252366992,
-          "Data2": 8780013966934208113,
-          "Data3": -8486352732775490591,
-          "Data4": 6777768720975918941
+          "Data1": 2236443702256880519,
+          "Data2": -4637194214352942295,
+          "Data3": 1506854185754314887,
+          "Data4": -8972219424795424470
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Forms.ValidationSummary",
@@ -2841,7 +2719,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "AdditionalAttributes",
             "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
             "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Forms.ValidationSummary.AdditionalAttributes",
@@ -2851,7 +2728,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Model",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Components.Forms.ValidationSummary.Model",
@@ -2869,10 +2745,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -7930269220939289169,
-          "Data2": -3823795430271552280,
-          "Data3": -6766555444483409379,
-          "Data4": 601125770970382031
+          "Data1": -3240860403992573257,
+          "Data2": 5822947913639406324,
+          "Data3": -8756269775768192136,
+          "Data4": -4611353422432826480
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Routing.NavLink",
@@ -2887,7 +2763,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "ActiveClass",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Routing.NavLink.ActiveClass",
@@ -2897,7 +2772,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "AdditionalAttributes",
             "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
             "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Routing.NavLink.AdditionalAttributes",
@@ -2907,7 +2781,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ChildContent",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Routing.NavLink.ChildContent",
@@ -2918,7 +2791,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Match",
             "TypeName": "Microsoft.AspNetCore.Components.Routing.NavLinkMatch",
             "IsEnum": true,
@@ -2936,10 +2808,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 1067206396698089627,
-          "Data2": -8074835301360337358,
-          "Data3": 5233166494748657446,
-          "Data4": 4826562835420918186
+          "Data1": -1107855582372063008,
+          "Data2": -5671915378606023880,
+          "Data3": -58912785841935677,
+          "Data4": -5479638336041014752
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Routing.NavLink",
@@ -2954,7 +2826,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "ActiveClass",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Routing.NavLink.ActiveClass",
@@ -2964,7 +2835,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "AdditionalAttributes",
             "TypeName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object>",
             "DisplayName": "System.Collections.Generic.IReadOnlyDictionary<System.String, System.Object> Microsoft.AspNetCore.Components.Routing.NavLink.AdditionalAttributes",
@@ -2974,7 +2844,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ChildContent",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Routing.NavLink.ChildContent",
@@ -2985,7 +2854,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Match",
             "TypeName": "Microsoft.AspNetCore.Components.Routing.NavLinkMatch",
             "IsEnum": true,
@@ -3055,10 +2923,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -4072619110006879300,
-          "Data2": -6716239322897067393,
-          "Data3": 6290479884185608838,
-          "Data4": -6965375435982299232
+          "Data1": 5857842373429144568,
+          "Data2": 2499310004812972900,
+          "Data3": -4228548359682634411,
+          "Data4": 5321320430360311532
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView",
@@ -3073,7 +2941,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "Authorizing",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.Authorizing",
@@ -3084,7 +2951,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "NotAuthorized",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState> Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.NotAuthorized",
@@ -3095,7 +2961,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "DefaultLayout",
             "TypeName": "System.Type",
             "DisplayName": "System.Type Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.DefaultLayout",
@@ -3105,7 +2970,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "RouteData",
             "TypeName": "Microsoft.AspNetCore.Components.RouteData",
             "DisplayName": "Microsoft.AspNetCore.Components.RouteData Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.RouteData",
@@ -3115,7 +2979,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Context",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.Context",
@@ -3133,10 +2996,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 1546535669066383674,
-          "Data2": -6624947166155208018,
-          "Data3": -8975974415570372582,
-          "Data4": 182678049566650579
+          "Data1": -3763808454196852747,
+          "Data2": -3597090929263414172,
+          "Data3": 5390997603620084410,
+          "Data4": 718642153331988188
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView",
@@ -3151,7 +3014,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "Authorizing",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.Authorizing",
@@ -3162,7 +3024,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "NotAuthorized",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState> Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.NotAuthorized",
@@ -3173,7 +3034,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "DefaultLayout",
             "TypeName": "System.Type",
             "DisplayName": "System.Type Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.DefaultLayout",
@@ -3183,7 +3043,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "RouteData",
             "TypeName": "Microsoft.AspNetCore.Components.RouteData",
             "DisplayName": "Microsoft.AspNetCore.Components.RouteData Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.RouteData",
@@ -3193,7 +3052,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Context",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.Context",
@@ -3263,10 +3121,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -7900880670236778436,
-          "Data2": -492759724666899603,
-          "Data3": -8318058108170115511,
-          "Data4": 7692819440845412472
+          "Data1": -2305063709664911972,
+          "Data2": -3836692330257859269,
+          "Data3": 1152516664308530557,
+          "Data4": 7677710536495400697
         },
         "Kind": "Components.ChildContent",
         "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.NotAuthorized",
@@ -3282,7 +3140,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.ChildContent",
             "Name": "Context",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.NotAuthorized.Context",
@@ -3301,10 +3158,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 2052719071089013692,
-          "Data2": -4831329913779962238,
-          "Data3": -8298312194907749583,
-          "Data4": 7869366869121859110
+          "Data1": 5146293947353785505,
+          "Data2": -2585789208612711294,
+          "Data3": 6422608924898860015,
+          "Data4": -7127218711851004348
         },
         "Kind": "Components.ChildContent",
         "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.NotAuthorized",
@@ -3320,7 +3177,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.ChildContent",
             "Name": "Context",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.NotAuthorized.Context",
@@ -3340,10 +3196,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -8070427849713960,
-          "Data2": -9149071925088452531,
-          "Data3": -5079158912811502097,
-          "Data4": -2159343735077021184
+          "Data1": 2169351904371775293,
+          "Data2": 735371848485746954,
+          "Data3": -8815848765391602976,
+          "Data4": 3473247602770987591
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeView",
@@ -3358,7 +3214,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "Policy",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Policy",
@@ -3368,7 +3223,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Roles",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Roles",
@@ -3378,7 +3232,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Authorized",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState> Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Authorized",
@@ -3389,7 +3242,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Authorizing",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Authorizing",
@@ -3400,7 +3252,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ChildContent",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState> Microsoft.AspNetCore.Components.Authorization.AuthorizeView.ChildContent",
@@ -3411,7 +3262,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "NotAuthorized",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState> Microsoft.AspNetCore.Components.Authorization.AuthorizeView.NotAuthorized",
@@ -3422,7 +3272,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Resource",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Resource",
@@ -3432,7 +3281,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Context",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Context",
@@ -3450,10 +3298,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -2552795462621933001,
-          "Data2": -4475327305971357852,
-          "Data3": 4189549595930373829,
-          "Data4": -6862794564859221714
+          "Data1": -2045590790797547151,
+          "Data2": 1618390722270554152,
+          "Data3": 7991193592933725366,
+          "Data4": 189264197067846988
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeView",
@@ -3468,7 +3316,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "Policy",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Policy",
@@ -3478,7 +3325,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Roles",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Roles",
@@ -3488,7 +3334,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Authorized",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState> Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Authorized",
@@ -3499,7 +3344,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Authorizing",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Authorizing",
@@ -3510,7 +3354,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "ChildContent",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState> Microsoft.AspNetCore.Components.Authorization.AuthorizeView.ChildContent",
@@ -3521,7 +3364,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "NotAuthorized",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Authorization.AuthenticationState> Microsoft.AspNetCore.Components.Authorization.AuthorizeView.NotAuthorized",
@@ -3532,7 +3374,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Resource",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Resource",
@@ -3542,7 +3383,6 @@
             }
           },
           {
-            "Kind": "Components.Component",
             "Name": "Context",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Context",
@@ -3561,10 +3401,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -8792258945095018355,
-          "Data2": 1677955596885467840,
-          "Data3": -8452829606142298716,
-          "Data4": 3565606104018453671
+          "Data1": 4816202770201418108,
+          "Data2": 2477212693312575066,
+          "Data3": 7657344376580364956,
+          "Data4": 3572789110943803256
         },
         "Kind": "Components.ChildContent",
         "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Authorized",
@@ -3580,7 +3420,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.ChildContent",
             "Name": "Context",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Authorized.Context",
@@ -3599,10 +3438,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -725821276974157574,
-          "Data2": -3841790774438785247,
-          "Data3": -7268991471424337278,
-          "Data4": -6786916453996432686
+          "Data1": -7447782942421774606,
+          "Data2": 7252076789583392581,
+          "Data3": 7804960329063965226,
+          "Data4": 6164634307386151822
         },
         "Kind": "Components.ChildContent",
         "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Authorized",
@@ -3618,7 +3457,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.ChildContent",
             "Name": "Context",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.Authorized.Context",
@@ -3689,10 +3527,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -6074874818036093638,
-          "Data2": -5343328456938605482,
-          "Data3": -7523482950792461170,
-          "Data4": 1043767006905425447
+          "Data1": 1793175268476174552,
+          "Data2": 8253576654194619302,
+          "Data3": -7729274157426279151,
+          "Data4": 3171616222788854502
         },
         "Kind": "Components.ChildContent",
         "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeView.ChildContent",
@@ -3708,7 +3546,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.ChildContent",
             "Name": "Context",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.ChildContent.Context",
@@ -3727,10 +3564,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -7804629385657189790,
-          "Data2": -4392657441089329898,
-          "Data3": 8513447399513683184,
-          "Data4": 64583600662086218
+          "Data1": -7835446588884424946,
+          "Data2": -3438698165991645918,
+          "Data3": -1986762761220695606,
+          "Data4": -4850942685575299932
         },
         "Kind": "Components.ChildContent",
         "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeView.ChildContent",
@@ -3746,7 +3583,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.ChildContent",
             "Name": "Context",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.ChildContent.Context",
@@ -3766,10 +3602,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -5084918521656317734,
-          "Data2": -5503808218703353072,
-          "Data3": -2824350835764492638,
-          "Data4": 5716971420806197934
+          "Data1": -1757679111339041480,
+          "Data2": 1868200205735905425,
+          "Data3": -8361515324976835325,
+          "Data4": -4099795905783720617
         },
         "Kind": "Components.ChildContent",
         "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeView.NotAuthorized",
@@ -3785,7 +3621,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.ChildContent",
             "Name": "Context",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.NotAuthorized.Context",
@@ -3804,10 +3639,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -8996975521189226223,
-          "Data2": 3919434235983000783,
-          "Data3": -8790808738430810417,
-          "Data4": -2475279372665641175
+          "Data1": 7908104894269432140,
+          "Data2": -6392661935104968283,
+          "Data3": -4035029582563983419,
+          "Data4": 1538599295674173276
         },
         "Kind": "Components.ChildContent",
         "Name": "Microsoft.AspNetCore.Components.Authorization.AuthorizeView.NotAuthorized",
@@ -3823,7 +3658,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.ChildContent",
             "Name": "Context",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Authorization.AuthorizeView.NotAuthorized.Context",
@@ -3843,10 +3677,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -56405805199506980,
-          "Data2": 519958640554576957,
-          "Data3": 4300585853209901115,
-          "Data4": -8677661075565932619
+          "Data1": 400304921512101592,
+          "Data2": -2324079323346758672,
+          "Data3": -2172593692317741303,
+          "Data4": -8300976869231578811
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Authorization.CascadingAuthenticationState",
@@ -3860,7 +3694,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "ChildContent",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Authorization.CascadingAuthenticationState.ChildContent",
@@ -3878,10 +3711,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -325803510819845466,
-          "Data2": 5725878852881593564,
-          "Data3": 6569730579271063039,
-          "Data4": 999510316322616976
+          "Data1": 2954484474720783013,
+          "Data2": 7203683079082070346,
+          "Data3": 6037391209836578291,
+          "Data4": -4209279650204791142
         },
         "Kind": "Components.Component",
         "Name": "Microsoft.AspNetCore.Components.Authorization.CascadingAuthenticationState",
@@ -3895,7 +3728,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Component",
             "Name": "ChildContent",
             "TypeName": "Microsoft.AspNetCore.Components.RenderFragment",
             "DisplayName": "Microsoft.AspNetCore.Components.RenderFragment Microsoft.AspNetCore.Components.Authorization.CascadingAuthenticationState.ChildContent",
@@ -3965,10 +3797,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -8992313363209873927,
-          "Data2": -3655802480539703541,
-          "Data3": -2330326131543029036,
-          "Data4": 7519391784737206318
+          "Data1": -3940417563334077494,
+          "Data2": -2793705821820990431,
+          "Data3": -2819452048435388354,
+          "Data4": -6427168090089153143
         },
         "Kind": "Components.EventHandler",
         "Name": "onabort",
@@ -4016,14 +3848,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onabort",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onabort",
             "Documentation": "Sets the '@onabort' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.ProgressEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -4033,7 +3863,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -4060,10 +3889,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 938090781900994928,
-          "Data2": -5290180608186378248,
-          "Data3": -4957861622602349637,
-          "Data4": 3504043449466236137
+          "Data1": 663808531574318153,
+          "Data2": -5342669193472976545,
+          "Data3": 3231042630720217159,
+          "Data4": -4657886527781031961
         },
         "Kind": "Components.EventHandler",
         "Name": "onactivate",
@@ -4111,14 +3940,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onactivate",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onactivate",
             "Documentation": "Sets the '@onactivate' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -4128,7 +3955,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -4155,10 +3981,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 8039034258614680105,
-          "Data2": 331245233945891656,
-          "Data3": 4039577465971045385,
-          "Data4": -5191960783871073851
+          "Data1": 6132316950804341443,
+          "Data2": 6089971888954621902,
+          "Data3": -4156982735535684027,
+          "Data4": -2124537412001647170
         },
         "Kind": "Components.EventHandler",
         "Name": "onbeforeactivate",
@@ -4206,14 +4032,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onbeforeactivate",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onbeforeactivate",
             "Documentation": "Sets the '@onbeforeactivate' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -4223,7 +4047,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -4250,10 +4073,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -2715059873981265449,
-          "Data2": -160531301554072175,
-          "Data3": 8631261883321947732,
-          "Data4": 4824765216449323858
+          "Data1": -4417619601065321449,
+          "Data2": 5709741143472002433,
+          "Data3": 7826813524506825041,
+          "Data4": 80996938954557616
         },
         "Kind": "Components.EventHandler",
         "Name": "onbeforecopy",
@@ -4301,14 +4124,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onbeforecopy",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onbeforecopy",
             "Documentation": "Sets the '@onbeforecopy' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -4318,7 +4139,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -4345,10 +4165,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 4406535783273597157,
-          "Data2": -4107734861290127588,
-          "Data3": 3452629339803535205,
-          "Data4": -5601723211575787753
+          "Data1": 4083028498643620681,
+          "Data2": 6699159384895549212,
+          "Data3": -964135144641896893,
+          "Data4": 7077770681443152311
         },
         "Kind": "Components.EventHandler",
         "Name": "onbeforecut",
@@ -4396,14 +4216,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onbeforecut",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onbeforecut",
             "Documentation": "Sets the '@onbeforecut' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -4413,7 +4231,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -4440,10 +4257,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -6748682902735353586,
-          "Data2": -2530618646295627014,
-          "Data3": -1373333778984430042,
-          "Data4": 8629605447072873777
+          "Data1": -8025806188617320204,
+          "Data2": -6082686652704030811,
+          "Data3": -8093279825675698828,
+          "Data4": 5746838786326800862
         },
         "Kind": "Components.EventHandler",
         "Name": "onbeforedeactivate",
@@ -4491,14 +4308,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onbeforedeactivate",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onbeforedeactivate",
             "Documentation": "Sets the '@onbeforedeactivate' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -4508,7 +4323,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -4535,10 +4349,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -6885673437278318489,
-          "Data2": 1443414087206427903,
-          "Data3": 5369681800668979522,
-          "Data4": 7563256526975373971
+          "Data1": 7571357410927497047,
+          "Data2": 4411204822237174079,
+          "Data3": 5674332168413130579,
+          "Data4": -6407069184537736335
         },
         "Kind": "Components.EventHandler",
         "Name": "onbeforepaste",
@@ -4586,14 +4400,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onbeforepaste",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onbeforepaste",
             "Documentation": "Sets the '@onbeforepaste' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -4603,7 +4415,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -4630,10 +4441,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -1065766841023654020,
-          "Data2": -3484884816410802783,
-          "Data3": 188006565036612673,
-          "Data4": 17051617281311607
+          "Data1": -3083377324508042193,
+          "Data2": 4286671850891278896,
+          "Data3": -1562549968301713547,
+          "Data4": -5806696531572346695
         },
         "Kind": "Components.EventHandler",
         "Name": "onblur",
@@ -4681,14 +4492,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onblur",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.FocusEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.FocusEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onblur",
             "Documentation": "Sets the '@onblur' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.FocusEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -4698,7 +4507,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -4725,10 +4533,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 487929580127375551,
-          "Data2": 3945390865984076387,
-          "Data3": -2808422069315909470,
-          "Data4": 4592502409528287440
+          "Data1": -3765025795286826325,
+          "Data2": 4110408392074931211,
+          "Data3": -173425413977177963,
+          "Data4": 5397233470819788401
         },
         "Kind": "Components.EventHandler",
         "Name": "oncanplay",
@@ -4776,14 +4584,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@oncanplay",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.oncanplay",
             "Documentation": "Sets the '@oncanplay' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -4793,7 +4599,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -4820,10 +4625,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 8000283031634109416,
-          "Data2": -4034862828905020548,
-          "Data3": 6918861490875917576,
-          "Data4": -249377547285348801
+          "Data1": -2340322281072073047,
+          "Data2": 5662284887384028074,
+          "Data3": -5505732082821801489,
+          "Data4": 7245304881374543053
         },
         "Kind": "Components.EventHandler",
         "Name": "oncanplaythrough",
@@ -4871,14 +4676,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@oncanplaythrough",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.oncanplaythrough",
             "Documentation": "Sets the '@oncanplaythrough' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -4888,7 +4691,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -4915,10 +4717,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 8580018474683397615,
-          "Data2": 6533024525095838941,
-          "Data3": 3226142328585743393,
-          "Data4": -957644612510588954
+          "Data1": 9021550152565145703,
+          "Data2": -3681511981075089668,
+          "Data3": 8759804482147700930,
+          "Data4": 2691676552213055408
         },
         "Kind": "Components.EventHandler",
         "Name": "onchange",
@@ -4966,14 +4768,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onchange",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onchange",
             "Documentation": "Sets the '@onchange' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.ChangeEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -4983,7 +4783,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -5010,10 +4809,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -270506733203034501,
-          "Data2": 1405659296323328032,
-          "Data3": 4549523699376170843,
-          "Data4": 8225525741026718221
+          "Data1": 3597143635887702821,
+          "Data2": 6979406833120141731,
+          "Data3": 6279934246998199632,
+          "Data4": -8363376616623760505
         },
         "Kind": "Components.EventHandler",
         "Name": "onclick",
@@ -5061,14 +4860,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onclick",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onclick",
             "Documentation": "Sets the '@onclick' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.MouseEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -5078,7 +4875,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -5105,10 +4901,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 732711127777416450,
-          "Data2": 9073978716385361517,
-          "Data3": 4107644530974975671,
-          "Data4": 8168010277157660858
+          "Data1": -691375261581337061,
+          "Data2": -4119886487163562852,
+          "Data3": 5599418538762395144,
+          "Data4": -8888936334110578607
         },
         "Kind": "Components.EventHandler",
         "Name": "oncontextmenu",
@@ -5156,14 +4952,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@oncontextmenu",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.oncontextmenu",
             "Documentation": "Sets the '@oncontextmenu' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.MouseEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -5173,7 +4967,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -5200,10 +4993,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 4180491336450122779,
-          "Data2": 5178301776019581288,
-          "Data3": -6120218572909101793,
-          "Data4": -2305170841501477410
+          "Data1": -4360942504650104630,
+          "Data2": 7731955405905389575,
+          "Data3": 1443601099487356626,
+          "Data4": -2101997293292828843
         },
         "Kind": "Components.EventHandler",
         "Name": "oncopy",
@@ -5251,14 +5044,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@oncopy",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ClipboardEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ClipboardEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.oncopy",
             "Documentation": "Sets the '@oncopy' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.ClipboardEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -5268,7 +5059,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -5295,10 +5085,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -9194761777249079400,
-          "Data2": 7215424332804689345,
-          "Data3": -3467253666445796814,
-          "Data4": -3776339060074339686
+          "Data1": 286731150956740114,
+          "Data2": 4093610657574804738,
+          "Data3": 5407297486207738932,
+          "Data4": 5268212638313280214
         },
         "Kind": "Components.EventHandler",
         "Name": "oncuechange",
@@ -5346,14 +5136,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@oncuechange",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.oncuechange",
             "Documentation": "Sets the '@oncuechange' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -5363,7 +5151,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -5390,10 +5177,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -5979481306611366509,
-          "Data2": 7480165599396532900,
-          "Data3": 2397183492005605171,
-          "Data4": 3847186361487988074
+          "Data1": 8186128080124964816,
+          "Data2": 7586819290480753327,
+          "Data3": 6191209867032661391,
+          "Data4": -6331179048051247481
         },
         "Kind": "Components.EventHandler",
         "Name": "oncut",
@@ -5441,14 +5228,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@oncut",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ClipboardEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ClipboardEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.oncut",
             "Documentation": "Sets the '@oncut' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.ClipboardEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -5458,7 +5243,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -5485,10 +5269,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 655302450480600911,
-          "Data2": -8203389501365304054,
-          "Data3": 6238055548484043548,
-          "Data4": -1842064908091283518
+          "Data1": 6174667092485240069,
+          "Data2": -8616048023282187142,
+          "Data3": -1939823437066439316,
+          "Data4": 2617448786231930441
         },
         "Kind": "Components.EventHandler",
         "Name": "ondblclick",
@@ -5536,14 +5320,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@ondblclick",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ondblclick",
             "Documentation": "Sets the '@ondblclick' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.MouseEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -5553,7 +5335,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -5580,10 +5361,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 528133855451876454,
-          "Data2": 262103651467570452,
-          "Data3": 7953819921329981303,
-          "Data4": 4286844662165787282
+          "Data1": 5718547954337368240,
+          "Data2": 8196627432735438447,
+          "Data3": 3271260671104923917,
+          "Data4": -7816297703213577974
         },
         "Kind": "Components.EventHandler",
         "Name": "ondeactivate",
@@ -5631,14 +5412,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@ondeactivate",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ondeactivate",
             "Documentation": "Sets the '@ondeactivate' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -5648,7 +5427,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -5675,10 +5453,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -8408460013450947419,
-          "Data2": -3754262459668612324,
-          "Data3": 6790742602734241167,
-          "Data4": 1830769280010702872
+          "Data1": 3044718135165284681,
+          "Data2": 5436073248552167943,
+          "Data3": -2886877743044277554,
+          "Data4": 2909984613241968590
         },
         "Kind": "Components.EventHandler",
         "Name": "ondrag",
@@ -5726,14 +5504,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@ondrag",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ondrag",
             "Documentation": "Sets the '@ondrag' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.DragEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -5743,7 +5519,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -5770,10 +5545,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 8661603427781523039,
-          "Data2": -8091302018609837565,
-          "Data3": -6085486339797373471,
-          "Data4": -676327621026120397
+          "Data1": -4240671660995984402,
+          "Data2": 6239023547715669506,
+          "Data3": -7365327087602747392,
+          "Data4": 142584652111293589
         },
         "Kind": "Components.EventHandler",
         "Name": "ondragend",
@@ -5821,14 +5596,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@ondragend",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ondragend",
             "Documentation": "Sets the '@ondragend' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.DragEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -5838,7 +5611,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -5865,10 +5637,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 2360457622189309961,
-          "Data2": 3212346380712987877,
-          "Data3": -5433403870412558340,
-          "Data4": 6674708148271303889
+          "Data1": 4175038127814228424,
+          "Data2": -7673393665041000193,
+          "Data3": -7168823027377665897,
+          "Data4": 7874290089415791070
         },
         "Kind": "Components.EventHandler",
         "Name": "ondragenter",
@@ -5916,14 +5688,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@ondragenter",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ondragenter",
             "Documentation": "Sets the '@ondragenter' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.DragEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -5933,7 +5703,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -5960,10 +5729,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -3431183949975799,
-          "Data2": 8815675907271631516,
-          "Data3": -3139693124296631603,
-          "Data4": -267207877325848261
+          "Data1": 8507517644447978342,
+          "Data2": 4707143056418058996,
+          "Data3": 3210865660913819484,
+          "Data4": 8826429626879443685
         },
         "Kind": "Components.EventHandler",
         "Name": "ondragleave",
@@ -6011,14 +5780,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@ondragleave",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ondragleave",
             "Documentation": "Sets the '@ondragleave' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.DragEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -6028,7 +5795,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -6055,10 +5821,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 304914285728129990,
-          "Data2": 4486468370656578332,
-          "Data3": 4399657166913820151,
-          "Data4": -3084868545811521585
+          "Data1": 7365926596391016248,
+          "Data2": -86990075042666178,
+          "Data3": 2944230320276199164,
+          "Data4": 2661380786578760519
         },
         "Kind": "Components.EventHandler",
         "Name": "ondragover",
@@ -6106,14 +5872,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@ondragover",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ondragover",
             "Documentation": "Sets the '@ondragover' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.DragEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -6123,7 +5887,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -6150,10 +5913,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 4245529304312292165,
-          "Data2": 2270021441838136286,
-          "Data3": -2277226785297197373,
-          "Data4": -173405970674284069
+          "Data1": 1686507988083079929,
+          "Data2": -664640004120836139,
+          "Data3": 8195838960333187794,
+          "Data4": -4351979621907110879
         },
         "Kind": "Components.EventHandler",
         "Name": "ondragstart",
@@ -6201,14 +5964,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@ondragstart",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ondragstart",
             "Documentation": "Sets the '@ondragstart' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.DragEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -6218,7 +5979,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -6245,10 +6005,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -3695978626967096645,
-          "Data2": -8910527857220207474,
-          "Data3": 7577179099463582456,
-          "Data4": 567597144051890312
+          "Data1": 3949561660456432516,
+          "Data2": -5532765836738545780,
+          "Data3": -6317790637780236377,
+          "Data4": -6247129404604341375
         },
         "Kind": "Components.EventHandler",
         "Name": "ondrop",
@@ -6296,14 +6056,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@ondrop",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ondrop",
             "Documentation": "Sets the '@ondrop' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.DragEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -6313,7 +6071,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -6340,10 +6097,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 8767245720749797564,
-          "Data2": -3716654200287911171,
-          "Data3": 7298451416425598867,
-          "Data4": -5440497943522783902
+          "Data1": 6549922667733891321,
+          "Data2": 8272157126127871938,
+          "Data3": -4141681556352313974,
+          "Data4": -2924455488559300037
         },
         "Kind": "Components.EventHandler",
         "Name": "ondurationchange",
@@ -6391,14 +6148,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@ondurationchange",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ondurationchange",
             "Documentation": "Sets the '@ondurationchange' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -6408,7 +6163,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -6435,10 +6189,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -9031562292274969334,
-          "Data2": -4051485378920049263,
-          "Data3": 1809546549777222580,
-          "Data4": 3704987913888927157
+          "Data1": -5427119264634528570,
+          "Data2": -7461394206739689388,
+          "Data3": 3737727228850993403,
+          "Data4": 7327876271960377507
         },
         "Kind": "Components.EventHandler",
         "Name": "onemptied",
@@ -6486,14 +6240,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onemptied",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onemptied",
             "Documentation": "Sets the '@onemptied' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -6503,7 +6255,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -6530,10 +6281,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -4596934114238515693,
-          "Data2": 8460259568003933792,
-          "Data3": 5847056605481585608,
-          "Data4": -6777811705195969471
+          "Data1": 4647465251142650686,
+          "Data2": 7814692682838903311,
+          "Data3": -3615158978828975616,
+          "Data4": 1531774199038467053
         },
         "Kind": "Components.EventHandler",
         "Name": "onended",
@@ -6581,14 +6332,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onended",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onended",
             "Documentation": "Sets the '@onended' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -6598,7 +6347,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -6625,10 +6373,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -1193097015575903270,
-          "Data2": -2008094150608211795,
-          "Data3": 756587039488238444,
-          "Data4": -8187774346664142489
+          "Data1": -1596925086852964803,
+          "Data2": 1776254936090663812,
+          "Data3": 3058272697794013257,
+          "Data4": 1598192923627348132
         },
         "Kind": "Components.EventHandler",
         "Name": "onerror",
@@ -6676,14 +6424,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onerror",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ErrorEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ErrorEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onerror",
             "Documentation": "Sets the '@onerror' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.ErrorEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -6693,7 +6439,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -6720,10 +6465,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -8012765882865991197,
-          "Data2": 420375298737495490,
-          "Data3": 9095781999548236655,
-          "Data4": 2512187253827646169
+          "Data1": -7611270163357449083,
+          "Data2": 807394460243871062,
+          "Data3": 7319378948627440297,
+          "Data4": -5980104535027657485
         },
         "Kind": "Components.EventHandler",
         "Name": "onfocus",
@@ -6771,14 +6516,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onfocus",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.FocusEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.FocusEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onfocus",
             "Documentation": "Sets the '@onfocus' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.FocusEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -6788,7 +6531,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -6815,10 +6557,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 1008037031413733485,
-          "Data2": -7776374144217599573,
-          "Data3": 5567380910031784024,
-          "Data4": -3882406179725726786
+          "Data1": 47970977334695629,
+          "Data2": 7680994261274497927,
+          "Data3": -3935370477930522912,
+          "Data4": -6898621426090770654
         },
         "Kind": "Components.EventHandler",
         "Name": "onfocusin",
@@ -6866,14 +6608,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onfocusin",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.FocusEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.FocusEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onfocusin",
             "Documentation": "Sets the '@onfocusin' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.FocusEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -6883,7 +6623,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -6910,10 +6649,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -4078801300782880044,
-          "Data2": 6357221084841556614,
-          "Data3": 8909922999789205131,
-          "Data4": 2746991765097356463
+          "Data1": 2922748392745508869,
+          "Data2": -5078526997396378787,
+          "Data3": -417313702075665350,
+          "Data4": -1149393826271446116
         },
         "Kind": "Components.EventHandler",
         "Name": "onfocusout",
@@ -6961,14 +6700,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onfocusout",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.FocusEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.FocusEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onfocusout",
             "Documentation": "Sets the '@onfocusout' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.FocusEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -6978,7 +6715,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -7005,10 +6741,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 3748398068694140397,
-          "Data2": 1789254824896643776,
-          "Data3": 4281673255768891181,
-          "Data4": -7339463010393178755
+          "Data1": -5618781630314055488,
+          "Data2": -6706525966075289273,
+          "Data3": -5504548583371703349,
+          "Data4": 8038011664956760552
         },
         "Kind": "Components.EventHandler",
         "Name": "onfullscreenchange",
@@ -7056,14 +6792,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onfullscreenchange",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onfullscreenchange",
             "Documentation": "Sets the '@onfullscreenchange' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -7073,7 +6807,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -7100,10 +6833,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 6143557232192514532,
-          "Data2": 5313561540884187359,
-          "Data3": 4562882334661045255,
-          "Data4": -8057493163682039217
+          "Data1": 285145613875688311,
+          "Data2": 1075794768690470036,
+          "Data3": -2332515893041586408,
+          "Data4": 5148676719031280983
         },
         "Kind": "Components.EventHandler",
         "Name": "onfullscreenerror",
@@ -7151,14 +6884,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onfullscreenerror",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onfullscreenerror",
             "Documentation": "Sets the '@onfullscreenerror' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -7168,7 +6899,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -7195,10 +6925,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 1810092170361480640,
-          "Data2": -5695465101068399257,
-          "Data3": -3355885507269303089,
-          "Data4": -6466362608387315441
+          "Data1": -5900958437777690378,
+          "Data2": -854426927757262816,
+          "Data3": 5695205279963327325,
+          "Data4": -856881713920611722
         },
         "Kind": "Components.EventHandler",
         "Name": "ongotpointercapture",
@@ -7246,14 +6976,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@ongotpointercapture",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ongotpointercapture",
             "Documentation": "Sets the '@ongotpointercapture' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.PointerEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -7263,7 +6991,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -7290,10 +7017,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -994553175436224498,
-          "Data2": -8297573944475294150,
-          "Data3": -3933369079134565418,
-          "Data4": -1264871846781415373
+          "Data1": 3516843657437049369,
+          "Data2": 2888678420013701146,
+          "Data3": -5174009308955285918,
+          "Data4": 9060818771074397901
         },
         "Kind": "Components.EventHandler",
         "Name": "oninput",
@@ -7341,14 +7068,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@oninput",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.oninput",
             "Documentation": "Sets the '@oninput' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.ChangeEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -7358,7 +7083,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -7385,10 +7109,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -2714956559329502355,
-          "Data2": -4601499003207600832,
-          "Data3": 6350757066058386688,
-          "Data4": 6122559872396130006
+          "Data1": -8991665153212194909,
+          "Data2": 2501333078317245326,
+          "Data3": -6805796059615775649,
+          "Data4": -3802205414553884343
         },
         "Kind": "Components.EventHandler",
         "Name": "oninvalid",
@@ -7436,14 +7160,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@oninvalid",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.oninvalid",
             "Documentation": "Sets the '@oninvalid' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -7453,7 +7175,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -7480,10 +7201,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 8500264250369838647,
-          "Data2": 1288049217954232404,
-          "Data3": -2928909052872348258,
-          "Data4": -2061741459109943881
+          "Data1": -8336210659089602833,
+          "Data2": -6583326979754605591,
+          "Data3": 767336994680526441,
+          "Data4": -2398746601444360666
         },
         "Kind": "Components.EventHandler",
         "Name": "onkeydown",
@@ -7531,14 +7252,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onkeydown",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.KeyboardEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.KeyboardEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onkeydown",
             "Documentation": "Sets the '@onkeydown' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.KeyboardEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -7548,7 +7267,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -7575,10 +7293,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 537865827575277207,
-          "Data2": -7608042593903517561,
-          "Data3": -5887726097586358822,
-          "Data4": -6564770010099859947
+          "Data1": -6677243767676095035,
+          "Data2": 3389728025038222789,
+          "Data3": 8230228331528941381,
+          "Data4": -9070131644502584525
         },
         "Kind": "Components.EventHandler",
         "Name": "onkeypress",
@@ -7626,14 +7344,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onkeypress",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.KeyboardEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.KeyboardEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onkeypress",
             "Documentation": "Sets the '@onkeypress' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.KeyboardEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -7643,7 +7359,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -7670,10 +7385,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -282195063404575294,
-          "Data2": 3559554579684659354,
-          "Data3": -1896957945893105935,
-          "Data4": -5762970838781658157
+          "Data1": -8017834596925491646,
+          "Data2": 2650303292375038693,
+          "Data3": -3063234541744385358,
+          "Data4": -3526453776222353578
         },
         "Kind": "Components.EventHandler",
         "Name": "onkeyup",
@@ -7721,14 +7436,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onkeyup",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.KeyboardEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.KeyboardEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onkeyup",
             "Documentation": "Sets the '@onkeyup' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.KeyboardEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -7738,7 +7451,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -7765,10 +7477,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -8219294938181661818,
-          "Data2": -3114856425072902848,
-          "Data3": 8563716233073505522,
-          "Data4": 5842462224341574637
+          "Data1": -2243489098095344885,
+          "Data2": -8936461220896769529,
+          "Data3": -2992401163237418763,
+          "Data4": 6889902857441278920
         },
         "Kind": "Components.EventHandler",
         "Name": "onload",
@@ -7816,14 +7528,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onload",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onload",
             "Documentation": "Sets the '@onload' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.ProgressEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -7833,7 +7543,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -7860,10 +7569,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 1280036194840794422,
-          "Data2": 952735821565671384,
-          "Data3": -5366449481013792767,
-          "Data4": -7757896402767644613
+          "Data1": 6182385573677660212,
+          "Data2": -8734116397153133732,
+          "Data3": 1284254613761687775,
+          "Data4": -8747990934255698978
         },
         "Kind": "Components.EventHandler",
         "Name": "onloadeddata",
@@ -7911,14 +7620,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onloadeddata",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onloadeddata",
             "Documentation": "Sets the '@onloadeddata' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -7928,7 +7635,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -7955,10 +7661,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 3487880945611944831,
-          "Data2": 1379452475400128545,
-          "Data3": -8609239590097591728,
-          "Data4": 3304429238991859128
+          "Data1": -510831045754026685,
+          "Data2": 6964289838075083330,
+          "Data3": -8998034021489020112,
+          "Data4": 1398669890987511756
         },
         "Kind": "Components.EventHandler",
         "Name": "onloadedmetadata",
@@ -8006,14 +7712,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onloadedmetadata",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onloadedmetadata",
             "Documentation": "Sets the '@onloadedmetadata' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -8023,7 +7727,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -8050,10 +7753,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -5183813432152713598,
-          "Data2": -457644289804803703,
-          "Data3": -8382707469427649935,
-          "Data4": 5124029908389916518
+          "Data1": -1846785159651334689,
+          "Data2": 228583969728688184,
+          "Data3": 6282700219626528827,
+          "Data4": 8447352556658793790
         },
         "Kind": "Components.EventHandler",
         "Name": "onloadend",
@@ -8101,14 +7804,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onloadend",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onloadend",
             "Documentation": "Sets the '@onloadend' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.ProgressEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -8118,7 +7819,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -8145,10 +7845,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 7019034768863239104,
-          "Data2": 8945764393955519690,
-          "Data3": -4483761491075313948,
-          "Data4": 3591507612402996275
+          "Data1": -3271444022478402571,
+          "Data2": 6808684954229955978,
+          "Data3": 4118696354490472116,
+          "Data4": 1313084385443518196
         },
         "Kind": "Components.EventHandler",
         "Name": "onloadstart",
@@ -8196,14 +7896,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onloadstart",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onloadstart",
             "Documentation": "Sets the '@onloadstart' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.ProgressEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -8213,7 +7911,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -8240,10 +7937,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -5337434583613890486,
-          "Data2": -2288218562628072906,
-          "Data3": 8837441716426765621,
-          "Data4": 7272075379502616454
+          "Data1": 8560192747025301747,
+          "Data2": -3364043371282526417,
+          "Data3": 6534159599336212745,
+          "Data4": 6669620656951171824
         },
         "Kind": "Components.EventHandler",
         "Name": "onlostpointercapture",
@@ -8291,14 +7988,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onlostpointercapture",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onlostpointercapture",
             "Documentation": "Sets the '@onlostpointercapture' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.PointerEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -8308,7 +8003,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -8335,10 +8029,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -8499527276985856938,
-          "Data2": -5945727223042270324,
-          "Data3": -914720205243991140,
-          "Data4": -2637557931607282003
+          "Data1": 3844853799839066938,
+          "Data2": 6472949402307730128,
+          "Data3": -673570821360318099,
+          "Data4": -2068373078827981868
         },
         "Kind": "Components.EventHandler",
         "Name": "onmousedown",
@@ -8386,14 +8080,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onmousedown",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onmousedown",
             "Documentation": "Sets the '@onmousedown' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.MouseEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -8403,7 +8095,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -8430,10 +8121,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -7539384554556083808,
-          "Data2": 6197014764847614428,
-          "Data3": -7537082863181454402,
-          "Data4": 7444379417817272742
+          "Data1": -7231672217104957342,
+          "Data2": 1275343828862811216,
+          "Data3": -3212667756407280009,
+          "Data4": -591063670399133423
         },
         "Kind": "Components.EventHandler",
         "Name": "onmousemove",
@@ -8481,14 +8172,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onmousemove",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onmousemove",
             "Documentation": "Sets the '@onmousemove' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.MouseEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -8498,7 +8187,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -8525,10 +8213,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 1718494917698166093,
-          "Data2": -8088309744321105102,
-          "Data3": -2795933410244225743,
-          "Data4": -3856281089353983332
+          "Data1": -4695915169767853137,
+          "Data2": -5012006215027764888,
+          "Data3": -4562876979739212288,
+          "Data4": 6969325254105350676
         },
         "Kind": "Components.EventHandler",
         "Name": "onmouseout",
@@ -8576,14 +8264,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onmouseout",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onmouseout",
             "Documentation": "Sets the '@onmouseout' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.MouseEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -8593,7 +8279,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -8620,10 +8305,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 5012343951601570790,
-          "Data2": 2271936887089129444,
-          "Data3": -4378691882860515464,
-          "Data4": 1533056839996905330
+          "Data1": -6670020986484482530,
+          "Data2": -4264524944378393009,
+          "Data3": 342329424020831623,
+          "Data4": 9216840125230822241
         },
         "Kind": "Components.EventHandler",
         "Name": "onmouseover",
@@ -8671,14 +8356,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onmouseover",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onmouseover",
             "Documentation": "Sets the '@onmouseover' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.MouseEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -8688,7 +8371,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -8715,10 +8397,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -354755370155575287,
-          "Data2": 5157730915077286008,
-          "Data3": 1785566629709386987,
-          "Data4": -5642283525445394646
+          "Data1": -8889769109475686179,
+          "Data2": -5718366049848122649,
+          "Data3": -2148202606540034464,
+          "Data4": 8063740994164547748
         },
         "Kind": "Components.EventHandler",
         "Name": "onmouseup",
@@ -8766,14 +8448,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onmouseup",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onmouseup",
             "Documentation": "Sets the '@onmouseup' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.MouseEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -8783,7 +8463,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -8810,10 +8489,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -3685488739900425245,
-          "Data2": 3543117801477740853,
-          "Data3": -7600806534422380566,
-          "Data4": -9084334842163918202
+          "Data1": -6064950808595188814,
+          "Data2": -4784466688234000366,
+          "Data3": -4595545819708619615,
+          "Data4": 6522007861271265334
         },
         "Kind": "Components.EventHandler",
         "Name": "onmousewheel",
@@ -8861,14 +8540,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onmousewheel",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.WheelEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.WheelEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onmousewheel",
             "Documentation": "Sets the '@onmousewheel' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.WheelEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -8878,7 +8555,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -8905,10 +8581,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -5545434610732115589,
-          "Data2": 6206834905478667766,
-          "Data3": 959789173692075988,
-          "Data4": -6367120776534227582
+          "Data1": -7905893440531719543,
+          "Data2": 7562212679621791805,
+          "Data3": -6096208515109829503,
+          "Data4": -6276469631909286987
         },
         "Kind": "Components.EventHandler",
         "Name": "onpaste",
@@ -8956,14 +8632,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onpaste",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ClipboardEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ClipboardEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onpaste",
             "Documentation": "Sets the '@onpaste' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.ClipboardEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -8973,7 +8647,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -9000,10 +8673,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 1848249201543246245,
-          "Data2": -958873359236205401,
-          "Data3": -3581328473172816602,
-          "Data4": -3758898222877262607
+          "Data1": -6838145208851156030,
+          "Data2": -5489756394814979955,
+          "Data3": -6599702282998226328,
+          "Data4": -8890740204366495772
         },
         "Kind": "Components.EventHandler",
         "Name": "onpause",
@@ -9051,14 +8724,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onpause",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onpause",
             "Documentation": "Sets the '@onpause' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -9068,7 +8739,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -9095,10 +8765,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -4768081475068792568,
-          "Data2": -5092757472491699207,
-          "Data3": -5535954244174206297,
-          "Data4": 4689518496931729140
+          "Data1": 2690716815643504147,
+          "Data2": 2394531767522550490,
+          "Data3": 8784326749896269104,
+          "Data4": 1824300260619810066
         },
         "Kind": "Components.EventHandler",
         "Name": "onplay",
@@ -9146,14 +8816,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onplay",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onplay",
             "Documentation": "Sets the '@onplay' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -9163,7 +8831,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -9190,10 +8857,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -431993913130920961,
-          "Data2": 2754983905930907281,
-          "Data3": 2066736676452781329,
-          "Data4": -6178597158872798192
+          "Data1": -3304281299509581153,
+          "Data2": -7862262381827351570,
+          "Data3": 2874030803864064860,
+          "Data4": -2096741352884955693
         },
         "Kind": "Components.EventHandler",
         "Name": "onplaying",
@@ -9241,14 +8908,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onplaying",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onplaying",
             "Documentation": "Sets the '@onplaying' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -9258,7 +8923,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -9285,10 +8949,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -69908269811856383,
-          "Data2": 5003502729786308822,
-          "Data3": 3699524134890501288,
-          "Data4": 299197890218910498
+          "Data1": -1873469006752919581,
+          "Data2": -5072981947445660059,
+          "Data3": 7662953476336022729,
+          "Data4": 4972866536032886405
         },
         "Kind": "Components.EventHandler",
         "Name": "onpointercancel",
@@ -9336,14 +9000,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onpointercancel",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onpointercancel",
             "Documentation": "Sets the '@onpointercancel' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.PointerEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -9353,7 +9015,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -9380,10 +9041,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -2627612773631161661,
-          "Data2": -7253201828851441492,
-          "Data3": 8150426462480015295,
-          "Data4": -4562576049896711455
+          "Data1": 2759905335606232699,
+          "Data2": -1964476083038050141,
+          "Data3": 1069871562731478040,
+          "Data4": 7728540198450016247
         },
         "Kind": "Components.EventHandler",
         "Name": "onpointerdown",
@@ -9431,14 +9092,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onpointerdown",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onpointerdown",
             "Documentation": "Sets the '@onpointerdown' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.PointerEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -9448,7 +9107,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -9475,10 +9133,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 4590115103316685125,
-          "Data2": 5033452337950853992,
-          "Data3": -7047137160119743584,
-          "Data4": 3151348835675099786
+          "Data1": -408131904856483925,
+          "Data2": -6987948489373291874,
+          "Data3": 88884820318461938,
+          "Data4": 1199116417888345380
         },
         "Kind": "Components.EventHandler",
         "Name": "onpointerenter",
@@ -9526,14 +9184,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onpointerenter",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onpointerenter",
             "Documentation": "Sets the '@onpointerenter' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.PointerEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -9543,7 +9199,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -9570,10 +9225,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 104065383959435934,
-          "Data2": 5014442713318741697,
-          "Data3": -1136037458535531937,
-          "Data4": -1213981790046670470
+          "Data1": -3998992340406114414,
+          "Data2": 1094366271103150357,
+          "Data3": -2447318345817832841,
+          "Data4": 3286070635033442150
         },
         "Kind": "Components.EventHandler",
         "Name": "onpointerleave",
@@ -9621,14 +9276,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onpointerleave",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onpointerleave",
             "Documentation": "Sets the '@onpointerleave' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.PointerEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -9638,7 +9291,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -9665,10 +9317,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -2444715965013225909,
-          "Data2": 5457329839803826033,
-          "Data3": -6557541334996049559,
-          "Data4": -6375843582772800026
+          "Data1": 4098880326052710505,
+          "Data2": 8337925582774510561,
+          "Data3": 814570697334145419,
+          "Data4": 1924203194735847832
         },
         "Kind": "Components.EventHandler",
         "Name": "onpointerlockchange",
@@ -9716,14 +9368,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onpointerlockchange",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onpointerlockchange",
             "Documentation": "Sets the '@onpointerlockchange' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -9733,7 +9383,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -9760,10 +9409,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -6031243105441696137,
-          "Data2": 8738018927093607121,
-          "Data3": -2704205843227897776,
-          "Data4": -3263477639055456625
+          "Data1": -8193803496749865602,
+          "Data2": -7799907065274240459,
+          "Data3": -2246010572961436915,
+          "Data4": 4092281294794004986
         },
         "Kind": "Components.EventHandler",
         "Name": "onpointerlockerror",
@@ -9811,14 +9460,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onpointerlockerror",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onpointerlockerror",
             "Documentation": "Sets the '@onpointerlockerror' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -9828,7 +9475,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -9855,10 +9501,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -6568299342670857145,
-          "Data2": -2054967744558589945,
-          "Data3": -5887420191748111911,
-          "Data4": -7273468561018662019
+          "Data1": 8989341770890372802,
+          "Data2": -435613441997019748,
+          "Data3": 2313846410646583447,
+          "Data4": 2185099028154550104
         },
         "Kind": "Components.EventHandler",
         "Name": "onpointermove",
@@ -9906,14 +9552,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onpointermove",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onpointermove",
             "Documentation": "Sets the '@onpointermove' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.PointerEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -9923,7 +9567,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -9950,10 +9593,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 9192749751188342701,
-          "Data2": -1142189869928650506,
-          "Data3": -5871896420744026361,
-          "Data4": 3806515850895707431
+          "Data1": -8525423674060353641,
+          "Data2": 8762580170020229294,
+          "Data3": -7696103862721831891,
+          "Data4": 1775657013434054859
         },
         "Kind": "Components.EventHandler",
         "Name": "onpointerout",
@@ -10001,14 +9644,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onpointerout",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onpointerout",
             "Documentation": "Sets the '@onpointerout' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.PointerEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -10018,7 +9659,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -10045,10 +9685,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -6119502897468270360,
-          "Data2": -7168647918149086948,
-          "Data3": -8837994681499470748,
-          "Data4": 3419447637844379589
+          "Data1": -3566498173339828859,
+          "Data2": 8076687167598020713,
+          "Data3": -4418971580259372899,
+          "Data4": -1523120538178311881
         },
         "Kind": "Components.EventHandler",
         "Name": "onpointerover",
@@ -10096,14 +9736,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onpointerover",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onpointerover",
             "Documentation": "Sets the '@onpointerover' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.PointerEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -10113,7 +9751,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -10140,10 +9777,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -3036629148688680306,
-          "Data2": 3768485959591132978,
-          "Data3": -524857230977016761,
-          "Data4": 5257046259763731289
+          "Data1": 4403598085412452850,
+          "Data2": -1947316553595927374,
+          "Data3": 6509234971427491243,
+          "Data4": 1087587615653973315
         },
         "Kind": "Components.EventHandler",
         "Name": "onpointerup",
@@ -10191,14 +9828,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onpointerup",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onpointerup",
             "Documentation": "Sets the '@onpointerup' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.PointerEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -10208,7 +9843,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -10235,10 +9869,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -3612531637016116443,
-          "Data2": -7604390932138986625,
-          "Data3": -4639528630153371052,
-          "Data4": -6534366152080794694
+          "Data1": 3879427843670869193,
+          "Data2": 8428864266088137881,
+          "Data3": -1304270801097457931,
+          "Data4": -7026290091599055325
         },
         "Kind": "Components.EventHandler",
         "Name": "onprogress",
@@ -10286,14 +9920,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onprogress",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onprogress",
             "Documentation": "Sets the '@onprogress' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.ProgressEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -10303,7 +9935,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -10330,10 +9961,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -1171802726441380158,
-          "Data2": 6716053206861850448,
-          "Data3": -7960013301786121445,
-          "Data4": 8493687962019931521
+          "Data1": 6018351090573102403,
+          "Data2": 5385994926661756669,
+          "Data3": 4899745047929325574,
+          "Data4": 386529701324508905
         },
         "Kind": "Components.EventHandler",
         "Name": "onratechange",
@@ -10381,14 +10012,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onratechange",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onratechange",
             "Documentation": "Sets the '@onratechange' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -10398,7 +10027,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -10425,10 +10053,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 5549675870604081106,
-          "Data2": 5983995960551391160,
-          "Data3": -5814879962753542769,
-          "Data4": -45311664465710997
+          "Data1": -7104441795945113833,
+          "Data2": -2672458172754879857,
+          "Data3": 4232630043954398249,
+          "Data4": -3331973936600836381
         },
         "Kind": "Components.EventHandler",
         "Name": "onreadystatechange",
@@ -10476,14 +10104,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onreadystatechange",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onreadystatechange",
             "Documentation": "Sets the '@onreadystatechange' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -10493,7 +10119,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -10520,10 +10145,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -6793169459373045928,
-          "Data2": -8940586841033871148,
-          "Data3": 5721402946476292510,
-          "Data4": -3764854300946704689
+          "Data1": 1224827343190729662,
+          "Data2": 9146705381189747431,
+          "Data3": -3572015617153571978,
+          "Data4": 6642642978339759881
         },
         "Kind": "Components.EventHandler",
         "Name": "onreset",
@@ -10571,14 +10196,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onreset",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onreset",
             "Documentation": "Sets the '@onreset' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -10588,7 +10211,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -10615,10 +10237,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 50932382131278391,
-          "Data2": 6786570223791825052,
-          "Data3": -5204420339568076830,
-          "Data4": -6764902546290993971
+          "Data1": -5269019469634634394,
+          "Data2": -5215184336752733527,
+          "Data3": 8037565605809365375,
+          "Data4": 3956396367102989396
         },
         "Kind": "Components.EventHandler",
         "Name": "onscroll",
@@ -10666,14 +10288,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onscroll",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onscroll",
             "Documentation": "Sets the '@onscroll' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -10683,7 +10303,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -10710,10 +10329,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -7636998867032495473,
-          "Data2": -8702634190147313848,
-          "Data3": 5472687282026819462,
-          "Data4": 4638125859776519218
+          "Data1": 5348764166581152634,
+          "Data2": -185856157442222895,
+          "Data3": -7699263863770504875,
+          "Data4": -8500278865866131135
         },
         "Kind": "Components.EventHandler",
         "Name": "onseeked",
@@ -10761,14 +10380,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onseeked",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onseeked",
             "Documentation": "Sets the '@onseeked' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -10778,7 +10395,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -10805,10 +10421,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -4243514470256934213,
-          "Data2": -3316274032335463380,
-          "Data3": 6057604528642727068,
-          "Data4": 6695750958298872104
+          "Data1": -5337289748336579194,
+          "Data2": -2764425311147520028,
+          "Data3": 3940806194153714994,
+          "Data4": -7737017287730939222
         },
         "Kind": "Components.EventHandler",
         "Name": "onseeking",
@@ -10856,14 +10472,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onseeking",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onseeking",
             "Documentation": "Sets the '@onseeking' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -10873,7 +10487,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -10900,10 +10513,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 6011842282011998011,
-          "Data2": -7450408051113514272,
-          "Data3": -5245602878709287494,
-          "Data4": 7884664947854717975
+          "Data1": -8999554027865065483,
+          "Data2": 9053506557548338835,
+          "Data3": -8055523883860285167,
+          "Data4": 2771945697403335479
         },
         "Kind": "Components.EventHandler",
         "Name": "onselect",
@@ -10951,14 +10564,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onselect",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onselect",
             "Documentation": "Sets the '@onselect' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -10968,7 +10579,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -10995,10 +10605,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 1746989425378096663,
-          "Data2": -8640046640506567283,
-          "Data3": 6918396212570770727,
-          "Data4": 9175195839669489178
+          "Data1": -3401103688762081775,
+          "Data2": 8709192630522774774,
+          "Data3": -837919988537380635,
+          "Data4": -4460520393601812411
         },
         "Kind": "Components.EventHandler",
         "Name": "onselectionchange",
@@ -11046,14 +10656,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onselectionchange",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onselectionchange",
             "Documentation": "Sets the '@onselectionchange' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -11063,7 +10671,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -11090,10 +10697,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -6719421518233835927,
-          "Data2": 6124178761715133607,
-          "Data3": 833860924933740847,
-          "Data4": 3085090808722492834
+          "Data1": 2547025097855028199,
+          "Data2": -7605025420708277560,
+          "Data3": -1312716523978744516,
+          "Data4": -6504621706267392300
         },
         "Kind": "Components.EventHandler",
         "Name": "onselectstart",
@@ -11141,14 +10748,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onselectstart",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onselectstart",
             "Documentation": "Sets the '@onselectstart' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -11158,7 +10763,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -11185,10 +10789,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 4632247784605405926,
-          "Data2": 1357035186492854563,
-          "Data3": -7828805816288689812,
-          "Data4": -1199418379413185326
+          "Data1": -5434978434956537759,
+          "Data2": 8936011303415081287,
+          "Data3": 5426628164775390400,
+          "Data4": -2430245909846221519
         },
         "Kind": "Components.EventHandler",
         "Name": "onstalled",
@@ -11236,14 +10840,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onstalled",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onstalled",
             "Documentation": "Sets the '@onstalled' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -11253,7 +10855,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -11280,10 +10881,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 8215716261089663278,
-          "Data2": -1993612056794286495,
-          "Data3": 8972316947729144660,
-          "Data4": 3563098834516788238
+          "Data1": 4673650175081597591,
+          "Data2": 3024822344042810919,
+          "Data3": 8906429931535552461,
+          "Data4": 8540796470304621340
         },
         "Kind": "Components.EventHandler",
         "Name": "onstop",
@@ -11331,14 +10932,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onstop",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onstop",
             "Documentation": "Sets the '@onstop' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -11348,7 +10947,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -11375,10 +10973,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 175504589960068888,
-          "Data2": 3617020468668043226,
-          "Data3": 8513784585829710405,
-          "Data4": 5261024363730127579
+          "Data1": 535484282712467334,
+          "Data2": -735898059947873195,
+          "Data3": 5783258117750854991,
+          "Data4": 4371570045216854086
         },
         "Kind": "Components.EventHandler",
         "Name": "onsubmit",
@@ -11426,14 +11024,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onsubmit",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onsubmit",
             "Documentation": "Sets the '@onsubmit' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -11443,7 +11039,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -11470,10 +11065,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -6546261087754994642,
-          "Data2": -2236484803825846692,
-          "Data3": 7228930727518819934,
-          "Data4": -4618792761099331093
+          "Data1": -6351861245085816570,
+          "Data2": -5797567101172751535,
+          "Data3": 1043467516572737658,
+          "Data4": -6481474979887666324
         },
         "Kind": "Components.EventHandler",
         "Name": "onsuspend",
@@ -11521,14 +11116,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onsuspend",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onsuspend",
             "Documentation": "Sets the '@onsuspend' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -11538,7 +11131,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -11565,10 +11157,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 3992258750121037426,
-          "Data2": 6323702819727765867,
-          "Data3": -2136781013652503586,
-          "Data4": 6961525213224517493
+          "Data1": 8292097123581819337,
+          "Data2": 2776394615863869302,
+          "Data3": -4849882703177702563,
+          "Data4": 906162761099879996
         },
         "Kind": "Components.EventHandler",
         "Name": "ontimeout",
@@ -11616,14 +11208,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@ontimeout",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ontimeout",
             "Documentation": "Sets the '@ontimeout' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.ProgressEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -11633,7 +11223,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -11660,10 +11249,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -2214741385997304201,
-          "Data2": -6606835475595020262,
-          "Data3": 8377511257059188712,
-          "Data4": -1074047246347546315
+          "Data1": -5667603341153897733,
+          "Data2": 3892972364029271543,
+          "Data3": -6949172278752942387,
+          "Data4": 3539967113494603846
         },
         "Kind": "Components.EventHandler",
         "Name": "ontimeupdate",
@@ -11711,14 +11300,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@ontimeupdate",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ontimeupdate",
             "Documentation": "Sets the '@ontimeupdate' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -11728,7 +11315,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -11755,10 +11341,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -1133697546365942217,
-          "Data2": 2846655195072323153,
-          "Data3": -8923294808969449599,
-          "Data4": 9146082058184231203
+          "Data1": -7806331998966020903,
+          "Data2": -7707138743821744509,
+          "Data3": 6455382756265501102,
+          "Data4": 3384184814395207884
         },
         "Kind": "Components.EventHandler",
         "Name": "ontouchcancel",
@@ -11806,14 +11392,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@ontouchcancel",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ontouchcancel",
             "Documentation": "Sets the '@ontouchcancel' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.TouchEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -11823,7 +11407,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -11850,10 +11433,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 9007070606949804477,
-          "Data2": -570581130659477775,
-          "Data3": -826315685999488629,
-          "Data4": -8536989373140589634
+          "Data1": 4542987420449600718,
+          "Data2": 9013789881031146024,
+          "Data3": -4367289269788149840,
+          "Data4": -2578806760145339096
         },
         "Kind": "Components.EventHandler",
         "Name": "ontouchend",
@@ -11901,14 +11484,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@ontouchend",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ontouchend",
             "Documentation": "Sets the '@ontouchend' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.TouchEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -11918,7 +11499,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -11945,10 +11525,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -4891522945269330912,
-          "Data2": 8707129859434563795,
-          "Data3": -3606045852813014025,
-          "Data4": -6985005546860252692
+          "Data1": -3779697527290143720,
+          "Data2": 527832603341980700,
+          "Data3": -7864893452240933530,
+          "Data4": 7790765333844005658
         },
         "Kind": "Components.EventHandler",
         "Name": "ontouchenter",
@@ -11996,14 +11576,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@ontouchenter",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ontouchenter",
             "Documentation": "Sets the '@ontouchenter' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.TouchEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -12013,7 +11591,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -12040,10 +11617,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -3406066103649149481,
-          "Data2": -6737960632301676707,
-          "Data3": -8756138932146023478,
-          "Data4": 1881924083614898546
+          "Data1": 6510294364378274278,
+          "Data2": -7346350569613905399,
+          "Data3": -4594177156102174679,
+          "Data4": 7819420859205945506
         },
         "Kind": "Components.EventHandler",
         "Name": "ontouchleave",
@@ -12091,14 +11668,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@ontouchleave",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ontouchleave",
             "Documentation": "Sets the '@ontouchleave' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.TouchEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -12108,7 +11683,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -12135,10 +11709,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 5410243272992980184,
-          "Data2": -6194012663912538171,
-          "Data3": 1215085195241635325,
-          "Data4": 1564539683647479599
+          "Data1": 4812163409056452754,
+          "Data2": 8423701471397266046,
+          "Data3": -784211087395201266,
+          "Data4": -6024175971943845623
         },
         "Kind": "Components.EventHandler",
         "Name": "ontouchmove",
@@ -12186,14 +11760,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@ontouchmove",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ontouchmove",
             "Documentation": "Sets the '@ontouchmove' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.TouchEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -12203,7 +11775,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -12230,10 +11801,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -2112607231250824421,
-          "Data2": -2541786134542638533,
-          "Data3": 7291387570030293557,
-          "Data4": -5091261834150797385
+          "Data1": -9084276094204070050,
+          "Data2": -7558266861140587626,
+          "Data3": -672148720628532948,
+          "Data4": -4330234491150592726
         },
         "Kind": "Components.EventHandler",
         "Name": "ontouchstart",
@@ -12281,14 +11852,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@ontouchstart",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.ontouchstart",
             "Documentation": "Sets the '@ontouchstart' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.TouchEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -12298,7 +11867,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -12325,10 +11893,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 3483067743732566648,
-          "Data2": -5112375592840571055,
-          "Data3": 2764181402770370250,
-          "Data4": -3769343457322130372
+          "Data1": -2888202117723849406,
+          "Data2": -7094292676896212492,
+          "Data3": 2782059822840370194,
+          "Data4": 1229613741760470804
         },
         "Kind": "Components.EventHandler",
         "Name": "onvolumechange",
@@ -12376,14 +11944,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onvolumechange",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onvolumechange",
             "Documentation": "Sets the '@onvolumechange' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -12393,7 +11959,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -12420,10 +11985,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -7378724543697118848,
-          "Data2": 8570765810383615164,
-          "Data3": 8061337064854922668,
-          "Data4": 8394833639484503331
+          "Data1": -8838217443688849831,
+          "Data2": -845497231821731321,
+          "Data3": -4695288501574354576,
+          "Data4": 1430466430403331030
         },
         "Kind": "Components.EventHandler",
         "Name": "onwaiting",
@@ -12471,14 +12036,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onwaiting",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.EventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onwaiting",
             "Documentation": "Sets the '@onwaiting' attribute to the provided string or delegate value. A delegate value should be of type 'System.EventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -12488,7 +12051,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -12515,10 +12077,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 1457119206319840276,
-          "Data2": 1122491258436564712,
-          "Data3": 8663712771153475427,
-          "Data4": 2958975596339200799
+          "Data1": 6695658002474050984,
+          "Data2": 7759070390999581965,
+          "Data3": -833171135367282962,
+          "Data4": 5069663121235466930
         },
         "Kind": "Components.EventHandler",
         "Name": "onwheel",
@@ -12566,14 +12128,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.EventHandler",
             "Name": "@onwheel",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.WheelEventArgs>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.WheelEventArgs> Microsoft.AspNetCore.Components.Web.EventHandlers.onwheel",
             "Documentation": "Sets the '@onwheel' attribute to the provided string or delegate value. A delegate value should be of type 'Microsoft.AspNetCore.Components.Web.WheelEventArgs'.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.EventHandler",
                 "Name": "preventDefault",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":preventDefault",
@@ -12583,7 +12143,6 @@
                 }
               },
               {
-                "Kind": "Components.EventHandler",
                 "Name": "stopPropagation",
                 "TypeName": "System.Boolean",
                 "DisplayName": ":stopPropagation",
@@ -12610,10 +12169,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -8716393892360256242,
-          "Data2": -4244164127876370316,
-          "Data3": -1759310098319271923,
-          "Data4": -3881329688635097031
+          "Data1": -4729156663012653819,
+          "Data2": 7887674614229876202,
+          "Data3": 1368514906265025673,
+          "Data4": -1263323792859939829
         },
         "Kind": "Components.Splat",
         "Name": "Attributes",
@@ -12637,7 +12196,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Splat",
             "Name": "@attributes",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Components.Attributes.Attributes",
@@ -12657,10 +12215,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 6437172118496696487,
-          "Data2": 1579667537803280320,
-          "Data3": -5792281139030274687,
-          "Data4": 425664341198191389
+          "Data1": -6794739141767603240,
+          "Data2": -5156856437996489133,
+          "Data3": -3600799249922803548,
+          "Data4": 41373604104144405
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper",
@@ -12794,7 +12352,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "ITagHelper",
             "Name": "asp-action",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Action",
@@ -12805,7 +12362,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-area",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Area",
@@ -12816,7 +12372,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-controller",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Controller",
@@ -12827,7 +12382,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-fragment",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Fragment",
@@ -12838,7 +12392,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-host",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Host",
@@ -12849,7 +12402,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-page",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Page",
@@ -12860,7 +12412,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-page-handler",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.PageHandler",
@@ -12871,7 +12422,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-protocol",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Protocol",
@@ -12882,7 +12432,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-route",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Route",
@@ -12893,7 +12442,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-all-route-data",
             "TypeName": "System.Collections.Generic.IDictionary<System.String, System.String>",
             "HasIndexer": true,
@@ -12914,10 +12462,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 8036395382492645249,
-          "Data2": -4554537117285658496,
-          "Data3": 922096170992990223,
-          "Data4": 1174907081109763542
+          "Data1": 803856148043977981,
+          "Data2": -8162261837284733185,
+          "Data3": 6526685680895779212,
+          "Data4": 1040784387441383280
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper",
@@ -12933,7 +12481,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "ITagHelper",
             "Name": "priority",
             "TypeName": "Microsoft.Extensions.Caching.Memory.CacheItemPriority?",
             "DisplayName": "Microsoft.Extensions.Caching.Memory.CacheItemPriority? Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper.Priority",
@@ -12944,7 +12491,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "enabled",
             "TypeName": "System.Boolean",
             "DisplayName": "bool Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper.Enabled",
@@ -12955,7 +12501,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "expires-after",
             "TypeName": "System.TimeSpan?",
             "DisplayName": "System.TimeSpan? Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper.ExpiresAfter",
@@ -12966,7 +12511,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "expires-on",
             "TypeName": "System.DateTimeOffset?",
             "DisplayName": "System.DateTimeOffset? Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper.ExpiresOn",
@@ -12977,7 +12521,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "expires-sliding",
             "TypeName": "System.TimeSpan?",
             "DisplayName": "System.TimeSpan? Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper.ExpiresSliding",
@@ -12988,7 +12531,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "vary-by",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper.VaryBy",
@@ -12999,7 +12541,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "vary-by-cookie",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper.VaryByCookie",
@@ -13010,7 +12551,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "vary-by-culture",
             "TypeName": "System.Boolean",
             "DisplayName": "bool Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper.VaryByCulture",
@@ -13021,7 +12561,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "vary-by-header",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper.VaryByHeader",
@@ -13032,7 +12571,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "vary-by-query",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper.VaryByQuery",
@@ -13043,7 +12581,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "vary-by-route",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper.VaryByRoute",
@@ -13054,7 +12591,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "vary-by-user",
             "TypeName": "System.Boolean",
             "DisplayName": "bool Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper.VaryByUser",
@@ -13072,10 +12608,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -3203059400996600239,
-          "Data2": 47474692131183591,
-          "Data3": 8060267402246450538,
-          "Data4": 7752332121629601526
+          "Data1": 4581920250563710317,
+          "Data2": -8880893329172663176,
+          "Data3": 8668544002643465490,
+          "Data4": -3449420563159090491
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.ComponentTagHelper",
@@ -13099,7 +12635,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "ITagHelper",
             "Name": "type",
             "TypeName": "System.Type",
             "DisplayName": "System.Type Microsoft.AspNetCore.Mvc.TagHelpers.ComponentTagHelper.ComponentType",
@@ -13110,7 +12645,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "params",
             "TypeName": "System.Collections.Generic.IDictionary<System.String, System.Object>",
             "HasIndexer": true,
@@ -13124,7 +12658,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "render-mode",
             "TypeName": "Microsoft.AspNetCore.Mvc.Rendering.RenderMode",
             "IsEnum": true,
@@ -13143,10 +12676,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 1457084986571988886,
-          "Data2": -1835791068260285548,
-          "Data3": 5920657064959133661,
-          "Data4": -657941757376358650
+          "Data1": -4504640625100609167,
+          "Data2": 286858932747717958,
+          "Data3": 420905696124787708,
+          "Data4": 2962274153101561248
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper",
@@ -13169,7 +12702,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "ITagHelper",
             "Name": "name",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper.Name",
@@ -13180,7 +12712,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "enabled",
             "TypeName": "System.Boolean",
             "DisplayName": "bool Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper.Enabled",
@@ -13191,7 +12722,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "expires-after",
             "TypeName": "System.TimeSpan?",
             "DisplayName": "System.TimeSpan? Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper.ExpiresAfter",
@@ -13202,7 +12732,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "expires-on",
             "TypeName": "System.DateTimeOffset?",
             "DisplayName": "System.DateTimeOffset? Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper.ExpiresOn",
@@ -13213,7 +12742,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "expires-sliding",
             "TypeName": "System.TimeSpan?",
             "DisplayName": "System.TimeSpan? Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper.ExpiresSliding",
@@ -13224,7 +12752,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "vary-by",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper.VaryBy",
@@ -13235,7 +12762,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "vary-by-cookie",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper.VaryByCookie",
@@ -13246,7 +12772,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "vary-by-culture",
             "TypeName": "System.Boolean",
             "DisplayName": "bool Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper.VaryByCulture",
@@ -13257,7 +12782,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "vary-by-header",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper.VaryByHeader",
@@ -13268,7 +12792,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "vary-by-query",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper.VaryByQuery",
@@ -13279,7 +12802,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "vary-by-route",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper.VaryByRoute",
@@ -13290,7 +12812,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "vary-by-user",
             "TypeName": "System.Boolean",
             "DisplayName": "bool Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper.VaryByUser",
@@ -13308,10 +12829,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -6244314029428656247,
-          "Data2": 4422662980289934083,
-          "Data3": 8482117073384428678,
-          "Data4": -6994648780310624387
+          "Data1": -1150207218939309354,
+          "Data2": 5017059091154908576,
+          "Data3": -5856232270056752351,
+          "Data4": 307340105686381535
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.EnvironmentTagHelper",
@@ -13327,7 +12848,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "ITagHelper",
             "Name": "exclude",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.EnvironmentTagHelper.Exclude",
@@ -13338,7 +12858,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "include",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.EnvironmentTagHelper.Include",
@@ -13349,7 +12868,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "names",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.EnvironmentTagHelper.Names",
@@ -13367,10 +12885,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -1839989745175503537,
-          "Data2": -5797835548783988996,
-          "Data3": 3199388301249949301,
-          "Data4": -3140339119812329951
+          "Data1": -3726615085879205137,
+          "Data2": -2749921508980930552,
+          "Data3": -4428035603497049265,
+          "Data4": 8539145911212404645
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.FormActionTagHelper",
@@ -13826,7 +13344,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "ITagHelper",
             "Name": "asp-action",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormActionTagHelper.Action",
@@ -13837,7 +13354,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-area",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormActionTagHelper.Area",
@@ -13848,7 +13364,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-controller",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormActionTagHelper.Controller",
@@ -13859,7 +13374,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-fragment",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormActionTagHelper.Fragment",
@@ -13870,7 +13384,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-page",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormActionTagHelper.Page",
@@ -13881,7 +13394,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-page-handler",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormActionTagHelper.PageHandler",
@@ -13892,7 +13404,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-route",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormActionTagHelper.Route",
@@ -13903,7 +13414,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-all-route-data",
             "TypeName": "System.Collections.Generic.IDictionary<System.String, System.String>",
             "HasIndexer": true,
@@ -13924,10 +13434,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -8503342058938187939,
-          "Data2": 8908457285482963104,
-          "Data3": 6572150370971739804,
-          "Data4": 1459787782060302802
+          "Data1": -6338655364639362730,
+          "Data2": 4102675928858533915,
+          "Data3": -6911471262488690628,
+          "Data4": -7707236535894035642
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.FormTagHelper",
@@ -13943,7 +13453,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "ITagHelper",
             "Name": "asp-action",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormTagHelper.Action",
@@ -13954,7 +13463,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-antiforgery",
             "TypeName": "System.Boolean?",
             "DisplayName": "System.Boolean? Microsoft.AspNetCore.Mvc.TagHelpers.FormTagHelper.Antiforgery",
@@ -13965,7 +13473,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-area",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormTagHelper.Area",
@@ -13976,7 +13483,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-controller",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormTagHelper.Controller",
@@ -13987,7 +13493,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-fragment",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormTagHelper.Fragment",
@@ -13998,7 +13503,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-page",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormTagHelper.Page",
@@ -14009,7 +13513,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-page-handler",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormTagHelper.PageHandler",
@@ -14020,7 +13523,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-route",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.FormTagHelper.Route",
@@ -14031,7 +13533,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-all-route-data",
             "TypeName": "System.Collections.Generic.IDictionary<System.String, System.String>",
             "HasIndexer": true,
@@ -14052,10 +13553,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 5941993175013389810,
-          "Data2": 2316971509397246175,
-          "Data3": -5372271037021995133,
-          "Data4": -3568404182530302753
+          "Data1": -8870279712415447174,
+          "Data2": 6078425903863187833,
+          "Data3": -5415246709170453110,
+          "Data4": -8470988199746932398
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.ImageTagHelper",
@@ -14084,7 +13585,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "ITagHelper",
             "Name": "asp-append-version",
             "TypeName": "System.Boolean",
             "DisplayName": "bool Microsoft.AspNetCore.Mvc.TagHelpers.ImageTagHelper.AppendVersion",
@@ -14095,7 +13595,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "src",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.ImageTagHelper.Src",
@@ -14113,10 +13612,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -966982837233107783,
-          "Data2": -4600710420789516376,
-          "Data3": -2306226680818055244,
-          "Data4": 4731129653545288953
+          "Data1": 5705355647857304997,
+          "Data2": -5072557624117743047,
+          "Data3": 1296426584042257144,
+          "Data4": 2848941384404325948
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.InputTagHelper",
@@ -14140,7 +13639,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "ITagHelper",
             "Name": "asp-for",
             "TypeName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ModelExpression",
             "DisplayName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ModelExpression Microsoft.AspNetCore.Mvc.TagHelpers.InputTagHelper.For",
@@ -14151,7 +13649,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-format",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.InputTagHelper.Format",
@@ -14162,7 +13659,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "type",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.InputTagHelper.InputTypeName",
@@ -14173,7 +13669,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "name",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.InputTagHelper.Name",
@@ -14184,7 +13679,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "value",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.InputTagHelper.Value",
@@ -14202,10 +13696,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -7464875034690529151,
-          "Data2": -4834407811947692335,
-          "Data3": -7443738504397145692,
-          "Data4": 5176392868522775694
+          "Data1": 3554574752981167574,
+          "Data2": 6265055283691595622,
+          "Data3": 8745424011729455050,
+          "Data4": -5733662445732106688
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.LabelTagHelper",
@@ -14228,7 +13722,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "ITagHelper",
             "Name": "asp-for",
             "TypeName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ModelExpression",
             "DisplayName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ModelExpression Microsoft.AspNetCore.Mvc.TagHelpers.LabelTagHelper.For",
@@ -14246,10 +13739,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -4673431452971902593,
-          "Data2": 1900037175133130937,
-          "Data3": 6788791025322700871,
-          "Data4": 7238208653631370034
+          "Data1": 6156553920825600034,
+          "Data2": -3313600398067191160,
+          "Data3": 2922438975368121157,
+          "Data4": -5729865764986130647
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper",
@@ -14369,7 +13862,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "ITagHelper",
             "Name": "asp-append-version",
             "TypeName": "System.Boolean?",
             "DisplayName": "System.Boolean? Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper.AppendVersion",
@@ -14380,7 +13872,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-fallback-href",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper.FallbackHref",
@@ -14391,7 +13882,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-fallback-href-exclude",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper.FallbackHrefExclude",
@@ -14402,7 +13892,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-fallback-href-include",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper.FallbackHrefInclude",
@@ -14413,7 +13902,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-fallback-test-class",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper.FallbackTestClass",
@@ -14424,7 +13912,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-fallback-test-property",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper.FallbackTestProperty",
@@ -14435,7 +13922,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-fallback-test-value",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper.FallbackTestValue",
@@ -14446,7 +13932,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "href",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper.Href",
@@ -14457,7 +13942,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-href-exclude",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper.HrefExclude",
@@ -14468,7 +13952,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-href-include",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper.HrefInclude",
@@ -14479,7 +13962,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-suppress-fallback-integrity",
             "TypeName": "System.Boolean",
             "DisplayName": "bool Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper.SuppressFallbackIntegrity",
@@ -14497,10 +13979,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 8311321031342849583,
-          "Data2": 7782433395797493774,
-          "Data3": 3690947895676463732,
-          "Data4": 4004845685672975867
+          "Data1": 4344835990546831323,
+          "Data2": -2351293458660716903,
+          "Data3": -9102145309131368611,
+          "Data4": 6580944286578680571
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.OptionTagHelper",
@@ -14516,7 +13998,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "ITagHelper",
             "Name": "value",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.OptionTagHelper.Value",
@@ -14534,10 +14015,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 6655222548073601391,
-          "Data2": -5841446621140462555,
-          "Data3": -3635884188562496545,
-          "Data4": 2009988759667194141
+          "Data1": 5466786547207860338,
+          "Data2": 493634687525400824,
+          "Data3": 2314588454713957300,
+          "Data4": 3719630365100569977
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.PartialTagHelper",
@@ -14561,7 +14042,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "ITagHelper",
             "Name": "fallback-name",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.PartialTagHelper.FallbackName",
@@ -14572,7 +14052,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "for",
             "TypeName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ModelExpression",
             "DisplayName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ModelExpression Microsoft.AspNetCore.Mvc.TagHelpers.PartialTagHelper.For",
@@ -14583,7 +14062,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "model",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Mvc.TagHelpers.PartialTagHelper.Model",
@@ -14594,7 +14072,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "name",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.PartialTagHelper.Name",
@@ -14605,7 +14082,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "optional",
             "TypeName": "System.Boolean",
             "DisplayName": "bool Microsoft.AspNetCore.Mvc.TagHelpers.PartialTagHelper.Optional",
@@ -14616,7 +14092,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "view-data",
             "TypeName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary",
             "HasIndexer": true,
@@ -14637,10 +14112,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -8955084568513321912,
-          "Data2": -4668421744865959121,
-          "Data3": -554407759398374292,
-          "Data4": 600693531513133373
+          "Data1": 2895383444354329644,
+          "Data2": -6194998671113114949,
+          "Data3": -8565886842565356770,
+          "Data4": -674350993269314830
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.ScriptTagHelper",
@@ -14729,7 +14204,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "ITagHelper",
             "Name": "asp-append-version",
             "TypeName": "System.Boolean?",
             "DisplayName": "System.Boolean? Microsoft.AspNetCore.Mvc.TagHelpers.ScriptTagHelper.AppendVersion",
@@ -14740,7 +14214,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-fallback-src",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.ScriptTagHelper.FallbackSrc",
@@ -14751,7 +14224,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-fallback-src-exclude",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.ScriptTagHelper.FallbackSrcExclude",
@@ -14762,7 +14234,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-fallback-src-include",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.ScriptTagHelper.FallbackSrcInclude",
@@ -14773,7 +14244,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-fallback-test",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.ScriptTagHelper.FallbackTestExpression",
@@ -14784,7 +14254,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "src",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.ScriptTagHelper.Src",
@@ -14795,7 +14264,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-src-exclude",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.ScriptTagHelper.SrcExclude",
@@ -14806,7 +14274,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-src-include",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.ScriptTagHelper.SrcInclude",
@@ -14817,7 +14284,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-suppress-fallback-integrity",
             "TypeName": "System.Boolean",
             "DisplayName": "bool Microsoft.AspNetCore.Mvc.TagHelpers.ScriptTagHelper.SuppressFallbackIntegrity",
@@ -14835,10 +14301,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -5930593541024759232,
-          "Data2": -508333454746162427,
-          "Data3": 1970729229925577930,
-          "Data4": -6360518379695760159
+          "Data1": 6579479996482823186,
+          "Data2": -520876175589740566,
+          "Data3": 1806748383989227039,
+          "Data4": -458203092849747883
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.SelectTagHelper",
@@ -14872,7 +14338,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "ITagHelper",
             "Name": "asp-for",
             "TypeName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ModelExpression",
             "DisplayName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ModelExpression Microsoft.AspNetCore.Mvc.TagHelpers.SelectTagHelper.For",
@@ -14883,7 +14348,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "asp-items",
             "TypeName": "System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Mvc.Rendering.SelectListItem>",
             "DisplayName": "System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Mvc.Rendering.SelectListItem> Microsoft.AspNetCore.Mvc.TagHelpers.SelectTagHelper.Items",
@@ -14894,7 +14358,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "name",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.SelectTagHelper.Name",
@@ -14912,10 +14375,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -3925282118532711471,
-          "Data2": 4373072045370656794,
-          "Data3": 6794089760339492615,
-          "Data4": 4191694550384928781
+          "Data1": 6980159081445591201,
+          "Data2": -6480588413843073081,
+          "Data3": -3074849698123011725,
+          "Data4": 5108887778510629743
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.TextAreaTagHelper",
@@ -14938,7 +14401,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "ITagHelper",
             "Name": "asp-for",
             "TypeName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ModelExpression",
             "DisplayName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ModelExpression Microsoft.AspNetCore.Mvc.TagHelpers.TextAreaTagHelper.For",
@@ -14949,7 +14411,6 @@
             }
           },
           {
-            "Kind": "ITagHelper",
             "Name": "name",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Mvc.TagHelpers.TextAreaTagHelper.Name",
@@ -14967,10 +14428,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 558125475540278505,
-          "Data2": 2271200266503334649,
-          "Data3": -3953373900021188770,
-          "Data4": -2394225110975062064
+          "Data1": -5339600428732863986,
+          "Data2": 6065060134186830106,
+          "Data3": 2231597810216291074,
+          "Data4": -387028852536953028
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.ValidationMessageTagHelper",
@@ -14993,7 +14454,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "ITagHelper",
             "Name": "asp-validation-for",
             "TypeName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ModelExpression",
             "DisplayName": "Microsoft.AspNetCore.Mvc.ViewFeatures.ModelExpression Microsoft.AspNetCore.Mvc.TagHelpers.ValidationMessageTagHelper.For",
@@ -15011,10 +14471,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -6369954927046895051,
-          "Data2": -5718115467446222535,
-          "Data3": -2792393315539668605,
-          "Data4": 5739584012674155061
+          "Data1": -5925740776405247863,
+          "Data2": 4485792911133715007,
+          "Data3": 2572514906731951580,
+          "Data4": 3422618998698535538
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.ValidationSummaryTagHelper",
@@ -15037,7 +14497,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "ITagHelper",
             "Name": "asp-validation-summary",
             "TypeName": "Microsoft.AspNetCore.Mvc.Rendering.ValidationSummary",
             "IsEnum": true,
@@ -15464,10 +14923,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 6955953418904825149,
-          "Data2": 1545043285596528585,
-          "Data3": -4384753346925767688,
-          "Data4": -8008903300409832446
+          "Data1": -8374502925475485972,
+          "Data2": 4707130141488163023,
+          "Data3": 411338323922686677,
+          "Data4": 295545264586871050
         },
         "Kind": "Components.Bind",
         "Name": "Bind",
@@ -15492,7 +14951,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind-...",
             "TypeName": "System.Collections.Generic.Dictionary<string, object>",
             "HasIndexer": true,
@@ -15502,7 +14960,6 @@
             "Documentation": "Binds the provided expression to an attribute and a change event, based on the naming of the bind attribute. For example: <code>@bind-value=\"...\"</code> and <code>@bind-value:event=\"onchange\"</code> will assign the current value of the expression to the 'value' attribute, and assign a delegate that attempts to set the value to the 'onchange' attribute.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.Bind",
                 "Name": "format",
                 "TypeName": "System.String",
                 "DisplayName": ":format",
@@ -15512,7 +14969,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "event",
                 "TypeName": "System.String",
                 "DisplayName": ":event",
@@ -15522,7 +14978,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "culture",
                 "TypeName": "System.Globalization.CultureInfo",
                 "DisplayName": ":culture",
@@ -15548,10 +15003,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 3559055789757145885,
-          "Data2": -3844100913787900498,
-          "Data3": -3219857408097554002,
-          "Data4": 2555878054064637765
+          "Data1": -8083328137904785432,
+          "Data2": 3969359824820992635,
+          "Data3": -5251356362654280105,
+          "Data4": 204765281340957522
         },
         "Kind": "Components.Bind",
         "Name": "Bind",
@@ -15575,14 +15030,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind",
             "Documentation": "Binds the provided expression to the 'value' attribute and a change event delegate to the 'onchange' attribute.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.Bind",
                 "Name": "format",
                 "TypeName": "System.String",
                 "DisplayName": ":format",
@@ -15592,7 +15045,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "event",
                 "TypeName": "System.String",
                 "DisplayName": ":event",
@@ -15602,7 +15054,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "culture",
                 "TypeName": "System.Globalization.CultureInfo",
                 "DisplayName": ":culture",
@@ -15618,7 +15069,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "format-value",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -15641,10 +15091,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 3709114828043363206,
-          "Data2": 3164781137136747910,
-          "Data3": 7600352770956185810,
-          "Data4": 2053497015976413812
+          "Data1": -2045096310838737397,
+          "Data2": 1627355172981466643,
+          "Data3": -5202400309324669264,
+          "Data4": 1395355326308217900
         },
         "Kind": "Components.Bind",
         "Name": "Bind",
@@ -15668,14 +15118,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind",
             "Documentation": "Binds the provided expression to the 'value' attribute and a change event delegate to the 'onchange' attribute.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.Bind",
                 "Name": "format",
                 "TypeName": "System.String",
                 "DisplayName": ":format",
@@ -15685,7 +15133,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "event",
                 "TypeName": "System.String",
                 "DisplayName": ":event",
@@ -15695,7 +15142,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "culture",
                 "TypeName": "System.Globalization.CultureInfo",
                 "DisplayName": ":culture",
@@ -15711,7 +15157,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "format-value",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -15734,10 +15179,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -6525172771471608618,
-          "Data2": -8537526920152498273,
-          "Data3": -3763415542546640768,
-          "Data4": -1721520664096144691
+          "Data1": -1463477446241557898,
+          "Data2": -8451094983334327173,
+          "Data3": 309269024453531163,
+          "Data4": 7570536586517191144
         },
         "Kind": "Components.Bind",
         "Name": "Bind",
@@ -15767,14 +15212,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind",
             "Documentation": "Binds the provided expression to the 'checked' attribute and a change event delegate to the 'onchange' attribute.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.Bind",
                 "Name": "format",
                 "TypeName": "System.String",
                 "DisplayName": ":format",
@@ -15784,7 +15227,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "event",
                 "TypeName": "System.String",
                 "DisplayName": ":event",
@@ -15794,7 +15236,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "culture",
                 "TypeName": "System.Globalization.CultureInfo",
                 "DisplayName": ":culture",
@@ -15810,7 +15251,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "format-checked",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_checked",
@@ -15834,10 +15274,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 8437958793195015229,
-          "Data2": 7407159634817587993,
-          "Data3": -8657947475386149068,
-          "Data4": -4141816752790588311
+          "Data1": -610723102708122458,
+          "Data2": -1059946848847349542,
+          "Data3": -8733625058913092465,
+          "Data4": 7749118359074504351
         },
         "Kind": "Components.Bind",
         "Name": "Bind_value",
@@ -15867,14 +15307,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind-value",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind_value",
             "Documentation": "Binds the provided expression to the 'value' attribute and a change event delegate to the 'onchange' attribute.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.Bind",
                 "Name": "format",
                 "TypeName": "System.String",
                 "DisplayName": ":format",
@@ -15884,7 +15322,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "event",
                 "TypeName": "System.String",
                 "DisplayName": ":event",
@@ -15894,7 +15331,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "culture",
                 "TypeName": "System.Globalization.CultureInfo",
                 "DisplayName": ":culture",
@@ -15910,7 +15346,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "format-value",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -15934,10 +15369,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -1922165090207296883,
-          "Data2": 7547456049924998037,
-          "Data3": -3454127808016632097,
-          "Data4": -1278490135253545301
+          "Data1": -370761153577830254,
+          "Data2": -6937212866394766939,
+          "Data3": 9012680906355889818,
+          "Data4": 8282489071310411460
         },
         "Kind": "Components.Bind",
         "Name": "Bind",
@@ -15967,14 +15402,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind",
             "Documentation": "Binds the provided expression to the 'value' attribute and a change event delegate to the 'onchange' attribute.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.Bind",
                 "Name": "format",
                 "TypeName": "System.String",
                 "DisplayName": ":format",
@@ -15984,7 +15417,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "event",
                 "TypeName": "System.String",
                 "DisplayName": ":event",
@@ -15994,7 +15426,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "culture",
                 "TypeName": "System.Globalization.CultureInfo",
                 "DisplayName": ":culture",
@@ -16010,7 +15441,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "format-value",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -16034,10 +15464,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -8840541532185681902,
-          "Data2": 6755984486736841471,
-          "Data3": 8105374864707417137,
-          "Data4": -8816368774590413765
+          "Data1": 376258524606428198,
+          "Data2": 6911672216055926280,
+          "Data3": -6079624827817224211,
+          "Data4": -9023036871903818635
         },
         "Kind": "Components.Bind",
         "Name": "Bind_value",
@@ -16067,14 +15497,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind-value",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind_value",
             "Documentation": "Binds the provided expression to the 'value' attribute and a change event delegate to the 'onchange' attribute.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.Bind",
                 "Name": "format",
                 "TypeName": "System.String",
                 "DisplayName": ":format",
@@ -16084,7 +15512,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "event",
                 "TypeName": "System.String",
                 "DisplayName": ":event",
@@ -16094,7 +15521,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "culture",
                 "TypeName": "System.Globalization.CultureInfo",
                 "DisplayName": ":culture",
@@ -16110,7 +15536,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "format-value",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -16134,10 +15559,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 6215834798227170962,
-          "Data2": -1303332902827340694,
-          "Data3": -2076030407990512393,
-          "Data4": -8324527856753295873
+          "Data1": 5923598738481015030,
+          "Data2": -815128937363244410,
+          "Data3": 8047116853466098117,
+          "Data4": -7923054426791402953
         },
         "Kind": "Components.Bind",
         "Name": "Bind",
@@ -16167,14 +15592,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind",
             "Documentation": "Binds the provided expression to the 'value' attribute and a change event delegate to the 'onchange' attribute.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.Bind",
                 "Name": "format",
                 "TypeName": "System.String",
                 "DisplayName": ":format",
@@ -16184,7 +15607,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "event",
                 "TypeName": "System.String",
                 "DisplayName": ":event",
@@ -16194,7 +15616,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "culture",
                 "TypeName": "System.Globalization.CultureInfo",
                 "DisplayName": ":culture",
@@ -16210,7 +15631,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "format-value",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -16234,10 +15654,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 8433843675901012240,
-          "Data2": 2953823365542171234,
-          "Data3": -7843312527231101708,
-          "Data4": -2820082572123812828
+          "Data1": -291129595025880893,
+          "Data2": -5756087797314309262,
+          "Data3": 7566509511520895168,
+          "Data4": 7257519651276114704
         },
         "Kind": "Components.Bind",
         "Name": "Bind_value",
@@ -16267,14 +15687,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind-value",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind_value",
             "Documentation": "Binds the provided expression to the 'value' attribute and a change event delegate to the 'onchange' attribute.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.Bind",
                 "Name": "format",
                 "TypeName": "System.String",
                 "DisplayName": ":format",
@@ -16284,7 +15702,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "event",
                 "TypeName": "System.String",
                 "DisplayName": ":event",
@@ -16294,7 +15711,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "culture",
                 "TypeName": "System.Globalization.CultureInfo",
                 "DisplayName": ":culture",
@@ -16310,7 +15726,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "format-value",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -16334,10 +15749,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 941979631798146651,
-          "Data2": -1002585265863307251,
-          "Data3": 2559402654560691467,
-          "Data4": -994465738359936976
+          "Data1": -2409928887212936452,
+          "Data2": -9205228317416867905,
+          "Data3": 7376276764479886690,
+          "Data4": -679354104792758218
         },
         "Kind": "Components.Bind",
         "Name": "Bind",
@@ -16367,14 +15782,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind",
             "Documentation": "Binds the provided expression to the 'value' attribute and a change event delegate to the 'onchange' attribute.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.Bind",
                 "Name": "format",
                 "TypeName": "System.String",
                 "DisplayName": ":format",
@@ -16384,7 +15797,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "event",
                 "TypeName": "System.String",
                 "DisplayName": ":event",
@@ -16394,7 +15806,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "culture",
                 "TypeName": "System.Globalization.CultureInfo",
                 "DisplayName": ":culture",
@@ -16410,7 +15821,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "format-value",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -16434,10 +15844,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 2174540807642168415,
-          "Data2": -3179278250606478555,
-          "Data3": 5392647902663443135,
-          "Data4": -1025800143481891284
+          "Data1": 8797729002162753254,
+          "Data2": 7437180336391192617,
+          "Data3": -2663967424455897645,
+          "Data4": -4517904462757297054
         },
         "Kind": "Components.Bind",
         "Name": "Bind_value",
@@ -16467,14 +15877,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind-value",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind_value",
             "Documentation": "Binds the provided expression to the 'value' attribute and a change event delegate to the 'onchange' attribute.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.Bind",
                 "Name": "format",
                 "TypeName": "System.String",
                 "DisplayName": ":format",
@@ -16484,7 +15892,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "event",
                 "TypeName": "System.String",
                 "DisplayName": ":event",
@@ -16494,7 +15901,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "culture",
                 "TypeName": "System.Globalization.CultureInfo",
                 "DisplayName": ":culture",
@@ -16510,7 +15916,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "format-value",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -16534,10 +15939,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -2078300913947844276,
-          "Data2": 4894479956990394618,
-          "Data3": 1870386379367796706,
-          "Data4": 7504144858783560527
+          "Data1": -1116788084557869619,
+          "Data2": -2898982718326102545,
+          "Data3": 6648341822851393022,
+          "Data4": -3034002887359481060
         },
         "Kind": "Components.Bind",
         "Name": "Bind",
@@ -16567,14 +15972,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind",
             "Documentation": "Binds the provided expression to the 'value' attribute and a change event delegate to the 'onchange' attribute.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.Bind",
                 "Name": "format",
                 "TypeName": "System.String",
                 "DisplayName": ":format",
@@ -16584,7 +15987,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "event",
                 "TypeName": "System.String",
                 "DisplayName": ":event",
@@ -16594,7 +15996,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "culture",
                 "TypeName": "System.Globalization.CultureInfo",
                 "DisplayName": ":culture",
@@ -16610,7 +16011,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "format-value",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -16634,10 +16034,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 6685936821857023326,
-          "Data2": -8976487522577367753,
-          "Data3": 4652097973092068824,
-          "Data4": -7815744953168422363
+          "Data1": -2129792389192263848,
+          "Data2": 5122137648131834190,
+          "Data3": 1055822938728292428,
+          "Data4": 6357760022537249938
         },
         "Kind": "Components.Bind",
         "Name": "Bind",
@@ -16667,14 +16067,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind",
             "Documentation": "Binds the provided expression to the 'value' attribute and a change event delegate to the 'onchange' attribute.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.Bind",
                 "Name": "format",
                 "TypeName": "System.String",
                 "DisplayName": ":format",
@@ -16684,7 +16082,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "event",
                 "TypeName": "System.String",
                 "DisplayName": ":event",
@@ -16694,7 +16091,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "culture",
                 "TypeName": "System.Globalization.CultureInfo",
                 "DisplayName": ":culture",
@@ -16710,7 +16106,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "format-value",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -16734,10 +16129,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -495223800206768677,
-          "Data2": -4755761357761691481,
-          "Data3": 8192626605674161691,
-          "Data4": -2839835776368612514
+          "Data1": 4507268336053185054,
+          "Data2": -4924529436625881637,
+          "Data3": -6384694186165311236,
+          "Data4": 1159189652648307039
         },
         "Kind": "Components.Bind",
         "Name": "Bind_value",
@@ -16767,14 +16162,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind-value",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind_value",
             "Documentation": "Binds the provided expression to the 'value' attribute and a change event delegate to the 'onchange' attribute.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.Bind",
                 "Name": "format",
                 "TypeName": "System.String",
                 "DisplayName": ":format",
@@ -16784,7 +16177,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "event",
                 "TypeName": "System.String",
                 "DisplayName": ":event",
@@ -16794,7 +16186,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "culture",
                 "TypeName": "System.Globalization.CultureInfo",
                 "DisplayName": ":culture",
@@ -16810,7 +16201,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "format-value",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -16834,10 +16224,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -4206026310857524911,
-          "Data2": -2158435609650253765,
-          "Data3": -2547362969453147796,
-          "Data4": -4228318087260989529
+          "Data1": -2786262672341805485,
+          "Data2": 496796405187848261,
+          "Data3": -2512096008251902916,
+          "Data4": 8495041879440838067
         },
         "Kind": "Components.Bind",
         "Name": "Bind",
@@ -16867,14 +16257,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind",
             "Documentation": "Binds the provided expression to the 'value' attribute and a change event delegate to the 'onchange' attribute.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.Bind",
                 "Name": "format",
                 "TypeName": "System.String",
                 "DisplayName": ":format",
@@ -16884,7 +16272,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "event",
                 "TypeName": "System.String",
                 "DisplayName": ":event",
@@ -16894,7 +16281,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "culture",
                 "TypeName": "System.Globalization.CultureInfo",
                 "DisplayName": ":culture",
@@ -16910,7 +16296,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "format-value",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -16934,10 +16319,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -431675232342982062,
-          "Data2": 5562706815367542686,
-          "Data3": -7494682530175644166,
-          "Data4": 703565882454692719
+          "Data1": -9039372246411499249,
+          "Data2": 5215789752599257667,
+          "Data3": 5482041223859225988,
+          "Data4": -5131003500985830395
         },
         "Kind": "Components.Bind",
         "Name": "Bind_value",
@@ -16961,14 +16346,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind-value",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind_value",
             "Documentation": "Binds the provided expression to the 'value' attribute and a change event delegate to the 'onchange' attribute.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.Bind",
                 "Name": "format",
                 "TypeName": "System.String",
                 "DisplayName": ":format",
@@ -16978,7 +16361,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "event",
                 "TypeName": "System.String",
                 "DisplayName": ":event",
@@ -16988,7 +16370,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "culture",
                 "TypeName": "System.Globalization.CultureInfo",
                 "DisplayName": ":culture",
@@ -17004,7 +16385,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "format-value",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -17027,10 +16407,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 6862348085032572005,
-          "Data2": 4076010055755403708,
-          "Data3": -1062934246911877211,
-          "Data4": -761533268760181743
+          "Data1": -8658166212506016373,
+          "Data2": 991767655367317235,
+          "Data3": -6419385054464713237,
+          "Data4": 2446416340530546326
         },
         "Kind": "Components.Bind",
         "Name": "Bind",
@@ -17054,14 +16434,12 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Components.Web.BindAttributes.Bind",
             "Documentation": "Binds the provided expression to the 'value' attribute and a change event delegate to the 'onchange' attribute.",
             "BoundAttributeParameters": [
               {
-                "Kind": "Components.Bind",
                 "Name": "format",
                 "TypeName": "System.String",
                 "DisplayName": ":format",
@@ -17071,7 +16449,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "event",
                 "TypeName": "System.String",
                 "DisplayName": ":event",
@@ -17081,7 +16458,6 @@
                 }
               },
               {
-                "Kind": "Components.Bind",
                 "Name": "culture",
                 "TypeName": "System.Globalization.CultureInfo",
                 "DisplayName": ":culture",
@@ -17097,7 +16473,6 @@
             }
           },
           {
-            "Kind": "Components.Bind",
             "Name": "format-value",
             "TypeName": "System.String",
             "DisplayName": "string Microsoft.AspNetCore.Components.Web.BindAttributes.Format_value",
@@ -17120,10 +16495,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 5464310647831340632,
-          "Data2": -4225680292850504318,
-          "Data3": 6731878032454867058,
-          "Data4": -183526864473592349
+          "Data1": -5080415232478509494,
+          "Data2": 4819699287119748366,
+          "Data3": -8209674754516177236,
+          "Data4": 2684243872072977176
         },
         "Kind": "Components.Bind",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputCheckbox",
@@ -17147,7 +16522,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind-Value",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.Boolean>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.Boolean> Microsoft.AspNetCore.Components.Forms.InputCheckbox.Value",
@@ -17169,10 +16543,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 5142409740839879008,
-          "Data2": -6023581524717463899,
-          "Data3": -1266276356644328991,
-          "Data4": -4685436692918428850
+          "Data1": 6345236687639076384,
+          "Data2": -3487871092147233171,
+          "Data3": -8551282643494994133,
+          "Data4": 8444671501195184205
         },
         "Kind": "Components.Bind",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputCheckbox",
@@ -17196,7 +16570,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind-Value",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.Boolean>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.Boolean> Microsoft.AspNetCore.Components.Forms.InputCheckbox.Value",
@@ -17219,10 +16592,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -7933440874465832531,
-          "Data2": 3359235417998484325,
-          "Data3": -9060581644037597880,
-          "Data4": -4006724082303282220
+          "Data1": -4314029047945001303,
+          "Data2": -1630859374079543980,
+          "Data3": -285602460916989842,
+          "Data4": -1956441111676836875
         },
         "Kind": "Components.Bind",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputDate<TValue>",
@@ -17246,7 +16619,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind-Value",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.Value",
@@ -17268,10 +16640,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 2786632647215688936,
-          "Data2": -6669184041220132279,
-          "Data3": -8070883639167550583,
-          "Data4": 295610034354764578
+          "Data1": -8606467388077565933,
+          "Data2": 6026805045330357622,
+          "Data3": 2947170347199897399,
+          "Data4": 8283420710909573260
         },
         "Kind": "Components.Bind",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputDate<TValue>",
@@ -17295,7 +16667,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind-Value",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.Value",
@@ -17318,10 +16689,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -4486805715726299099,
-          "Data2": -2558925032407710962,
-          "Data3": 3272951237760099474,
-          "Data4": 5988933523789754544
+          "Data1": 770310171565119570,
+          "Data2": 1346830284163346421,
+          "Data3": -5116255847226173193,
+          "Data4": -3179112254135771168
         },
         "Kind": "Components.Bind",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>",
@@ -17345,7 +16716,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind-Value",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.Value",
@@ -17367,10 +16737,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -1151933251497496306,
-          "Data2": 3827002398665945264,
-          "Data3": 7076684105104821506,
-          "Data4": -3129624712126799800
+          "Data1": 5318434596194194593,
+          "Data2": 562838146021960775,
+          "Data3": 1007413628672408739,
+          "Data4": -2099831474612322626
         },
         "Kind": "Components.Bind",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>",
@@ -17394,7 +16764,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind-Value",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.Value",
@@ -17417,10 +16786,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 2934955310506049583,
-          "Data2": 7689678754539448205,
-          "Data3": 7157260877792712206,
-          "Data4": 5686840378866554025
+          "Data1": 2980009989284336402,
+          "Data2": 3262046464264859668,
+          "Data3": 8225890023716967200,
+          "Data4": -5916661811237023621
         },
         "Kind": "Components.Bind",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>",
@@ -17444,7 +16813,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind-Value",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.Value",
@@ -17466,10 +16834,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 3128757348638582288,
-          "Data2": 7867719220884059163,
-          "Data3": 429871786664430292,
-          "Data4": -3235062909342276137
+          "Data1": -4739879909583326270,
+          "Data2": -4331164756340733023,
+          "Data3": -695035121757217838,
+          "Data4": -7303457385444870737
         },
         "Kind": "Components.Bind",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>",
@@ -17493,7 +16861,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind-Value",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<TValue>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<TValue> Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.Value",
@@ -17516,10 +16883,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 5787837837307142072,
-          "Data2": 9170252231524509202,
-          "Data3": -4373022746244859437,
-          "Data4": -3639367183119835653
+          "Data1": 7355656378855522805,
+          "Data2": 3662902899766694902,
+          "Data3": 2413703173523070260,
+          "Data4": -6738163032111662636
         },
         "Kind": "Components.Bind",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputText",
@@ -17543,7 +16910,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind-Value",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.String>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.String> Microsoft.AspNetCore.Components.Forms.InputText.Value",
@@ -17565,10 +16931,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 3146496331992963375,
-          "Data2": -1503563662951534517,
-          "Data3": -2186524395644904349,
-          "Data4": 1516969957365416391
+          "Data1": 2476657285447884112,
+          "Data2": 2888031809996437989,
+          "Data3": 6322966919060727303,
+          "Data4": -5883539387910982967
         },
         "Kind": "Components.Bind",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputText",
@@ -17592,7 +16958,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind-Value",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.String>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.String> Microsoft.AspNetCore.Components.Forms.InputText.Value",
@@ -17615,10 +16980,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 6668165779697050986,
-          "Data2": 2709975222122302598,
-          "Data3": -5805783541459875102,
-          "Data4": 4495999071488695591
+          "Data1": -5771655227374795541,
+          "Data2": -3839372673098512560,
+          "Data3": -3515657784015293388,
+          "Data4": 7730937333667464506
         },
         "Kind": "Components.Bind",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputTextArea",
@@ -17642,7 +17007,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind-Value",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.String>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.String> Microsoft.AspNetCore.Components.Forms.InputTextArea.Value",
@@ -17664,10 +17028,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 4892544306299641743,
-          "Data2": 385063849134624298,
-          "Data3": -1084336775230221306,
-          "Data4": 4918604952360942422
+          "Data1": 4108805942338143318,
+          "Data2": -1959355447728106029,
+          "Data3": 6859453115345515934,
+          "Data4": -5985838738746024879
         },
         "Kind": "Components.Bind",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputTextArea",
@@ -17691,7 +17055,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Bind",
             "Name": "@bind-Value",
             "TypeName": "Microsoft.AspNetCore.Components.EventCallback<System.String>",
             "DisplayName": "Microsoft.AspNetCore.Components.EventCallback<System.String> Microsoft.AspNetCore.Components.Forms.InputTextArea.Value",
@@ -17714,10 +17077,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -5449103146096860466,
-          "Data2": -2132202985975661720,
-          "Data3": -2814804539520273857,
-          "Data4": -1823621361521685543
+          "Data1": 1347304352155116622,
+          "Data2": -7243151059964407181,
+          "Data3": -5597255805512913270,
+          "Data4": 1929205353189293387
         },
         "Kind": "Components.Ref",
         "Name": "Ref",
@@ -17741,7 +17104,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Ref",
             "Name": "@ref",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Components.Ref.Ref",
@@ -17761,10 +17123,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -6044385195333980465,
-          "Data2": 5445105986336281132,
-          "Data3": 4759217335971864999,
-          "Data4": 5517360606873994049
+          "Data1": 3173142411512989623,
+          "Data2": 6084693246750490904,
+          "Data3": 1162821467855587449,
+          "Data4": -1742661707188792840
         },
         "Kind": "Components.Key",
         "Name": "Key",
@@ -17788,7 +17150,6 @@
         ],
         "BoundAttributes": [
           {
-            "Kind": "Components.Key",
             "Name": "@key",
             "TypeName": "System.Object",
             "DisplayName": "object Microsoft.AspNetCore.Components.Key.Key",


### PR DESCRIPTION
Add Parent properties to all of the nested tag helper objects:

* `AllowedChildTagDescriptor.Parent` -> `TagHelperDescriptor`
* `BoundAttributeDescriptor.Parent` -> `TagHelperDescriptor`
* `BoundAttributeParameterDescriptor.Parent` -> `BoundAttributeDescriptor`
* `TagMatchingRuleDescriptor.Parent` -> `TagHelperDescriptor`
* `RequiredAttributeDescriptor.Parent` -> `TagMatchingRuleDescriptor`

This removes the need for `BoundAttribute` and `BoundAttributeParameterDescriptor` to duplicate the `Kind` property from `TagHelperDescriptor`.