### PR TITLE
Make cohosting win over legacy editor

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/DocumentSymbol/CohostDocumentSymbolEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/DocumentSymbol/CohostDocumentSymbolEndpoint.cs
@@ -5,7 +5,6 @@ using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/DocumentSymbol/CohostDocumentSymbolEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/DocumentSymbol/CohostDocumentSymbolEndpoint.cs
@@ -6,6 +6,7 @@ using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
+using Microsoft.AspNetCore.Razor.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
@@ -50,7 +51,16 @@ internal sealed class CohostDocumentSymbolEndpoint(IRemoteServiceInvoker remoteS
         => request.TextDocument.ToRazorTextDocumentIdentifier();
 
     protected override Task<SumType<DocumentSymbol[], SymbolInformation[]>?> HandleRequestAsync(DocumentSymbolParams request, RazorCohostRequestContext context, CancellationToken cancellationToken)
-        => HandleRequestAsync(context.TextDocument.AssumeNotNull(), _useHierarchicalSymbols, cancellationToken);
+    {
+        // The editor can send us a document symbol request in a .NET Framework project for some reason, so we have to be
+        // a little defensive here.
+        if (context.TextDocument is null)
+        {
+            return SpecializedTasks.Default<SumType<DocumentSymbol[], SymbolInformation[]>?>();
+        }
+
+        return HandleRequestAsync(context.TextDocument, _useHierarchicalSymbols, cancellationToken);
+    }
 
     private async Task<SumType<DocumentSymbol[], SymbolInformation[]>?> HandleRequestAsync(TextDocument razorDocument, bool useHierarchicalSymbols, CancellationToken cancellationToken)
     {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/LinkedEditingRange/CohostLinkedEditingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/LinkedEditingRange/CohostLinkedEditingRangeEndpoint.cs
@@ -5,7 +5,6 @@ using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/LinkedEditingRange/CohostLinkedEditingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/LinkedEditingRange/CohostLinkedEditingRangeEndpoint.cs
@@ -56,7 +56,7 @@ internal sealed class CohostLinkedEditingRangeEndpoint(IRemoteServiceInvoker rem
         // a little defensive here.
         if (context.TextDocument is null)
         {
-            return SpecializedTasks.Default<LinkedEditingRanges?>();
+            return SpecializedTasks.Null<LinkedEditingRanges>();
         }
 
         return HandleRequestAsync(request, context.TextDocument, cancellationToken);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ILspEditorFeatureDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ILspEditorFeatureDetector.cs
@@ -17,6 +17,11 @@ internal interface ILspEditorFeatureDetector
     bool IsLspEditorSupported(string documentFilePath);
 
     /// <summary>
+    /// Determines whether the project containing the given document is a .NET Core project.
+    /// </summary>
+    bool IsDotNetCoreProject(string documentFilePath);
+
+    /// <summary>
     /// A remote client is a LiveShare guest or a Codespaces instance
     /// </summary>
     bool IsRemoteClient();

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/CSHTMLFilePathToContentTypeProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/CSHTMLFilePathToContentTypeProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient;
@@ -12,7 +13,8 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient;
 [method: ImportingConstructor]
 internal class CSHTMLFilePathToContentTypeProvider(
     IContentTypeRegistryService contentTypeRegistryService,
-    ILspEditorFeatureDetector lspEditorFeatureDetector)
-    : RazorFilePathToContentTypeProviderBase(contentTypeRegistryService, lspEditorFeatureDetector)
+    ILspEditorFeatureDetector lspEditorFeatureDetector,
+    LanguageServerFeatureOptions options)
+    : RazorFilePathToContentTypeProviderBase(contentTypeRegistryService, lspEditorFeatureDetector, options)
 {
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/RazorFilePathToContentTypeProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/RazorFilePathToContentTypeProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient;
@@ -12,7 +13,8 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient;
 [method: ImportingConstructor]
 internal class RazorFilePathToContentTypeProvider(
     IContentTypeRegistryService contentTypeRegistryService,
-    ILspEditorFeatureDetector lspEditorFeatureDetector)
-    : RazorFilePathToContentTypeProviderBase(contentTypeRegistryService, lspEditorFeatureDetector)
+    ILspEditorFeatureDetector lspEditorFeatureDetector,
+    LanguageServerFeatureOptions options)
+    : RazorFilePathToContentTypeProviderBase(contentTypeRegistryService, lspEditorFeatureDetector, options)
 {
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/RazorFilePathToContentTypeProviderBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/RazorFilePathToContentTypeProviderBase.cs
@@ -18,23 +18,33 @@ internal abstract class RazorFilePathToContentTypeProviderBase(
 
     public bool TryGetContentTypeForFilePath(string filePath, [NotNullWhen(true)] out IContentType? contentType)
     {
-        // When cohosting is on, it's on for all non .NET Framework projects, regardless of feature flags or
-        // project capabilities.
-        if (_options.UseRazorCohostServer &&
-            _lspEditorFeatureDetector.IsDotNetCoreProject(filePath))
-        {
-            contentType = _contentTypeRegistryService.GetContentType(RazorConstants.RazorLSPContentTypeName);
-            return true;
-        }
-
-        if (_lspEditorFeatureDetector.IsLspEditorEnabled() &&
-            _lspEditorFeatureDetector.IsLspEditorSupported(filePath))
+        if (UseLSPEditor(filePath))
         {
             contentType = _contentTypeRegistryService.GetContentType(RazorConstants.RazorLSPContentTypeName);
             return true;
         }
 
         contentType = null;
+        return false;
+    }
+
+    private bool UseLSPEditor(string filePath)
+    {
+        // When cohosting is on, it's on for all non .NET Framework projects, regardless of feature flags or
+        // project capabilities.
+        if (_options.UseRazorCohostServer &&
+            _lspEditorFeatureDetector.IsDotNetCoreProject(filePath))
+        {
+            return true;
+        }
+
+        // Otherwise, we just check for the lack of feature flag feature or project capability.
+        if (_lspEditorFeatureDetector.IsLspEditorEnabled() &&
+            _lspEditorFeatureDetector.IsLspEditorSupported(filePath))
+        {
+            return true;
+        }
+
         return false;
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/RazorFilePathToContentTypeProviderBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/RazorFilePathToContentTypeProviderBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient;
@@ -10,17 +11,29 @@ internal abstract class RazorFilePathToContentTypeProviderBase : IFilePathToCont
 {
     private readonly IContentTypeRegistryService _contentTypeRegistryService;
     private readonly ILspEditorFeatureDetector _lspEditorFeatureDetector;
+    private readonly LanguageServerFeatureOptions _options;
 
     public RazorFilePathToContentTypeProviderBase(
         IContentTypeRegistryService contentTypeRegistryService,
-        ILspEditorFeatureDetector lspEditorFeatureDetector)
+        ILspEditorFeatureDetector lspEditorFeatureDetector,
+        LanguageServerFeatureOptions options)
     {
         _contentTypeRegistryService = contentTypeRegistryService;
         _lspEditorFeatureDetector = lspEditorFeatureDetector;
+        _options = options;
     }
 
     public bool TryGetContentTypeForFilePath(string filePath, [NotNullWhen(true)] out IContentType? contentType)
     {
+        // When cohosting is on, it's on for all non .NET Framework projects, regardless of feature flags or
+        // project capabilities.
+        if (_options.UseRazorCohostServer &&
+            _lspEditorFeatureDetector.IsDotNetCoreProject(filePath))
+        {
+            contentType = _contentTypeRegistryService.GetContentType(RazorConstants.RazorLSPContentTypeName);
+            return true;
+        }
+
         if (_lspEditorFeatureDetector.IsLspEditorEnabled() &&
             _lspEditorFeatureDetector.IsLspEditorSupported(filePath))
         {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/RazorFilePathToContentTypeProviderBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/RazorFilePathToContentTypeProviderBase.cs
@@ -7,21 +7,14 @@ using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient;
 
-internal abstract class RazorFilePathToContentTypeProviderBase : IFilePathToContentTypeProvider
+internal abstract class RazorFilePathToContentTypeProviderBase(
+    IContentTypeRegistryService contentTypeRegistryService,
+    ILspEditorFeatureDetector lspEditorFeatureDetector,
+    LanguageServerFeatureOptions options) : IFilePathToContentTypeProvider
 {
-    private readonly IContentTypeRegistryService _contentTypeRegistryService;
-    private readonly ILspEditorFeatureDetector _lspEditorFeatureDetector;
-    private readonly LanguageServerFeatureOptions _options;
-
-    public RazorFilePathToContentTypeProviderBase(
-        IContentTypeRegistryService contentTypeRegistryService,
-        ILspEditorFeatureDetector lspEditorFeatureDetector,
-        LanguageServerFeatureOptions options)
-    {
-        _contentTypeRegistryService = contentTypeRegistryService;
-        _lspEditorFeatureDetector = lspEditorFeatureDetector;
-        _options = options;
-    }
+    private readonly IContentTypeRegistryService _contentTypeRegistryService = contentTypeRegistryService;
+    private readonly ILspEditorFeatureDetector _lspEditorFeatureDetector = lspEditorFeatureDetector;
+    private readonly LanguageServerFeatureOptions _options = options;
 
     public bool TryGetContentTypeForFilePath(string filePath, [NotNullWhen(true)] out IContentType? contentType)
     {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LspEditorFeatureDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LspEditorFeatureDetector.cs
@@ -103,17 +103,18 @@ internal sealed class LspEditorFeatureDetector : ILspEditorFeatureDetector, IDis
             return false;
         }
 
-        var supportsRazor = _projectCapabilityResolver.ResolveCapability(WellKnownProjectCapabilities.DotNetCoreCSharp, documentFilePath);
-
-        if (!supportsRazor)
+        if (!IsDotNetCoreProject(documentFilePath))
         {
             _activityLog.LogInfo($"'{documentFilePath}' does not support the LSP editor because it is not associated with the '{WellKnownProjectCapabilities.DotNetCoreCSharp}' capability.");
             return false;
         }
 
         _activityLog.LogInfo($"LSP editor is supported for '{documentFilePath}'.");
-        return supportsRazor;
+        return true;
     }
+
+    public bool IsDotNetCoreProject(string documentFilePath)
+        => _projectCapabilityResolver.ResolveCapability(WellKnownProjectCapabilities.DotNetCoreCSharp, documentFilePath);
 
     public bool IsRemoteClient()
         => _uiContextService.IsActive(Guids.LiveShareGuestUIContextGuid) ||

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostEndpointTest.cs
@@ -166,6 +166,7 @@ public class CohostEndpointTest(ITestOutputHelper testOutputHelper) : ToolingTes
         public bool IsLiveShareHost() => throw new NotImplementedException();
         public bool IsLspEditorEnabled() => throw new NotImplementedException();
         public bool IsLspEditorSupported(string documentFilePath) => throw new NotImplementedException();
+        public bool IsDotNetCoreProject(string documentFilePath) => throw new NotImplementedException();
         public bool IsRemoteClient() => throw new NotImplementedException();
     }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/11941

This change means that if cohosting is on, we'll always use LSP, except for .NET Framework projects which will fall back to the really really legacy legacy editor. That editor has no interaction with any of our code, except the VS editor does send us a couple of LSP methods (because dynamic registration is by file extension, not content type) so we have to be a tiny bit defensive.