### PR TITLE
Fix overly aggressive delegated completion

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/Completion/RazorVSInternalCompletionParams.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/Completion/RazorVSInternalCompletionParams.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Text.Json.Serialization;
+
+namespace Roslyn.LanguageServer.Protocol;
+
+/// <summary>
+/// A replacement of the LSP protocol <see cref="CompletionParams"/> that ensures correct serialization between LSP servers.
+/// </summary>
+/// <remarks>
+/// This is the same as the LSP protocol <see cref="CompletionParams"/> except that it strongly types the <see cref="Context"/> property as VSInternalCompletionContext,
+/// because our custom message target gets handled by a JsonRpc connection set up by the editor, that has no Roslyn converters.
+/// Without using this class, we lose VSInternalCompletionContext.InvokeKind property when calling Roslyn or HTML servers from Razor
+/// which results in default value of "Invoked" to be used and can cause overly aggressive completion list.
+/// </remarks>
+internal sealed class RazorVSInternalCompletionParams : TextDocumentPositionParams, IPartialResultParams<SumType<CompletionItem[], CompletionList>?>, IWorkDoneProgressOptions
+{
+    public RazorVSInternalCompletionParams()
+    {
+    }
+
+    /// <summary>
+    /// The completion context. This is only available if the client specifies the
+    /// client capability <see cref="CompletionSetting.ContextSupport"/>.
+    /// </summary>
+    [JsonPropertyName("context")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public VSInternalCompletionContext? Context
+    {
+        get;
+        set;
+    }
+
+    /// <inheritdoc/>
+    [JsonPropertyName(Methods.PartialResultTokenName)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IProgress<SumType<CompletionItem[], CompletionList>?>? PartialResultToken
+    {
+        get;
+        set;
+    }
+
+    /// <inheritdoc/>
+    [JsonPropertyName("workDoneProgress")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool WorkDoneProgress { get; init; }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_Completion.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_Completion.cs
@@ -96,7 +96,7 @@ internal partial class RazorCustomMessageTarget
             return null;
         }
 
-        var completionParams = new CompletionParams()
+        var completionParams = new RazorVSInternalCompletionParams()
         {
             Context = request.Context,
             Position = request.ProjectedPosition,
@@ -134,7 +134,7 @@ internal partial class RazorCustomMessageTarget
             ReinvocationResponse<RazorVSInternalCompletionList?>? response;
             using (_telemetryReporter.TrackLspRequest(lspMethodName, languageServerName, TelemetryThresholds.CompletionSubLSPTelemetryThreshold, request.CorrelationId))
             {
-                response = await _requestInvoker.ReinvokeRequestOnServerAsync<CompletionParams, RazorVSInternalCompletionList?>(
+                response = await _requestInvoker.ReinvokeRequestOnServerAsync<RazorVSInternalCompletionParams, RazorVSInternalCompletionList?>(
                     textBuffer,
                     lspMethodName,
                     languageServerName,


### PR DESCRIPTION
We were losing VSInternalCompletionContext.InvokeKind value when re-invoking completion request on delegated servers (C#, HTML). That caused default value of "Invoked" being used in delegated server, which basically means Ctrl+J/Show Completion command. That caused overly aggressive behavior as if completion was forced rather than auto-shown by typing.

﻿### Summary of the changes

- This change properly types Context of CompletionParams so that VSInternalCompletionContext is properly serialized/deserialized and InvokeKind value doesn't get lost.

Fixes:
Internally filed AzDO issue