### PR TITLE
Add missing paren to SyntaxSerializer

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxSerializer.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxSerializer.cs
@@ -105,7 +105,7 @@ internal abstract partial class SyntaxSerializer(StringBuilder builder) : Syntax
 
     protected virtual void WriteSpan(TextSpan span)
     {
-        WriteValue($"[{span.Start}..{span.End}{Separator}Width: {span.End - span.Start}");
+        WriteValue($"[{span.Start}..{span.End}){Separator}Width: {span.End - span.Start}");
     }
 
     private void WriteRazorDirective(RazorDirectiveSyntax node)


### PR DESCRIPTION
The paren seems to be unintentionally dropped in https://github.com/dotnet/razor/pull/11853 cc @DustinCampbell 