### PR TITLE
Rework required attributes

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/TagHelperBlockRewriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/TagHelperBlockRewriterTest.cs
@@ -16,37 +16,30 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
     public static ImmutableArray<TagHelperDescriptor> SymbolBoundAttributes_Descriptors =
     [
         TagHelperDescriptorBuilder.Create("CatchAllTagHelper", "SomeAssembly")
-            .TagMatchingRuleDescriptor(rule =>
-                rule
+            .TagMatchingRuleDescriptor(rule => rule
                 .RequireTagName("*")
                 .RequireAttributeDescriptor(attribute => attribute.Name("bound")))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("[item]")
                 .Metadata(PropertyName("ListItems"))
                 .TypeName(typeof(List<string>).Namespace + "List<System.String>"))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("[(item)]")
                 .Metadata(PropertyName("ArrayItems"))
                 .TypeName(typeof(string[]).Namespace + "System.String[]"))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("(click)")
                 .Metadata(PropertyName("Event1"))
                 .TypeName(typeof(Action).FullName))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("(^click)")
                 .Metadata(PropertyName("Event2"))
                 .TypeName(typeof(Action).FullName))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("*something")
                 .Metadata(PropertyName("StringProperty1"))
                 .TypeName(typeof(string).FullName))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("#local")
                 .Metadata(PropertyName("StringProperty2"))
                 .TypeName(typeof(string).FullName))
@@ -98,8 +91,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
     public static ImmutableArray<TagHelperDescriptor> WithoutEndTag_Descriptors =
     [
         TagHelperDescriptorBuilder.Create("InputTagHelper", "SomeAssembly")
-            .TagMatchingRuleDescriptor(rule =>
-                rule
+            .TagMatchingRuleDescriptor(rule => rule
                 .RequireTagName("input")
                 .RequireTagStructure(TagStructure.WithoutEndTag))
             .Build()
@@ -140,14 +132,12 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         return
         [
             TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
-                .TagMatchingRuleDescriptor(rule =>
-                    rule
+                .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("input")
                     .RequireTagStructure(structure1))
                 .Build(),
             TagHelperDescriptorBuilder.Create("InputTagHelper2", "SomeAssembly")
-                .TagMatchingRuleDescriptor(rule =>
-                    rule
+                .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("input")
                     .RequireTagStructure(structure2))
                 .Build()
@@ -241,16 +231,11 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         ImmutableArray<TagHelperDescriptor> descriptors =
         [
             TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
-                .TagMatchingRuleDescriptor(rule =>
-                {
-                    rule
-                        .RequireTagName("*")
-                        .RequireAttributeDescriptor(b =>
-                        {
-                            b.Name = "@onclick";
-                            b.SetMetadata(Attributes.IsDirectiveAttribute);
-                        });
-                })
+                .TagMatchingRuleDescriptor(rule => rule
+                    .RequireTagName("*")
+                    .RequireAttributeDescriptor(attribute => attribute
+                        .Name("@onclick")
+                        .IsDirectiveAttribute()))
                 .Metadata(SpecialKind(ComponentMetadata.EventHandler.TagHelperKind))
                 .Build(),
         ];
@@ -266,17 +251,11 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         ImmutableArray<TagHelperDescriptor> descriptors =
         [
             TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
-                .TagMatchingRuleDescriptor(rule =>
-                {
-                    rule
-                        .RequireTagName("*")
-                        .RequireAttributeDescriptor(b =>
-                        {
-                            b.Name = "@onclick";
-                            b.SetMetadata(Attributes.IsDirectiveAttribute);
-                        });
-
-                })
+                .TagMatchingRuleDescriptor(rule => rule
+                    .RequireTagName("*")
+                    .RequireAttributeDescriptor(attribute => attribute
+                        .Name("@onclick")
+                        .IsDirectiveAttribute()))
                 .Metadata(SpecialKind(ComponentMetadata.EventHandler.TagHelperKind))
                 .Build(),
         ];
@@ -457,18 +436,15 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
     [
         TagHelperDescriptorBuilder.Create("PersonTagHelper", "personAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("person"))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("age")
                 .Metadata(PropertyName("Age"))
                 .TypeName(typeof(int).FullName))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("birthday")
                 .Metadata(PropertyName("BirthDay"))
                 .TypeName(typeof(DateTime).FullName))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("name")
                 .Metadata(PropertyName("Name"))
                 .TypeName(typeof(string).FullName))
@@ -869,13 +845,11 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
     [
         TagHelperDescriptorBuilder.Create("mythTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("myth"))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("bound")
                 .Metadata(PropertyName("Bound"))
                 .TypeName(typeof(bool).FullName))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("name")
                 .Metadata(PropertyName("Name"))
                 .TypeName(typeof(string).FullName))
@@ -1282,41 +1256,34 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
     public static ImmutableArray<TagHelperDescriptor> MinimizedAttribute_Descriptors =
     [
         TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
-            .TagMatchingRuleDescriptor(rule =>
-                rule
+            .TagMatchingRuleDescriptor(rule => rule
                 .RequireTagName("input")
                 .RequireAttributeDescriptor(attribute => attribute.Name("unbound-required")))
-            .TagMatchingRuleDescriptor(rule =>
-                rule
+            .TagMatchingRuleDescriptor(rule => rule
                 .RequireTagName("input")
                 .RequireAttributeDescriptor(attribute => attribute.Name("bound-required-string")))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("bound-required-string")
                 .Metadata(PropertyName("BoundRequiredString"))
                 .TypeName(typeof(string).FullName))
             .Build(),
         TagHelperDescriptorBuilder.Create("InputTagHelper2", "SomeAssembly")
-            .TagMatchingRuleDescriptor(rule =>
-                rule
+            .TagMatchingRuleDescriptor(rule => rule
                 .RequireTagName("input")
                 .RequireAttributeDescriptor(attribute => attribute.Name("bound-required-int")))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("bound-required-int")
                 .Metadata(PropertyName("BoundRequiredInt"))
                 .TypeName(typeof(int).FullName))
             .Build(),
         TagHelperDescriptorBuilder.Create("InputTagHelper3", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("input"))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("int-dictionary")
                 .Metadata(PropertyName("DictionaryOfIntProperty"))
                 .TypeName(typeof(IDictionary<string, int>).Namespace + ".IDictionary<System.String, System.Int32>")
                 .AsDictionaryAttribute("int-prefix-", typeof(int).FullName))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("string-dictionary")
                 .Metadata(PropertyName("DictionaryOfStringProperty"))
                 .TypeName(typeof(IDictionary<string, string>).Namespace + ".IDictionary<System.String, System.String>")
@@ -1324,13 +1291,11 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
             .Build(),
         TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("bound-string")
                 .Metadata(PropertyName("BoundRequiredString"))
                 .TypeName(typeof(string).FullName))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("bound-int")
                 .Metadata(PropertyName("BoundRequiredString"))
                 .TypeName(typeof(int).FullName))
@@ -2160,16 +2125,13 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         ImmutableArray<TagHelperDescriptor> descriptors =
         [
             TagHelperDescriptorBuilder.Create("InputTagHelper", "SomeAssembly")
-                .TagMatchingRuleDescriptor(rule =>
-                    rule
+                .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("input"))
-                .BoundAttributeDescriptor(attribute =>
-                    attribute
+                .BoundAttributeDescriptor(attribute => attribute
                     .Name("boundbool")
                     .Metadata(PropertyName("BoundBoolProp"))
                     .TypeName(typeof(bool).FullName))
-                .BoundAttributeDescriptor(attribute =>
-                    attribute
+                .BoundAttributeDescriptor(attribute => attribute
                     .Name("boundbooldict")
                     .Metadata(PropertyName("BoundBoolDictProp"))
                     .TypeName("System.Collections.Generic.IDictionary<string, bool>")
@@ -2189,16 +2151,13 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         ImmutableArray<TagHelperDescriptor> descriptors =
         [
             TagHelperDescriptorBuilder.Create("InputTagHelper", "SomeAssembly")
-                .TagMatchingRuleDescriptor(rule =>
-                    rule
+                .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("input"))
-                .BoundAttributeDescriptor(attribute =>
-                    attribute
+                .BoundAttributeDescriptor(attribute => attribute
                     .Name("boundbool")
                     .Metadata(PropertyName("BoundBoolProp"))
                     .TypeName(typeof(bool).FullName))
-                .BoundAttributeDescriptor(attribute =>
-                    attribute
+                .BoundAttributeDescriptor(attribute => attribute
                     .Name("boundbooldict")
                     .Metadata(PropertyName("BoundBoolDictProp"))
                     .TypeName("System.Collections.Generic.IDictionary<string, bool>")
@@ -2224,17 +2183,12 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
                     RuntimeName(ComponentMetadata.Bind.RuntimeName),
                     TypeName("Microsoft.AspNetCore.Components.Bind"),
                     MakeTrue(ComponentMetadata.Bind.FallbackKey))
-                .TagMatchingRuleDescriptor(rule =>
-                    rule
-                        .RequireTagName("*")
-                        .RequireAttributeDescriptor(r =>
-                        {
-                            r.Name = "@bind-";
-                            r.NameComparison = RequiredAttributeNameComparison.PrefixMatch;
-                            r.SetMetadata(Attributes.IsDirectiveAttribute);
-                        }))
-                .BoundAttributeDescriptor(attribute =>
-                    attribute
+                .TagMatchingRuleDescriptor(rule => rule
+                    .RequireTagName("*")
+                    .RequireAttributeDescriptor(attribute => attribute
+                        .Name("@bind-", RequiredAttributeNameComparison.PrefixMatch)
+                        .IsDirectiveAttribute()))
+                .BoundAttributeDescriptor(attribute => attribute
                     .Name("@bind-...")
                     .Metadata(PropertyName("Bind"), IsDirectiveAttribute)
                     .AsDictionaryAttribute("@bind-", typeof(object).FullName)
@@ -2269,17 +2223,12 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
                     RuntimeName(ComponentMetadata.Bind.RuntimeName),
                     TypeName("Microsoft.AspNetCore.Components.Bind"),
                     MakeTrue(ComponentMetadata.Bind.FallbackKey))
-                .TagMatchingRuleDescriptor(rule =>
-                    rule
-                        .RequireTagName("*")
-                        .RequireAttributeDescriptor(r =>
-                        {
-                            r.Name = "@bind-";
-                            r.NameComparison = RequiredAttributeNameComparison.PrefixMatch;
-                            r.SetMetadata(Attributes.IsDirectiveAttribute);
-                        }))
-                .BoundAttributeDescriptor(attribute =>
-                    attribute
+                .TagMatchingRuleDescriptor(rule => rule
+                    .RequireTagName("*")
+                    .RequireAttributeDescriptor(attribute => attribute
+                        .Name("@bind-", RequiredAttributeNameComparison.PrefixMatch)
+                        .IsDirectiveAttribute()))
+                .BoundAttributeDescriptor(attribute => attribute
                     .Name("@bind-...")
                     .Metadata(PropertyName("Bind"), IsDirectiveAttribute)
                     .AsDictionaryAttribute("@bind-", typeof(object).FullName)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/TagHelperBlockRewriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/TagHelperBlockRewriterTest.cs
@@ -2230,7 +2230,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
                         .RequireAttributeDescriptor(r =>
                         {
                             r.Name = "@bind-";
-                            r.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch;
+                            r.NameComparison = RequiredAttributeNameComparison.PrefixMatch;
                             r.SetMetadata(Attributes.IsDirectiveAttribute);
                         }))
                 .BoundAttributeDescriptor(attribute =>
@@ -2275,7 +2275,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
                         .RequireAttributeDescriptor(r =>
                         {
                             r.Name = "@bind-";
-                            r.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch;
+                            r.NameComparison = RequiredAttributeNameComparison.PrefixMatch;
                             r.SetMetadata(Attributes.IsDirectiveAttribute);
                         }))
                 .BoundAttributeDescriptor(attribute =>

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorTagHelperBinderPhaseTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorTagHelperBinderPhaseTest.cs
@@ -265,12 +265,10 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
             [
                 ruleBuilder => ruleBuilder
                     .RequireAttributeDescriptor(attribute => attribute
-                        .Name("a")
-                        .NameComparison(RequiredAttributeNameComparison.FullMatch)),
+                        .Name("a", RequiredAttributeNameComparison.FullMatch)),
                 ruleBuilder => ruleBuilder
                     .RequireAttributeDescriptor(attribute => attribute
-                        .Name("b")
-                        .NameComparison(RequiredAttributeNameComparison.FullMatch)),
+                        .Name("b", RequiredAttributeNameComparison.FullMatch)),
             ]);
 
         var content = @"
@@ -309,12 +307,10 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
             [
                 ruleBuilder => ruleBuilder
                     .RequireAttributeDescriptor(attribute => attribute
-                        .Name("a")
-                        .NameComparison(RequiredAttributeNameComparison.FullMatch)),
+                        .Name("a", RequiredAttributeNameComparison.FullMatch)),
                 ruleBuilder => ruleBuilder
                     .RequireAttributeDescriptor(attribute => attribute
-                        .Name("b")
-                        .NameComparison(RequiredAttributeNameComparison.FullMatch)),
+                        .Name("b", RequiredAttributeNameComparison.FullMatch)),
             ]);
 
         var content = @"

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorTagHelperBinderPhaseTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorTagHelperBinderPhaseTest.cs
@@ -266,11 +266,11 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
                 ruleBuilder => ruleBuilder
                     .RequireAttributeDescriptor(attribute => attribute
                         .Name("a")
-                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)),
+                        .NameComparison(RequiredAttributeNameComparison.FullMatch)),
                 ruleBuilder => ruleBuilder
                     .RequireAttributeDescriptor(attribute => attribute
                         .Name("b")
-                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)),
+                        .NameComparison(RequiredAttributeNameComparison.FullMatch)),
             ]);
 
         var content = @"
@@ -310,11 +310,11 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
                 ruleBuilder => ruleBuilder
                     .RequireAttributeDescriptor(attribute => attribute
                         .Name("a")
-                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)),
+                        .NameComparison(RequiredAttributeNameComparison.FullMatch)),
                 ruleBuilder => ruleBuilder
                     .RequireAttributeDescriptor(attribute => attribute
                         .Name("b")
-                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)),
+                        .NameComparison(RequiredAttributeNameComparison.FullMatch)),
             ]);
 
         var content = @"

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DefaultRequiredAttributeDescriptorBuilderTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DefaultRequiredAttributeDescriptorBuilderTest.cs
@@ -16,9 +16,7 @@ public class DefaultRequiredAttributeDescriptorBuilderTest
         var tagMatchingRuleBuilder = new TagMatchingRuleDescriptorBuilder(tagHelperBuilder);
         var builder = new RequiredAttributeDescriptorBuilder(tagMatchingRuleBuilder);
 
-        builder
-            .Name("asp-action")
-            .NameComparison(RequiredAttributeNameComparison.FullMatch);
+        builder.Name("asp-action", RequiredAttributeNameComparison.FullMatch);
 
         // Act
         var descriptor = builder.Build();
@@ -35,9 +33,7 @@ public class DefaultRequiredAttributeDescriptorBuilderTest
         var tagMatchingRuleBuilder = new TagMatchingRuleDescriptorBuilder(tagHelperBuilder);
         var builder = new RequiredAttributeDescriptorBuilder(tagMatchingRuleBuilder);
 
-        builder
-            .Name("asp-route-")
-            .NameComparison(RequiredAttributeNameComparison.PrefixMatch);
+        builder.Name("asp-route-", RequiredAttributeNameComparison.PrefixMatch);
 
         // Act
         var descriptor = builder.Build();

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DefaultRequiredAttributeDescriptorBuilderTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DefaultRequiredAttributeDescriptorBuilderTest.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.Language;
@@ -40,57 +39,5 @@ public class DefaultRequiredAttributeDescriptorBuilderTest
 
         // Assert
         Assert.Equal("asp-route-...", attribute.DisplayName);
-    }
-
-    [Fact]
-    public void Metadata_Same()
-    {
-        // When SetMetadata is called on multiple builders with the same metadata collection,
-        // they should share the instance.
-
-        // Arrange
-        var metadata = MetadataCollection.Create(KeyValuePair.Create<string, string?>("TestKey", "TestValue"));
-
-        var builder = TagHelperDescriptorBuilder.Create(TagHelperConventions.DefaultKind, "TestTagHelper", "Test")
-            .TagMatchingRuleDescriptor(rule => rule
-                .RequireAttributeDescriptor(attribute => attribute
-                    .Name("test1")
-                    .SetMetadata(metadata))
-                .RequireAttributeDescriptor(attribute => attribute
-                    .Name("test2")
-                    .SetMetadata(metadata)));
-
-        // Act
-        var tagHelper = builder.Build();
-        var attribute1 = tagHelper.TagMatchingRules[0].Attributes[0];
-        var attribute2 = tagHelper.TagMatchingRules[0].Attributes[1];
-
-        // Assert
-        Assert.Same(attribute1.Metadata, attribute2.Metadata);
-    }
-
-    [Fact]
-    public void Metadata_NotSame()
-    {
-        // When Metadata is accessed on multiple builders with the same metadata,
-        // they do not share the instance.
-
-        // Arrange
-        var builder = TagHelperDescriptorBuilder.Create(TagHelperConventions.DefaultKind, "TestTagHelper", "Test")
-            .TagMatchingRuleDescriptor(rule => rule
-                .RequireAttributeDescriptor(attribute => attribute
-                    .Name("test1")
-                    .Metadata.Add("TestKey", "TestValue"))
-                .RequireAttributeDescriptor(attribute => attribute
-                    .Name("test2")
-                    .Metadata.Add("TestKey", "TestValue")));
-
-        // Act
-        var tagHelper = builder.Build();
-        var attribute1 = tagHelper.TagMatchingRules[0].Attributes[0];
-        var attribute2 = tagHelper.TagMatchingRules[0].Attributes[1];
-
-        // Assert
-        Assert.NotSame(attribute1.Metadata, attribute2.Metadata);
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DefaultRequiredAttributeDescriptorBuilderTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DefaultRequiredAttributeDescriptorBuilderTest.cs
@@ -18,7 +18,7 @@ public class DefaultRequiredAttributeDescriptorBuilderTest
 
         builder
             .Name("asp-action")
-            .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch);
+            .NameComparison(RequiredAttributeNameComparison.FullMatch);
 
         // Act
         var descriptor = builder.Build();
@@ -37,7 +37,7 @@ public class DefaultRequiredAttributeDescriptorBuilderTest
 
         builder
             .Name("asp-route-")
-            .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch);
+            .NameComparison(RequiredAttributeNameComparison.PrefixMatch);
 
         // Act
         var descriptor = builder.Build();

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/TestTagHelperDescriptors.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/TestTagHelperDescriptors.cs
@@ -116,10 +116,8 @@ public class TestTagHelperDescriptors
                         {
                             builder => builder
                                 .RequireAttributeDescriptor(attribute => attribute
-                                    .Name("href")
-                                    .NameComparison(RequiredAttributeNameComparison.FullMatch)
-                                    .Value("~/")
-                                    .ValueComparison(RequiredAttributeValueComparison.FullMatch)),
+                                    .Name("href", RequiredAttributeNameComparison.FullMatch)
+                                    .Value("~/", RequiredAttributeValueComparison.FullMatch)),
                         }),
                     CreateTagHelperDescriptor(
                         tagName: "a",
@@ -129,15 +127,11 @@ public class TestTagHelperDescriptors
                         {
                             builder => builder
                                 .RequireAttributeDescriptor(attribute => attribute
-                                    .Name("href")
-                                    .NameComparison(RequiredAttributeNameComparison.FullMatch)
-                                    .Value("~/")
-                                    .ValueComparison(RequiredAttributeValueComparison.PrefixMatch))
+                                    .Name("href", RequiredAttributeNameComparison.FullMatch)
+                                    .Value("~/", RequiredAttributeValueComparison.PrefixMatch))
                                 .RequireAttributeDescriptor(attribute => attribute
-                                    .Name("href")
-                                    .NameComparison(RequiredAttributeNameComparison.FullMatch)
-                                    .Value("?hello=world")
-                                    .ValueComparison(RequiredAttributeValueComparison.SuffixMatch)),
+                                    .Name("href", RequiredAttributeNameComparison.FullMatch)
+                                    .Value("?hello=world", RequiredAttributeValueComparison.SuffixMatch)),
                         }),
                     CreateTagHelperDescriptor(
                         tagName: "input",
@@ -151,10 +145,8 @@ public class TestTagHelperDescriptors
                         {
                             builder => builder
                                 .RequireAttributeDescriptor(attribute => attribute
-                                    .Name("type")
-                                    .NameComparison(RequiredAttributeNameComparison.FullMatch)
-                                    .Value("text")
-                                    .ValueComparison(RequiredAttributeValueComparison.FullMatch)),
+                                    .Name("type", RequiredAttributeNameComparison.FullMatch)
+                                    .Value("text", RequiredAttributeValueComparison.FullMatch)),
                         }),
                     CreateTagHelperDescriptor(
                         tagName: "input",
@@ -168,8 +160,7 @@ public class TestTagHelperDescriptors
                         {
                             builder => builder
                                 .RequireAttributeDescriptor(attribute => attribute
-                                    .Name("ty")
-                                    .NameComparison(RequiredAttributeNameComparison.PrefixMatch)),
+                                    .Name("ty", RequiredAttributeNameComparison.PrefixMatch)),
                         }),
                     CreateTagHelperDescriptor(
                         tagName: "*",
@@ -179,10 +170,8 @@ public class TestTagHelperDescriptors
                         {
                             builder => builder
                                 .RequireAttributeDescriptor(attribute => attribute
-                                    .Name("href")
-                                    .NameComparison(RequiredAttributeNameComparison.FullMatch)
-                                    .Value("~/")
-                                    .ValueComparison(RequiredAttributeValueComparison.PrefixMatch)),
+                                    .Name("href", RequiredAttributeNameComparison.FullMatch)
+                                    .Value("~/", RequiredAttributeValueComparison.PrefixMatch)),
                         }),
                     CreateTagHelperDescriptor(
                         tagName: "*",
@@ -192,8 +181,7 @@ public class TestTagHelperDescriptors
                         {
                             builder => builder
                                 .RequireAttributeDescriptor(attribute => attribute
-                                    .Name("type")
-                                    .NameComparison(RequiredAttributeNameComparison.FullMatch)),
+                                    .Name("type", RequiredAttributeNameComparison.FullMatch)),
                         }),
                 };
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/TestTagHelperDescriptors.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/TestTagHelperDescriptors.cs
@@ -117,9 +117,9 @@ public class TestTagHelperDescriptors
                             builder => builder
                                 .RequireAttributeDescriptor(attribute => attribute
                                     .Name("href")
-                                    .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)
+                                    .NameComparison(RequiredAttributeNameComparison.FullMatch)
                                     .Value("~/")
-                                    .ValueComparisonMode(RequiredAttributeDescriptor.ValueComparisonMode.FullMatch)),
+                                    .ValueComparison(RequiredAttributeValueComparison.FullMatch)),
                         }),
                     CreateTagHelperDescriptor(
                         tagName: "a",
@@ -130,14 +130,14 @@ public class TestTagHelperDescriptors
                             builder => builder
                                 .RequireAttributeDescriptor(attribute => attribute
                                     .Name("href")
-                                    .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)
+                                    .NameComparison(RequiredAttributeNameComparison.FullMatch)
                                     .Value("~/")
-                                    .ValueComparisonMode(RequiredAttributeDescriptor.ValueComparisonMode.PrefixMatch))
+                                    .ValueComparison(RequiredAttributeValueComparison.PrefixMatch))
                                 .RequireAttributeDescriptor(attribute => attribute
                                     .Name("href")
-                                    .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)
+                                    .NameComparison(RequiredAttributeNameComparison.FullMatch)
                                     .Value("?hello=world")
-                                    .ValueComparisonMode(RequiredAttributeDescriptor.ValueComparisonMode.SuffixMatch)),
+                                    .ValueComparison(RequiredAttributeValueComparison.SuffixMatch)),
                         }),
                     CreateTagHelperDescriptor(
                         tagName: "input",
@@ -152,9 +152,9 @@ public class TestTagHelperDescriptors
                             builder => builder
                                 .RequireAttributeDescriptor(attribute => attribute
                                     .Name("type")
-                                    .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)
+                                    .NameComparison(RequiredAttributeNameComparison.FullMatch)
                                     .Value("text")
-                                    .ValueComparisonMode(RequiredAttributeDescriptor.ValueComparisonMode.FullMatch)),
+                                    .ValueComparison(RequiredAttributeValueComparison.FullMatch)),
                         }),
                     CreateTagHelperDescriptor(
                         tagName: "input",
@@ -169,7 +169,7 @@ public class TestTagHelperDescriptors
                             builder => builder
                                 .RequireAttributeDescriptor(attribute => attribute
                                     .Name("ty")
-                                    .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch)),
+                                    .NameComparison(RequiredAttributeNameComparison.PrefixMatch)),
                         }),
                     CreateTagHelperDescriptor(
                         tagName: "*",
@@ -180,9 +180,9 @@ public class TestTagHelperDescriptors
                             builder => builder
                                 .RequireAttributeDescriptor(attribute => attribute
                                     .Name("href")
-                                    .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)
+                                    .NameComparison(RequiredAttributeNameComparison.FullMatch)
                                     .Value("~/")
-                                    .ValueComparisonMode(RequiredAttributeDescriptor.ValueComparisonMode.PrefixMatch)),
+                                    .ValueComparison(RequiredAttributeValueComparison.PrefixMatch)),
                         }),
                     CreateTagHelperDescriptor(
                         tagName: "*",
@@ -193,7 +193,7 @@ public class TestTagHelperDescriptors
                             builder => builder
                                 .RequireAttributeDescriptor(attribute => attribute
                                     .Name("type")
-                                    .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)),
+                                    .NameComparison(RequiredAttributeNameComparison.FullMatch)),
                         }),
                 };
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperBlockRewriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperBlockRewriterTest.cs
@@ -2453,7 +2453,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
                         .RequireAttributeDescriptor(r =>
                         {
                             r.Name = "@bind-";
-                            r.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch;
+                            r.NameComparison = RequiredAttributeNameComparison.PrefixMatch;
                             r.SetMetadata(Attributes.IsDirectiveAttribute);
                         }))
                 .BoundAttributeDescriptor(attribute =>
@@ -2498,7 +2498,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
                         .RequireAttributeDescriptor(r =>
                         {
                             r.Name = "@bind-";
-                            r.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch;
+                            r.NameComparison = RequiredAttributeNameComparison.PrefixMatch;
                             r.SetMetadata(Attributes.IsDirectiveAttribute);
                         }))
                 .BoundAttributeDescriptor(attribute =>

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperBlockRewriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperBlockRewriterTest.cs
@@ -17,37 +17,30 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
     public static ImmutableArray<TagHelperDescriptor> SymbolBoundAttributes_Descriptors =
     [
         TagHelperDescriptorBuilder.Create("CatchAllTagHelper", "SomeAssembly")
-            .TagMatchingRuleDescriptor(rule =>
-                rule
+            .TagMatchingRuleDescriptor(rule => rule
                 .RequireTagName("*")
                 .RequireAttributeDescriptor(attribute => attribute.Name("bound")))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("[item]")
                 .Metadata(PropertyName("ListItems"))
                 .TypeName(typeof(List<string>).Namespace + "List<System.String>"))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("[(item)]")
                 .Metadata(PropertyName("ArrayItems"))
                 .TypeName(typeof(string[]).Namespace + "System.String[]"))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("(click)")
                 .Metadata(PropertyName("Event1"))
                 .TypeName(typeof(Action).FullName))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("(^click)")
                 .Metadata(PropertyName("Event2"))
                 .TypeName(typeof(Action).FullName))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("*something")
                 .Metadata(PropertyName("StringProperty1"))
                 .TypeName(typeof(string).FullName))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("#local")
                 .Metadata(PropertyName("StringProperty2"))
                 .TypeName(typeof(string).FullName))
@@ -99,8 +92,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
     public static ImmutableArray<TagHelperDescriptor> WithoutEndTag_Descriptors =
     [
         TagHelperDescriptorBuilder.Create("InputTagHelper", "SomeAssembly")
-            .TagMatchingRuleDescriptor(rule =>
-                rule
+            .TagMatchingRuleDescriptor(rule => rule
                 .RequireTagName("input")
                 .RequireTagStructure(TagStructure.WithoutEndTag))
             .Build()
@@ -141,14 +133,12 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         return
         [
             TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
-                .TagMatchingRuleDescriptor(rule =>
-                    rule
+                .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("input")
                     .RequireTagStructure(structure1))
                 .Build(),
             TagHelperDescriptorBuilder.Create("InputTagHelper2", "SomeAssembly")
-                .TagMatchingRuleDescriptor(rule =>
-                    rule
+                .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("input")
                     .RequireTagStructure(structure2))
                 .Build()
@@ -242,16 +232,11 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         ImmutableArray<TagHelperDescriptor> descriptors =
         [
             TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
-                .TagMatchingRuleDescriptor(rule =>
-                {
-                    rule
-                        .RequireTagName("*")
-                        .RequireAttributeDescriptor(b =>
-                        {
-                            b.Name = "@onclick";
-                            b.SetMetadata(Attributes.IsDirectiveAttribute);
-                        });
-                })
+                .TagMatchingRuleDescriptor(rule => rule
+                    .RequireTagName("*")
+                    .RequireAttributeDescriptor(b => b
+                        .Name("@onclick")
+                        .IsDirectiveAttribute()))
                 .Metadata(SpecialKind(ComponentMetadata.EventHandler.TagHelperKind))
                 .Build(),
         ];
@@ -267,17 +252,11 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         ImmutableArray<TagHelperDescriptor> descriptors =
         [
             TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
-                .TagMatchingRuleDescriptor(rule =>
-                {
-                    rule
-                        .RequireTagName("*")
-                        .RequireAttributeDescriptor(b =>
-                        {
-                            b.Name = "@onclick";
-                            b.SetMetadata(Attributes.IsDirectiveAttribute);
-                        });
-
-                })
+                .TagMatchingRuleDescriptor(rule => rule
+                    .RequireTagName("*")
+                    .RequireAttributeDescriptor(b => b
+                        .Name("@onclick")
+                        .IsDirectiveAttribute()))
                 .Metadata(SpecialKind(ComponentMetadata.EventHandler.TagHelperKind))
                 .Build(),
         ];
@@ -458,28 +437,23 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
     [
         TagHelperDescriptorBuilder.Create("PersonTagHelper", "personAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("person"))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("age")
                 .Metadata(PropertyName("Age"))
                 .TypeName(typeof(int).FullName))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("birthday")
                 .Metadata(PropertyName("BirthDay"))
                 .TypeName(typeof(DateTime).FullName))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("name")
                 .Metadata(PropertyName("Name"))
                 .TypeName(typeof(string).FullName))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("alive")
                 .Metadata(PropertyName("Alive"))
                 .TypeName(typeof(bool).FullName))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("tag")
                 .Metadata(PropertyName("Tag"))
                 .TypeName(typeof(object).FullName))
@@ -681,13 +655,12 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
             [TagHelperDescriptorBuilder
                 .Create("InputTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("input"))
-                .BoundAttributeDescriptor(attribute =>
-                    attribute
-                        .Name("tuple-dictionary")
-                        .Metadata(PropertyName("DictionaryOfBoolAndStringTupleProperty"))
-                        .TypeName(typeof(IDictionary<string, int>).Namespace + ".IDictionary<System.String, (System.Boolean, System.String)>")
-                        .AsDictionaryAttribute("tuple-prefix-", typeof((bool, string)).FullName))
-                    .Build()],
+                .BoundAttributeDescriptor(attribute => attribute
+                    .Name("tuple-dictionary")
+                    .Metadata(PropertyName("DictionaryOfBoolAndStringTupleProperty"))
+                    .TypeName(typeof(IDictionary<string, int>).Namespace + ".IDictionary<System.String, (System.Boolean, System.String)>")
+                    .AsDictionaryAttribute("tuple-prefix-", typeof((bool, string)).FullName))
+                .Build()],
             """
             @{ 
                 var item = new { Items = new System.List<string>() { "one", "two" } };
@@ -1092,13 +1065,11 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
     [
         TagHelperDescriptorBuilder.Create("mythTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("myth"))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("bound")
                 .Metadata(PropertyName("Bound"))
                 .TypeName(typeof(bool).FullName))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("name")
                 .Metadata(PropertyName("Name"))
                 .TypeName(typeof(string).FullName))
@@ -1505,41 +1476,34 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
     public static ImmutableArray<TagHelperDescriptor> MinimizedAttribute_Descriptors =
     [
         TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
-            .TagMatchingRuleDescriptor(rule =>
-                rule
+            .TagMatchingRuleDescriptor(rule => rule
                 .RequireTagName("input")
                 .RequireAttributeDescriptor(attribute => attribute.Name("unbound-required")))
-            .TagMatchingRuleDescriptor(rule =>
-                rule
+            .TagMatchingRuleDescriptor(rule => rule
                 .RequireTagName("input")
                 .RequireAttributeDescriptor(attribute => attribute.Name("bound-required-string")))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("bound-required-string")
                 .Metadata(PropertyName("BoundRequiredString"))
                 .TypeName(typeof(string).FullName))
             .Build(),
         TagHelperDescriptorBuilder.Create("InputTagHelper2", "SomeAssembly")
-            .TagMatchingRuleDescriptor(rule =>
-                rule
+            .TagMatchingRuleDescriptor(rule => rule
                 .RequireTagName("input")
                 .RequireAttributeDescriptor(attribute => attribute.Name("bound-required-int")))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("bound-required-int")
                 .Metadata(PropertyName("BoundRequiredInt"))
                 .TypeName(typeof(int).FullName))
             .Build(),
         TagHelperDescriptorBuilder.Create("InputTagHelper3", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("input"))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("int-dictionary")
                 .Metadata(PropertyName("DictionaryOfIntProperty"))
                 .TypeName(typeof(IDictionary<string, int>).Namespace + ".IDictionary<System.String, System.Int32>")
                 .AsDictionaryAttribute("int-prefix-", typeof(int).FullName))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("string-dictionary")
                 .Metadata(PropertyName("DictionaryOfStringProperty"))
                 .TypeName(typeof(IDictionary<string, string>).Namespace + ".IDictionary<System.String, System.String>")
@@ -1547,13 +1511,11 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
             .Build(),
         TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("bound-string")
                 .Metadata(PropertyName("BoundRequiredString"))
                 .TypeName(typeof(string).FullName))
-            .BoundAttributeDescriptor(attribute =>
-                attribute
+            .BoundAttributeDescriptor(attribute => attribute
                 .Name("bound-int")
                 .Metadata(PropertyName("BoundRequiredString"))
                 .TypeName(typeof(int).FullName))
@@ -2383,16 +2345,13 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         ImmutableArray<TagHelperDescriptor> descriptors =
         [
             TagHelperDescriptorBuilder.Create("InputTagHelper", "SomeAssembly")
-                .TagMatchingRuleDescriptor(rule =>
-                    rule
+                .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("input"))
-                .BoundAttributeDescriptor(attribute =>
-                    attribute
+                .BoundAttributeDescriptor(attribute => attribute
                     .Name("boundbool")
                     .Metadata(PropertyName("BoundBoolProp"))
                     .TypeName(typeof(bool).FullName))
-                .BoundAttributeDescriptor(attribute =>
-                    attribute
+                .BoundAttributeDescriptor(attribute => attribute
                     .Name("boundbooldict")
                     .Metadata(PropertyName("BoundBoolDictProp"))
                     .TypeName("System.Collections.Generic.IDictionary<string, bool>")
@@ -2412,16 +2371,13 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         ImmutableArray<TagHelperDescriptor> descriptors =
         [
             TagHelperDescriptorBuilder.Create("InputTagHelper", "SomeAssembly")
-                .TagMatchingRuleDescriptor(rule =>
-                    rule
+                .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("input"))
-                .BoundAttributeDescriptor(attribute =>
-                    attribute
+                .BoundAttributeDescriptor(attribute => attribute
                     .Name("boundbool")
                     .Metadata(PropertyName("BoundBoolProp"))
                     .TypeName(typeof(bool).FullName))
-                .BoundAttributeDescriptor(attribute =>
-                    attribute
+                .BoundAttributeDescriptor(attribute => attribute
                     .Name("boundbooldict")
                     .Metadata(PropertyName("BoundBoolDictProp"))
                     .TypeName("System.Collections.Generic.IDictionary<string, bool>")
@@ -2447,17 +2403,12 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
                     RuntimeName(ComponentMetadata.Bind.RuntimeName),
                     TypeName("Microsoft.AspNetCore.Components.Bind"),
                     MakeTrue(ComponentMetadata.Bind.FallbackKey))
-                .TagMatchingRuleDescriptor(rule =>
-                    rule
-                        .RequireTagName("*")
-                        .RequireAttributeDescriptor(r =>
-                        {
-                            r.Name = "@bind-";
-                            r.NameComparison = RequiredAttributeNameComparison.PrefixMatch;
-                            r.SetMetadata(Attributes.IsDirectiveAttribute);
-                        }))
-                .BoundAttributeDescriptor(attribute =>
-                    attribute
+                .TagMatchingRuleDescriptor(rule => rule
+                    .RequireTagName("*")
+                    .RequireAttributeDescriptor(attribute => attribute
+                        .Name("@bind-", RequiredAttributeNameComparison.PrefixMatch)
+                        .IsDirectiveAttribute()))
+                .BoundAttributeDescriptor(attribute => attribute
                     .Name("@bind-...")
                     .Metadata(PropertyName("Bind"), IsDirectiveAttribute)
                     .AsDictionaryAttribute("@bind-", typeof(object).FullName)
@@ -2492,17 +2443,12 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
                     RuntimeName(ComponentMetadata.Bind.RuntimeName),
                     TypeName("Microsoft.AspNetCore.Components.Bind"),
                     MakeTrue(ComponentMetadata.Bind.FallbackKey))
-                .TagMatchingRuleDescriptor(rule =>
-                    rule
-                        .RequireTagName("*")
-                        .RequireAttributeDescriptor(r =>
-                        {
-                            r.Name = "@bind-";
-                            r.NameComparison = RequiredAttributeNameComparison.PrefixMatch;
-                            r.SetMetadata(Attributes.IsDirectiveAttribute);
-                        }))
-                .BoundAttributeDescriptor(attribute =>
-                    attribute
+                .TagMatchingRuleDescriptor(rule => rule
+                    .RequireTagName("*")
+                    .RequireAttributeDescriptor(attribute => attribute
+                        .Name("@bind-", RequiredAttributeNameComparison.PrefixMatch)
+                        .IsDirectiveAttribute()))
+                .BoundAttributeDescriptor(attribute => attribute
                     .Name("@bind-...")
                     .Metadata(PropertyName("Bind"), IsDirectiveAttribute)
                     .AsDictionaryAttribute("@bind-", typeof(object).FullName)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TagHelperBinderTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TagHelperBinderTest.cs
@@ -244,7 +244,7 @@ public class TagHelperBinderTest
                     .RequireAttributeDescriptor(attribute =>
                         attribute
                         .Name("nodashprefix")
-                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch)))
+                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch)))
                 .Build();
             var catchAllDescriptor = TagHelperDescriptorBuilder.Create("CatchAllTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule =>
@@ -266,7 +266,7 @@ public class TagHelperBinderTest
                     .RequireAttributeDescriptor(attribute =>
                         attribute
                         .Name("prefix-")
-                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch)))
+                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch)))
                 .Build();
             ImmutableArray<TagHelperDescriptor> defaultAvailableDescriptors =
                 [divDescriptor, inputDescriptor, catchAllDescriptor, catchAllDescriptor2];

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TagHelperBinderTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TagHelperBinderTest.cs
@@ -225,48 +225,38 @@ public class TagHelperBinderTest
         get
         {
             var divDescriptor = TagHelperDescriptorBuilder.Create("DivTagHelper", "SomeAssembly")
-                .TagMatchingRuleDescriptor(rule =>
-                    rule
+                .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("div")
                     .RequireAttributeDescriptor(attribute => attribute.Name("style")))
                 .Build();
             var inputDescriptor = TagHelperDescriptorBuilder.Create("InputTagHelper", "SomeAssembly")
-                .TagMatchingRuleDescriptor(rule =>
-                    rule
+                .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("input")
                     .RequireAttributeDescriptor(attribute => attribute.Name("class"))
                     .RequireAttributeDescriptor(attribute => attribute.Name("style")))
                 .Build();
             var inputWildcardPrefixDescriptor = TagHelperDescriptorBuilder.Create("InputWildCardAttribute", "SomeAssembly")
-                .TagMatchingRuleDescriptor(rule =>
-                    rule
+                .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("input")
-                    .RequireAttributeDescriptor(attribute =>
-                        attribute
-                        .Name("nodashprefix")
-                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch)))
+                    .RequireAttributeDescriptor(attribute => attribute
+                        .Name("nodashprefix", RequiredAttributeNameComparison.PrefixMatch)))
                 .Build();
             var catchAllDescriptor = TagHelperDescriptorBuilder.Create("CatchAllTagHelper", "SomeAssembly")
-                .TagMatchingRuleDescriptor(rule =>
-                    rule
+                .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName(TagHelperMatchingConventions.ElementCatchAllName)
                     .RequireAttributeDescriptor(attribute => attribute.Name("class")))
                 .Build();
             var catchAllDescriptor2 = TagHelperDescriptorBuilder.Create("CatchAllTagHelper2", "SomeAssembly")
-                .TagMatchingRuleDescriptor(rule =>
-                    rule
+                .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName(TagHelperMatchingConventions.ElementCatchAllName)
                     .RequireAttributeDescriptor(attribute => attribute.Name("custom"))
                     .RequireAttributeDescriptor(attribute => attribute.Name("class")))
                 .Build();
             var catchAllWildcardPrefixDescriptor = TagHelperDescriptorBuilder.Create("CatchAllWildCardAttribute", "SomeAssembly")
-                .TagMatchingRuleDescriptor(rule =>
-                    rule
+                .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName(TagHelperMatchingConventions.ElementCatchAllName)
-                    .RequireAttributeDescriptor(attribute =>
-                        attribute
-                        .Name("prefix-")
-                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch)))
+                    .RequireAttributeDescriptor(attribute => attribute
+                        .Name("prefix-", RequiredAttributeNameComparison.PrefixMatch)))
                 .Build();
             ImmutableArray<TagHelperDescriptor> defaultAvailableDescriptors =
                 [divDescriptor, inputDescriptor, catchAllDescriptor, catchAllDescriptor2];

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TagHelperMatchingConventionsTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TagHelperMatchingConventionsTest.cs
@@ -31,101 +31,79 @@ public class TagHelperMatchingConventionsTest
                         false
                     },
                     {
-                        builder => builder
-                            .Name("route-")
-                            .NameComparison(RequiredAttributeNameComparison.PrefixMatch),
+                        builder => builder.Name("route-", RequiredAttributeNameComparison.PrefixMatch),
                         "ROUTE-area",
                         "manage",
                         true
                     },
                     {
-                        builder => builder
-                            .Name("route-")
-                            .NameComparison(RequiredAttributeNameComparison.PrefixMatch),
+                        builder => builder.Name("route-", RequiredAttributeNameComparison.PrefixMatch),
                         "routearea",
                         "manage",
                         false
                     },
                     {
-                        builder => builder
-                            .Name("route-")
-                            .NameComparison(RequiredAttributeNameComparison.PrefixMatch),
+                        builder => builder.Name("route-", RequiredAttributeNameComparison.PrefixMatch),
                         "route-",
                         "manage",
                         false
                     },
                     {
-                        builder => builder
-                            .Name("key")
-                            .NameComparison(RequiredAttributeNameComparison.FullMatch),
+                        builder => builder.Name("key", RequiredAttributeNameComparison.FullMatch),
                         "KeY",
                         "value",
                         true
                     },
                     {
-                        builder => builder
-                            .Name("key")
-                            .NameComparison(RequiredAttributeNameComparison.FullMatch),
+                        builder => builder.Name("key", RequiredAttributeNameComparison.FullMatch),
                         "keys",
                         "value",
                         false
                     },
                     {
                         builder => builder
-                            .Name("key")
-                            .NameComparison(RequiredAttributeNameComparison.FullMatch)
-                            .Value("value")
-                            .ValueComparison(RequiredAttributeValueComparison.FullMatch),
+                            .Name("key", RequiredAttributeNameComparison.FullMatch)
+                            .Value("value", RequiredAttributeValueComparison.FullMatch),
                         "key",
                         "value",
                         true
                     },
                     {
                         builder => builder
-                            .Name("key")
-                            .NameComparison(RequiredAttributeNameComparison.FullMatch)
-                            .Value("value")
-                            .ValueComparison(RequiredAttributeValueComparison.FullMatch),
+                            .Name("key", RequiredAttributeNameComparison.FullMatch)
+                            .Value("value", RequiredAttributeValueComparison.FullMatch),
                         "key",
                         "Value",
                         false
                     },
                     {
                         builder => builder
-                            .Name("class")
-                            .NameComparison(RequiredAttributeNameComparison.FullMatch)
-                            .Value("btn")
-                            .ValueComparison(RequiredAttributeValueComparison.PrefixMatch),
+                            .Name("class", RequiredAttributeNameComparison.FullMatch)
+                            .Value("btn", RequiredAttributeValueComparison.PrefixMatch),
                         "class",
                         "btn btn-success",
                         true
                     },
                     {
                         builder => builder
-                            .Name("class")
-                            .NameComparison(RequiredAttributeNameComparison.FullMatch)
-                            .Value("btn")
-                            .ValueComparison(RequiredAttributeValueComparison.PrefixMatch),
+                            .Name("class", RequiredAttributeNameComparison.FullMatch)
+                            .Value("btn", RequiredAttributeValueComparison.PrefixMatch),
                         "class",
                         "BTN btn-success",
                         false
                     },
                     {
                         builder => builder
-                            .Name("href")
-                            .NameComparison(RequiredAttributeNameComparison.FullMatch)
-                            .Value("#navigate")
-                            .ValueComparison(RequiredAttributeValueComparison.SuffixMatch),
+                            .Name("href", RequiredAttributeNameComparison.FullMatch)
+                            .Value("#navigate", RequiredAttributeValueComparison.SuffixMatch),
                         "href",
                         "/home/index#navigate",
                         true
                     },
                     {
                         builder => builder
-                            .Name("href")
-                            .NameComparison(RequiredAttributeNameComparison.FullMatch)
-                            .Value("#navigate")
-                            .ValueComparison(RequiredAttributeValueComparison.SuffixMatch),
+                            .Name("href", RequiredAttributeNameComparison.FullMatch)
+                            .Value("#navigate", RequiredAttributeValueComparison.SuffixMatch),
                         "href",
                         "/home/index#NAVigate",
                         false

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TagHelperMatchingConventionsTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TagHelperMatchingConventionsTest.cs
@@ -33,7 +33,7 @@ public class TagHelperMatchingConventionsTest
                     {
                         builder => builder
                             .Name("route-")
-                            .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch),
+                            .NameComparison(RequiredAttributeNameComparison.PrefixMatch),
                         "ROUTE-area",
                         "manage",
                         true
@@ -41,7 +41,7 @@ public class TagHelperMatchingConventionsTest
                     {
                         builder => builder
                             .Name("route-")
-                            .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch),
+                            .NameComparison(RequiredAttributeNameComparison.PrefixMatch),
                         "routearea",
                         "manage",
                         false
@@ -49,7 +49,7 @@ public class TagHelperMatchingConventionsTest
                     {
                         builder => builder
                             .Name("route-")
-                            .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch),
+                            .NameComparison(RequiredAttributeNameComparison.PrefixMatch),
                         "route-",
                         "manage",
                         false
@@ -57,7 +57,7 @@ public class TagHelperMatchingConventionsTest
                     {
                         builder => builder
                             .Name("key")
-                            .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch),
+                            .NameComparison(RequiredAttributeNameComparison.FullMatch),
                         "KeY",
                         "value",
                         true
@@ -65,7 +65,7 @@ public class TagHelperMatchingConventionsTest
                     {
                         builder => builder
                             .Name("key")
-                            .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch),
+                            .NameComparison(RequiredAttributeNameComparison.FullMatch),
                         "keys",
                         "value",
                         false
@@ -73,9 +73,9 @@ public class TagHelperMatchingConventionsTest
                     {
                         builder => builder
                             .Name("key")
-                            .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)
+                            .NameComparison(RequiredAttributeNameComparison.FullMatch)
                             .Value("value")
-                            .ValueComparisonMode(RequiredAttributeDescriptor.ValueComparisonMode.FullMatch),
+                            .ValueComparison(RequiredAttributeValueComparison.FullMatch),
                         "key",
                         "value",
                         true
@@ -83,9 +83,9 @@ public class TagHelperMatchingConventionsTest
                     {
                         builder => builder
                             .Name("key")
-                            .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)
+                            .NameComparison(RequiredAttributeNameComparison.FullMatch)
                             .Value("value")
-                            .ValueComparisonMode(RequiredAttributeDescriptor.ValueComparisonMode.FullMatch),
+                            .ValueComparison(RequiredAttributeValueComparison.FullMatch),
                         "key",
                         "Value",
                         false
@@ -93,9 +93,9 @@ public class TagHelperMatchingConventionsTest
                     {
                         builder => builder
                             .Name("class")
-                            .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)
+                            .NameComparison(RequiredAttributeNameComparison.FullMatch)
                             .Value("btn")
-                            .ValueComparisonMode(RequiredAttributeDescriptor.ValueComparisonMode.PrefixMatch),
+                            .ValueComparison(RequiredAttributeValueComparison.PrefixMatch),
                         "class",
                         "btn btn-success",
                         true
@@ -103,9 +103,9 @@ public class TagHelperMatchingConventionsTest
                     {
                         builder => builder
                             .Name("class")
-                            .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)
+                            .NameComparison(RequiredAttributeNameComparison.FullMatch)
                             .Value("btn")
-                            .ValueComparisonMode(RequiredAttributeDescriptor.ValueComparisonMode.PrefixMatch),
+                            .ValueComparison(RequiredAttributeValueComparison.PrefixMatch),
                         "class",
                         "BTN btn-success",
                         false
@@ -113,9 +113,9 @@ public class TagHelperMatchingConventionsTest
                     {
                         builder => builder
                             .Name("href")
-                            .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)
+                            .NameComparison(RequiredAttributeNameComparison.FullMatch)
                             .Value("#navigate")
-                            .ValueComparisonMode(RequiredAttributeDescriptor.ValueComparisonMode.SuffixMatch),
+                            .ValueComparison(RequiredAttributeValueComparison.SuffixMatch),
                         "href",
                         "/home/index#navigate",
                         true
@@ -123,9 +123,9 @@ public class TagHelperMatchingConventionsTest
                     {
                         builder => builder
                             .Name("href")
-                            .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)
+                            .NameComparison(RequiredAttributeNameComparison.FullMatch)
                             .Value("#navigate")
-                            .ValueComparisonMode(RequiredAttributeDescriptor.ValueComparisonMode.SuffixMatch),
+                            .ValueComparison(RequiredAttributeValueComparison.SuffixMatch),
                         "href",
                         "/home/index#NAVigate",
                         false

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/BindTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/BindTagHelperDescriptorProvider.cs
@@ -142,7 +142,7 @@ internal sealed class BindTagHelperDescriptorProvider() : TagHelperDescriptorPro
             rule.Attribute(attribute =>
             {
                 attribute.Name = "@bind-";
-                attribute.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch;
+                attribute.NameComparison = RequiredAttributeNameComparison.PrefixMatch;
                 attribute.SetMetadata(Attributes.IsDirectiveAttribute);
             });
         });
@@ -404,16 +404,16 @@ internal sealed class BindTagHelperDescriptorProvider() : TagHelperDescriptorPro
                     rule.Attribute(a =>
                     {
                         a.Name = "type";
-                        a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                        a.NameComparison = RequiredAttributeNameComparison.FullMatch;
                         a.Value = typeAttribute;
-                        a.ValueComparisonMode = RequiredAttributeDescriptor.ValueComparisonMode.FullMatch;
+                        a.ValueComparison = RequiredAttributeValueComparison.FullMatch;
                     });
                 }
 
                 rule.Attribute(a =>
                 {
                     a.Name = attributeName;
-                    a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                    a.NameComparison = RequiredAttributeNameComparison.FullMatch;
                     a.SetMetadata(Attributes.IsDirectiveAttribute);
                 });
             });
@@ -426,23 +426,23 @@ internal sealed class BindTagHelperDescriptorProvider() : TagHelperDescriptorPro
                     rule.Attribute(a =>
                     {
                         a.Name = "type";
-                        a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                        a.NameComparison = RequiredAttributeNameComparison.FullMatch;
                         a.Value = typeAttribute;
-                        a.ValueComparisonMode = RequiredAttributeDescriptor.ValueComparisonMode.FullMatch;
+                        a.ValueComparison = RequiredAttributeValueComparison.FullMatch;
                     });
                 }
 
                 rule.Attribute(a =>
                 {
                     a.Name = $"{attributeName}:get";
-                    a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                    a.NameComparison = RequiredAttributeNameComparison.FullMatch;
                     a.SetMetadata(Attributes.IsDirectiveAttribute);
                 });
 
                 rule.Attribute(a =>
                 {
                     a.Name = $"{attributeName}:set";
-                    a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                    a.NameComparison = RequiredAttributeNameComparison.FullMatch;
                     a.SetMetadata(Attributes.IsDirectiveAttribute);
                 });
             });
@@ -624,7 +624,7 @@ internal sealed class BindTagHelperDescriptorProvider() : TagHelperDescriptorPro
                     rule.Attribute(attribute =>
                     {
                         attribute.Name = "@bind-" + valueAttribute.Name;
-                        attribute.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                        attribute.NameComparison = RequiredAttributeNameComparison.FullMatch;
                         attribute.SetMetadata(Attributes.IsDirectiveAttribute);
                     });
                 });
@@ -635,13 +635,13 @@ internal sealed class BindTagHelperDescriptorProvider() : TagHelperDescriptorPro
                     rule.Attribute(attribute =>
                     {
                         attribute.Name = "@bind-" + valueAttribute.Name + ":get";
-                        attribute.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                        attribute.NameComparison = RequiredAttributeNameComparison.FullMatch;
                         attribute.SetMetadata(Attributes.IsDirectiveAttribute);
                     });
                     rule.Attribute(attribute =>
                     {
                         attribute.Name = "@bind-" + valueAttribute.Name + ":set";
-                        attribute.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                        attribute.NameComparison = RequiredAttributeNameComparison.FullMatch;
                         attribute.SetMetadata(Attributes.IsDirectiveAttribute);
                     });
                 });

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/BindTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/BindTagHelperDescriptorProvider.cs
@@ -143,7 +143,7 @@ internal sealed class BindTagHelperDescriptorProvider() : TagHelperDescriptorPro
             {
                 attribute.Name = "@bind-";
                 attribute.NameComparison = RequiredAttributeNameComparison.PrefixMatch;
-                attribute.SetMetadata(Attributes.IsDirectiveAttribute);
+                attribute.IsDirectiveAttribute = true;
             });
         });
 
@@ -414,7 +414,7 @@ internal sealed class BindTagHelperDescriptorProvider() : TagHelperDescriptorPro
                 {
                     a.Name = attributeName;
                     a.NameComparison = RequiredAttributeNameComparison.FullMatch;
-                    a.SetMetadata(Attributes.IsDirectiveAttribute);
+                    a.IsDirectiveAttribute = true;
                 });
             });
 
@@ -436,14 +436,14 @@ internal sealed class BindTagHelperDescriptorProvider() : TagHelperDescriptorPro
                 {
                     a.Name = $"{attributeName}:get";
                     a.NameComparison = RequiredAttributeNameComparison.FullMatch;
-                    a.SetMetadata(Attributes.IsDirectiveAttribute);
+                    a.IsDirectiveAttribute = true;
                 });
 
                 rule.Attribute(a =>
                 {
                     a.Name = $"{attributeName}:set";
                     a.NameComparison = RequiredAttributeNameComparison.FullMatch;
-                    a.SetMetadata(Attributes.IsDirectiveAttribute);
+                    a.IsDirectiveAttribute = true;
                 });
             });
 
@@ -625,7 +625,7 @@ internal sealed class BindTagHelperDescriptorProvider() : TagHelperDescriptorPro
                     {
                         attribute.Name = "@bind-" + valueAttribute.Name;
                         attribute.NameComparison = RequiredAttributeNameComparison.FullMatch;
-                        attribute.SetMetadata(Attributes.IsDirectiveAttribute);
+                        attribute.IsDirectiveAttribute = true;
                     });
                 });
 
@@ -636,13 +636,13 @@ internal sealed class BindTagHelperDescriptorProvider() : TagHelperDescriptorPro
                     {
                         attribute.Name = "@bind-" + valueAttribute.Name + ":get";
                         attribute.NameComparison = RequiredAttributeNameComparison.FullMatch;
-                        attribute.SetMetadata(Attributes.IsDirectiveAttribute);
+                        attribute.IsDirectiveAttribute = true;
                     });
                     rule.Attribute(attribute =>
                     {
                         attribute.Name = "@bind-" + valueAttribute.Name + ":set";
                         attribute.NameComparison = RequiredAttributeNameComparison.FullMatch;
-                        attribute.SetMetadata(Attributes.IsDirectiveAttribute);
+                        attribute.IsDirectiveAttribute = true;
                     });
                 });
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/EventHandlerTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/EventHandlerTagHelperDescriptorProvider.cs
@@ -181,7 +181,7 @@ internal sealed class EventHandlerTagHelperDescriptorProvider : TagHelperDescrip
                 {
                     a.Name = attributeName;
                     a.NameComparison = RequiredAttributeNameComparison.FullMatch;
-                    a.SetMetadata(Attributes.IsDirectiveAttribute);
+                    a.IsDirectiveAttribute = true;
                 });
             });
 
@@ -195,7 +195,7 @@ internal sealed class EventHandlerTagHelperDescriptorProvider : TagHelperDescrip
                     {
                         a.Name = attributeName + ":preventDefault";
                         a.NameComparison = RequiredAttributeNameComparison.FullMatch;
-                        a.SetMetadata(Attributes.IsDirectiveAttribute);
+                        a.IsDirectiveAttribute = true;
                     });
                 });
             }
@@ -210,7 +210,7 @@ internal sealed class EventHandlerTagHelperDescriptorProvider : TagHelperDescrip
                     {
                         a.Name = attributeName + ":stopPropagation";
                         a.NameComparison = RequiredAttributeNameComparison.FullMatch;
-                        a.SetMetadata(Attributes.IsDirectiveAttribute);
+                        a.IsDirectiveAttribute = true;
                     });
                 });
             }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/EventHandlerTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/EventHandlerTagHelperDescriptorProvider.cs
@@ -180,7 +180,7 @@ internal sealed class EventHandlerTagHelperDescriptorProvider : TagHelperDescrip
                 rule.Attribute(a =>
                 {
                     a.Name = attributeName;
-                    a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                    a.NameComparison = RequiredAttributeNameComparison.FullMatch;
                     a.SetMetadata(Attributes.IsDirectiveAttribute);
                 });
             });
@@ -194,7 +194,7 @@ internal sealed class EventHandlerTagHelperDescriptorProvider : TagHelperDescrip
                     rule.Attribute(a =>
                     {
                         a.Name = attributeName + ":preventDefault";
-                        a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                        a.NameComparison = RequiredAttributeNameComparison.FullMatch;
                         a.SetMetadata(Attributes.IsDirectiveAttribute);
                     });
                 });
@@ -209,7 +209,7 @@ internal sealed class EventHandlerTagHelperDescriptorProvider : TagHelperDescrip
                     rule.Attribute(a =>
                     {
                         a.Name = attributeName + ":stopPropagation";
-                        a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                        a.NameComparison = RequiredAttributeNameComparison.FullMatch;
                         a.SetMetadata(Attributes.IsDirectiveAttribute);
                     });
                 });

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/FormNameTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/FormNameTagHelperDescriptorProvider.cs
@@ -61,7 +61,7 @@ internal sealed class FormNameTagHelperDescriptorProvider() : TagHelperDescripto
             rule.Attribute(attribute =>
             {
                 attribute.Name = "@formname";
-                attribute.SetMetadata(Attributes.IsDirectiveAttribute);
+                attribute.IsDirectiveAttribute = true;
             });
         });
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/KeyTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/KeyTagHelperDescriptorProvider.cs
@@ -57,7 +57,7 @@ internal sealed class KeyTagHelperDescriptorProvider() : TagHelperDescriptorProv
             rule.Attribute(attribute =>
             {
                 attribute.Name = "@key";
-                attribute.SetMetadata(Attributes.IsDirectiveAttribute);
+                attribute.IsDirectiveAttribute = true;
             });
         });
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/RefTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/RefTagHelperDescriptorProvider.cs
@@ -57,7 +57,7 @@ internal sealed class RefTagHelperDescriptorProvider() : TagHelperDescriptorProv
             rule.Attribute(attribute =>
             {
                 attribute.Name = "@ref";
-                attribute.SetMetadata(Attributes.IsDirectiveAttribute);
+                attribute.IsDirectiveAttribute = true;
             });
         });
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/RenderModeTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/RenderModeTagHelperDescriptorProvider.cs
@@ -58,7 +58,7 @@ internal sealed class RenderModeTagHelperDescriptorProvider() : TagHelperDescrip
             rule.Attribute(attribute =>
             {
                 attribute.Name = "@rendermode";
-                attribute.SetMetadata(Attributes.IsDirectiveAttribute);
+                attribute.IsDirectiveAttribute = true;
             });
         });
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/RequiredAttributeParser.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/RequiredAttributeParser.cs
@@ -23,12 +23,12 @@ internal static class RequiredAttributeParser
     {
         private const char RequiredAttributeWildcardSuffix = '*';
 
-        private static readonly IReadOnlyDictionary<char, RequiredAttributeDescriptor.ValueComparisonMode> CssValueComparisons =
-            new Dictionary<char, RequiredAttributeDescriptor.ValueComparisonMode>
+        private static readonly IReadOnlyDictionary<char, RequiredAttributeValueComparison> CssValueComparisons =
+            new Dictionary<char, RequiredAttributeValueComparison>
             {
-                        { '=', RequiredAttributeDescriptor.ValueComparisonMode.FullMatch },
-                        { '^', RequiredAttributeDescriptor.ValueComparisonMode.PrefixMatch },
-                        { '$', RequiredAttributeDescriptor.ValueComparisonMode.SuffixMatch }
+                        { '=', RequiredAttributeValueComparison.FullMatch },
+                        { '^', RequiredAttributeValueComparison.PrefixMatch },
+                        { '$', RequiredAttributeValueComparison.SuffixMatch }
             };
         private static readonly char[] InvalidPlainAttributeNameCharacters = { ' ', '\t', ',', RequiredAttributeWildcardSuffix };
         private static readonly char[] InvalidCssAttributeNameCharacters = (new[] { ' ', '\t', ',', ']' })
@@ -112,7 +112,7 @@ internal static class RequiredAttributeParser
             var nameEndIndex = _requiredAttributes.IndexOfAny(InvalidPlainAttributeNameCharacters, _index);
             string attributeName;
 
-            var nameComparison = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+            var nameComparison = RequiredAttributeNameComparison.FullMatch;
             if (nameEndIndex == -1)
             {
                 attributeName = _requiredAttributes.Substring(_index);
@@ -125,7 +125,7 @@ internal static class RequiredAttributeParser
 
                 if (_requiredAttributes[nameEndIndex] == RequiredAttributeWildcardSuffix)
                 {
-                    nameComparison = RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch;
+                    nameComparison = RequiredAttributeNameComparison.PrefixMatch;
 
                     // Move past wild card
                     _index++;
@@ -133,7 +133,7 @@ internal static class RequiredAttributeParser
             }
 
             attributeBuilder.Name = attributeName;
-            attributeBuilder.NameComparisonMode = nameComparison;
+            attributeBuilder.NameComparison = nameComparison;
         }
 
         private void ParseCssAttributeName(RequiredAttributeDescriptorBuilder builder)
@@ -148,7 +148,7 @@ internal static class RequiredAttributeParser
             builder.Name = attributeName;
         }
 
-        private bool TryParseCssValueComparison(RequiredAttributeDescriptorBuilder builder, out RequiredAttributeDescriptor.ValueComparisonMode valueComparison)
+        private bool TryParseCssValueComparison(RequiredAttributeDescriptorBuilder builder, out RequiredAttributeValueComparison valueComparison)
         {
             Debug.Assert(!AtEnd);
 
@@ -178,7 +178,7 @@ internal static class RequiredAttributeParser
                 return false;
             }
 
-            builder.ValueComparisonMode = valueComparison;
+            builder.ValueComparison = valueComparison;
 
             return true;
         }
@@ -237,7 +237,7 @@ internal static class RequiredAttributeParser
                 return false;
             }
 
-            if (!TryParseCssValueComparison(attributeBuilder, out RequiredAttributeDescriptor.ValueComparisonMode valueComparison))
+            if (!TryParseCssValueComparison(attributeBuilder, out RequiredAttributeValueComparison valueComparison))
             {
                 return false;
             }
@@ -249,7 +249,7 @@ internal static class RequiredAttributeParser
                 return false;
             }
 
-            if (valueComparison != RequiredAttributeDescriptor.ValueComparisonMode.None && !TryParseCssValue(attributeBuilder))
+            if (valueComparison != RequiredAttributeValueComparison.None && !TryParseCssValue(attributeBuilder))
             {
                 return false;
             }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/SplatTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/SplatTagHelperDescriptorProvider.cs
@@ -56,7 +56,7 @@ internal sealed class SplatTagHelperDescriptorProvider : TagHelperDescriptorProv
             rule.Attribute(attribute =>
             {
                 attribute.Name = "@attributes";
-                attribute.SetMetadata(Attributes.IsDirectiveAttribute);
+                attribute.IsDirectiveAttribute = true;
             });
         });
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CommonMetadata.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CommonMetadata.cs
@@ -32,11 +32,6 @@ public static class CommonMetadata
     internal static KeyValuePair<string, string?> TypeNameIdentifier(string value)
         => new(TagHelperMetadata.Common.TypeNameIdentifier, value);
 
-    internal static class Attributes
-    {
-        public static readonly MetadataCollection IsDirectiveAttribute = MetadataCollection.Create(CommonMetadata.IsDirectiveAttribute);
-    }
-
     internal static class Parameters
     {
         public static readonly MetadataCollection After = MetadataCollection.Create(PropertyName("After"));

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeDescriptor.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeDescriptor.cs
@@ -24,16 +24,13 @@ public sealed class RequiredAttributeDescriptor : TagHelperObject<RequiredAttrib
     public bool CaseSensitive => _flags.IsFlagSet(RequiredAttributeDescriptorFlags.CaseSensitive);
     public bool IsDirectiveAttribute => _flags.IsFlagSet(RequiredAttributeDescriptorFlags.IsDirectiveAttribute);
 
-    public MetadataCollection Metadata { get; }
-
     internal RequiredAttributeDescriptor(
         RequiredAttributeDescriptorFlags flags,
         string name,
         RequiredAttributeNameComparison nameComparison,
         string? value,
         RequiredAttributeValueComparison valueComparison,
-        ImmutableArray<RazorDiagnostic> diagnostics,
-        MetadataCollection metadata)
+        ImmutableArray<RazorDiagnostic> diagnostics)
         : base(diagnostics)
     {
         _flags = flags;
@@ -41,7 +38,6 @@ public sealed class RequiredAttributeDescriptor : TagHelperObject<RequiredAttrib
         NameComparison = nameComparison;
         Value = value;
         ValueComparison = valueComparison;
-        Metadata = metadata ?? MetadataCollection.Empty;
     }
 
     private protected override void BuildChecksum(in Checksum.Builder builder)
@@ -51,7 +47,6 @@ public sealed class RequiredAttributeDescriptor : TagHelperObject<RequiredAttrib
         builder.AppendData((int)NameComparison);
         builder.AppendData(Value);
         builder.AppendData((int)ValueComparison);
-        builder.AppendData(Metadata.Checksum);
     }
 
     public TagMatchingRuleDescriptor Parent

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeDescriptor.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeDescriptor.cs
@@ -11,6 +11,7 @@ public sealed class RequiredAttributeDescriptor : TagHelperObject<RequiredAttrib
 {
     private readonly RequiredAttributeDescriptorFlags _flags;
     private TagMatchingRuleDescriptor? _parent;
+    private string? _displayName;
 
     internal RequiredAttributeDescriptorFlags Flags => _flags;
 
@@ -18,7 +19,7 @@ public sealed class RequiredAttributeDescriptor : TagHelperObject<RequiredAttrib
     public RequiredAttributeNameComparison NameComparison { get; }
     public string? Value { get; }
     public RequiredAttributeValueComparison ValueComparison { get; }
-    public string DisplayName { get; }
+    public string DisplayName => _displayName ??= GetDisplayName(Name, NameComparison);
 
     public bool CaseSensitive => _flags.IsFlagSet(RequiredAttributeDescriptorFlags.CaseSensitive);
     public bool IsDirectiveAttribute => _flags.IsFlagSet(RequiredAttributeDescriptorFlags.IsDirectiveAttribute);
@@ -31,7 +32,6 @@ public sealed class RequiredAttributeDescriptor : TagHelperObject<RequiredAttrib
         RequiredAttributeNameComparison nameComparison,
         string? value,
         RequiredAttributeValueComparison valueComparison,
-        string displayName,
         ImmutableArray<RazorDiagnostic> diagnostics,
         MetadataCollection metadata)
         : base(diagnostics)
@@ -41,7 +41,6 @@ public sealed class RequiredAttributeDescriptor : TagHelperObject<RequiredAttrib
         NameComparison = nameComparison;
         Value = value;
         ValueComparison = valueComparison;
-        DisplayName = displayName;
         Metadata = metadata ?? MetadataCollection.Empty;
     }
 
@@ -52,7 +51,6 @@ public sealed class RequiredAttributeDescriptor : TagHelperObject<RequiredAttrib
         builder.AppendData((int)NameComparison);
         builder.AppendData(Value);
         builder.AppendData((int)ValueComparison);
-        builder.AppendData(DisplayName);
         builder.AppendData(Metadata.Checksum);
     }
 
@@ -69,6 +67,11 @@ public sealed class RequiredAttributeDescriptor : TagHelperObject<RequiredAttrib
 
     public override string ToString()
     {
-        return DisplayName ?? base.ToString()!;
+        return DisplayName;
     }
+
+    internal static string GetDisplayName(string name, RequiredAttributeNameComparison nameComparison)
+        => nameComparison == RequiredAttributeNameComparison.PrefixMatch
+        ? name + "..."
+        : name;
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeDescriptor.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeDescriptor.cs
@@ -12,9 +12,9 @@ public sealed class RequiredAttributeDescriptor : TagHelperObject<RequiredAttrib
     private TagMatchingRuleDescriptor? _parent;
 
     public string Name { get; }
-    public NameComparisonMode NameComparison { get; }
+    public RequiredAttributeNameComparison NameComparison { get; }
     public string? Value { get; }
-    public ValueComparisonMode ValueComparison { get; }
+    public RequiredAttributeValueComparison ValueComparison { get; }
     public string DisplayName { get; }
     public bool CaseSensitive { get; }
 
@@ -22,10 +22,10 @@ public sealed class RequiredAttributeDescriptor : TagHelperObject<RequiredAttrib
 
     internal RequiredAttributeDescriptor(
         string name,
-        NameComparisonMode nameComparison,
+        RequiredAttributeNameComparison nameComparison,
         bool caseSensitive,
         string? value,
-        ValueComparisonMode valueComparison,
+        RequiredAttributeValueComparison valueComparison,
         string displayName,
         ImmutableArray<RazorDiagnostic> diagnostics,
         MetadataCollection metadata)
@@ -65,47 +65,5 @@ public sealed class RequiredAttributeDescriptor : TagHelperObject<RequiredAttrib
     public override string ToString()
     {
         return DisplayName ?? base.ToString()!;
-    }
-
-    /// <summary>
-    /// Acceptable <see cref="Name"/> comparison modes.
-    /// </summary>
-    public enum NameComparisonMode
-    {
-        /// <summary>
-        /// HTML attribute name case insensitively matches <see cref="Name"/>.
-        /// </summary>
-        FullMatch,
-
-        /// <summary>
-        /// HTML attribute name case insensitively starts with <see cref="Name"/>.
-        /// </summary>
-        PrefixMatch,
-    }
-
-    /// <summary>
-    /// Acceptable <see cref="Value"/> comparison modes.
-    /// </summary>
-    public enum ValueComparisonMode
-    {
-        /// <summary>
-        /// HTML attribute value always matches <see cref="Value"/>.
-        /// </summary>
-        None,
-
-        /// <summary>
-        /// HTML attribute value case sensitively matches <see cref="Value"/>.
-        /// </summary>
-        FullMatch,
-
-        /// <summary>
-        /// HTML attribute value case sensitively starts with <see cref="Value"/>.
-        /// </summary>
-        PrefixMatch,
-
-        /// <summary>
-        /// HTML attribute value case sensitively ends with <see cref="Value"/>.
-        /// </summary>
-        SuffixMatch,
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeDescriptor.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeDescriptor.cs
@@ -9,21 +9,26 @@ namespace Microsoft.AspNetCore.Razor.Language;
 
 public sealed class RequiredAttributeDescriptor : TagHelperObject<RequiredAttributeDescriptor>
 {
+    private readonly RequiredAttributeDescriptorFlags _flags;
     private TagMatchingRuleDescriptor? _parent;
+
+    internal RequiredAttributeDescriptorFlags Flags => _flags;
 
     public string Name { get; }
     public RequiredAttributeNameComparison NameComparison { get; }
     public string? Value { get; }
     public RequiredAttributeValueComparison ValueComparison { get; }
     public string DisplayName { get; }
-    public bool CaseSensitive { get; }
+
+    public bool CaseSensitive => _flags.IsFlagSet(RequiredAttributeDescriptorFlags.CaseSensitive);
+    public bool IsDirectiveAttribute => _flags.IsFlagSet(RequiredAttributeDescriptorFlags.IsDirectiveAttribute);
 
     public MetadataCollection Metadata { get; }
 
     internal RequiredAttributeDescriptor(
+        RequiredAttributeDescriptorFlags flags,
         string name,
         RequiredAttributeNameComparison nameComparison,
-        bool caseSensitive,
         string? value,
         RequiredAttributeValueComparison valueComparison,
         string displayName,
@@ -31,9 +36,9 @@ public sealed class RequiredAttributeDescriptor : TagHelperObject<RequiredAttrib
         MetadataCollection metadata)
         : base(diagnostics)
     {
+        _flags = flags;
         Name = name;
         NameComparison = nameComparison;
-        CaseSensitive = caseSensitive;
         Value = value;
         ValueComparison = valueComparison;
         DisplayName = displayName;
@@ -42,12 +47,12 @@ public sealed class RequiredAttributeDescriptor : TagHelperObject<RequiredAttrib
 
     private protected override void BuildChecksum(in Checksum.Builder builder)
     {
+        builder.AppendData((int)Flags);
         builder.AppendData(Name);
         builder.AppendData((int)NameComparison);
         builder.AppendData(Value);
         builder.AppendData((int)ValueComparison);
         builder.AppendData(DisplayName);
-        builder.AppendData(CaseSensitive);
         builder.AppendData(Metadata.Checksum);
     }
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeDescriptorBuilder.cs
@@ -7,7 +7,6 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.PooledObjects;
-using static Microsoft.AspNetCore.Razor.Language.RequiredAttributeDescriptor;
 
 namespace Microsoft.AspNetCore.Razor.Language;
 
@@ -27,9 +26,9 @@ public sealed partial class RequiredAttributeDescriptorBuilder : TagHelperObject
     }
 
     public string? Name { get; set; }
-    public NameComparisonMode NameComparisonMode { get; set; }
+    public RequiredAttributeNameComparison NameComparison { get; set; }
     public string? Value { get; set; }
-    public ValueComparisonMode ValueComparisonMode { get; set; }
+    public RequiredAttributeValueComparison ValueComparison { get; set; }
 
     internal bool CaseSensitive => _parent.CaseSensitive;
 
@@ -47,10 +46,10 @@ public sealed partial class RequiredAttributeDescriptorBuilder : TagHelperObject
 
         return new RequiredAttributeDescriptor(
             Name ?? string.Empty,
-            NameComparisonMode,
+            NameComparison,
             CaseSensitive,
             Value,
-            ValueComparisonMode,
+            ValueComparison,
             displayName,
             diagnostics,
             metadata);
@@ -58,7 +57,7 @@ public sealed partial class RequiredAttributeDescriptorBuilder : TagHelperObject
 
     private string GetDisplayName()
     {
-        return (NameComparisonMode == NameComparisonMode.PrefixMatch ? string.Concat(Name, "...") : Name) ?? string.Empty;
+        return (NameComparison == RequiredAttributeNameComparison.PrefixMatch ? string.Concat(Name, "...") : Name) ?? string.Empty;
     }
 
     private bool IsDirectiveAttribute()

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeDescriptorBuilder.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -15,7 +14,6 @@ public sealed partial class RequiredAttributeDescriptorBuilder : TagHelperObject
     [AllowNull]
     private TagMatchingRuleDescriptorBuilder _parent;
     private RequiredAttributeDescriptorFlags _flags;
-    private MetadataHolder _metadata;
 
     private RequiredAttributeDescriptorBuilder()
     {
@@ -39,14 +37,8 @@ public sealed partial class RequiredAttributeDescriptorBuilder : TagHelperObject
         set => _flags.UpdateFlag(RequiredAttributeDescriptorFlags.IsDirectiveAttribute, value);
     }
 
-    public IDictionary<string, string?> Metadata => _metadata.MetadataDictionary;
-
-    public void SetMetadata(MetadataCollection metadata) => _metadata.SetMetadataCollection(metadata);
-
     private protected override RequiredAttributeDescriptor BuildCore(ImmutableArray<RazorDiagnostic> diagnostics)
     {
-        var metadata = _metadata.GetMetadataCollection();
-
         var flags = _flags;
 
         if (CaseSensitive)
@@ -60,8 +52,7 @@ public sealed partial class RequiredAttributeDescriptorBuilder : TagHelperObject
             NameComparison,
             Value,
             ValueComparison,
-            diagnostics,
-            metadata);
+            diagnostics);
     }
 
     private protected override void CollectDiagnostics(ref PooledHashSet<RazorDiagnostic> diagnostics)

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeDescriptorBuilder.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 
 namespace Microsoft.AspNetCore.Razor.Language;
@@ -14,6 +13,7 @@ public sealed partial class RequiredAttributeDescriptorBuilder : TagHelperObject
 {
     [AllowNull]
     private TagMatchingRuleDescriptorBuilder _parent;
+    private RequiredAttributeDescriptorFlags _flags;
     private MetadataHolder _metadata;
 
     private RequiredAttributeDescriptorBuilder()
@@ -32,22 +32,32 @@ public sealed partial class RequiredAttributeDescriptorBuilder : TagHelperObject
 
     internal bool CaseSensitive => _parent.CaseSensitive;
 
+    public bool IsDirectiveAttribute
+    {
+        get => _flags.IsFlagSet(RequiredAttributeDescriptorFlags.IsDirectiveAttribute);
+        set => _flags.UpdateFlag(RequiredAttributeDescriptorFlags.IsDirectiveAttribute, value);
+    }
+
     public IDictionary<string, string?> Metadata => _metadata.MetadataDictionary;
 
     public void SetMetadata(MetadataCollection metadata) => _metadata.SetMetadataCollection(metadata);
-
-    public bool TryGetMetadataValue(string key, [NotNullWhen(true)] out string? value)
-        => _metadata.TryGetMetadataValue(key, out value);
 
     private protected override RequiredAttributeDescriptor BuildCore(ImmutableArray<RazorDiagnostic> diagnostics)
     {
         var displayName = GetDisplayName();
         var metadata = _metadata.GetMetadataCollection();
 
+        var flags = _flags;
+
+        if (CaseSensitive)
+        {
+            flags |= RequiredAttributeDescriptorFlags.CaseSensitive;
+        }
+
         return new RequiredAttributeDescriptor(
+            flags,
             Name ?? string.Empty,
             NameComparison,
-            CaseSensitive,
             Value,
             ValueComparison,
             displayName,
@@ -60,10 +70,6 @@ public sealed partial class RequiredAttributeDescriptorBuilder : TagHelperObject
         return (NameComparison == RequiredAttributeNameComparison.PrefixMatch ? string.Concat(Name, "...") : Name) ?? string.Empty;
     }
 
-    private bool IsDirectiveAttribute()
-        => TryGetMetadataValue(ComponentMetadata.Common.DirectiveAttribute, out var value) &&
-           value == bool.TrueString;
-
     private protected override void CollectDiagnostics(ref PooledHashSet<RazorDiagnostic> diagnostics)
     {
         if (Name.IsNullOrWhiteSpace())
@@ -75,7 +81,7 @@ public sealed partial class RequiredAttributeDescriptorBuilder : TagHelperObject
         else
         {
             var name = Name.AsSpan();
-            var isDirectiveAttribute = IsDirectiveAttribute();
+            var isDirectiveAttribute = IsDirectiveAttribute;
             if (isDirectiveAttribute && name[0] == '@')
             {
                 name = name[1..];

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeDescriptorBuilder_Pooling.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeDescriptorBuilder_Pooling.cs
@@ -28,8 +28,6 @@ public partial class RequiredAttributeDescriptorBuilder
         NameComparison = default;
         Value = null;
         ValueComparison = default;
-
-        _metadata.Clear();
     }
 
     private sealed class Policy : PooledBuilderPolicy<RequiredAttributeDescriptorBuilder>

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeDescriptorBuilder_Pooling.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeDescriptorBuilder_Pooling.cs
@@ -24,9 +24,9 @@ public partial class RequiredAttributeDescriptorBuilder
         _parent = null;
 
         Name = null;
-        NameComparisonMode = default;
+        NameComparison = default;
         Value = null;
-        ValueComparisonMode = default;
+        ValueComparison = default;
 
         _metadata.Clear();
     }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeDescriptorBuilder_Pooling.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeDescriptorBuilder_Pooling.cs
@@ -22,6 +22,7 @@ public partial class RequiredAttributeDescriptorBuilder
     private protected override void Reset()
     {
         _parent = null;
+        _flags = 0;
 
         Name = null;
         NameComparison = default;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeDescriptorFlags.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeDescriptorFlags.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.AspNetCore.Razor.Language;
+
+[Flags]
+internal enum RequiredAttributeDescriptorFlags
+{
+    None = 0,
+    CaseSensitive = 1 << 0,
+    IsDirectiveAttribute = 1 << 1
+}

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeNameComparison.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeNameComparison.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Razor.Language;
+
+/// <summary>
+/// Acceptable <see cref="RequiredAttributeDescriptor.NameComparison"/> comparison values.
+/// </summary>
+public enum RequiredAttributeNameComparison
+{
+    /// <summary>
+    /// HTML attribute name case insensitively matches <see cref="RequiredAttributeDescriptor.Name"/>.
+    /// </summary>
+    FullMatch,
+
+    /// <summary>
+    /// HTML attribute name case insensitively starts with <see cref="RequiredAttributeDescriptor.Name"/>.
+    /// </summary>
+    PrefixMatch
+}

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeValueComparison.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RequiredAttributeValueComparison.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Razor.Language;
+
+/// <summary>
+/// Acceptable <see cref="RequiredAttributeDescriptor.ValueComparison"/> values.
+/// </summary>
+public enum RequiredAttributeValueComparison
+{
+    /// <summary>
+    /// HTML attribute value always matches <see cref="RequiredAttributeDescriptor.Value"/>.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// HTML attribute value case sensitively matches <see cref="RequiredAttributeDescriptor.Value"/>.
+    /// </summary>
+    FullMatch,
+
+    /// <summary>
+    /// HTML attribute value case sensitively starts with <see cref="RequiredAttributeDescriptor.Value"/>.
+    /// </summary>
+    PrefixMatch,
+
+    /// <summary>
+    /// HTML attribute value case sensitively ends with <see cref="RequiredAttributeDescriptor.Value"/>.
+    /// </summary>
+    SuffixMatch
+}

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperMatchingConventions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperMatchingConventions.cs
@@ -235,11 +235,11 @@ internal static class TagHelperMatchingConventions
         string attributeValue)
     {
         var nameMatches = false;
-        if (descriptor.NameComparison == RequiredAttributeDescriptor.NameComparisonMode.FullMatch)
+        if (descriptor.NameComparison == RequiredAttributeNameComparison.FullMatch)
         {
             nameMatches = string.Equals(descriptor.Name, attributeName, descriptor.GetComparison());
         }
-        else if (descriptor.NameComparison == RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch)
+        else if (descriptor.NameComparison == RequiredAttributeNameComparison.PrefixMatch)
         {
             // attributeName cannot equal the Name if comparing as a PrefixMatch.
             nameMatches = attributeName.Length != descriptor.Name.Length &&
@@ -257,13 +257,13 @@ internal static class TagHelperMatchingConventions
 
         switch (descriptor.ValueComparison)
         {
-            case RequiredAttributeDescriptor.ValueComparisonMode.None:
+            case RequiredAttributeValueComparison.None:
                 return true;
-            case RequiredAttributeDescriptor.ValueComparisonMode.PrefixMatch: // Value starts with
+            case RequiredAttributeValueComparison.PrefixMatch: // Value starts with
                 return attributeValue.StartsWith(descriptor.Value.AssumeNotNull(), StringComparison.Ordinal);
-            case RequiredAttributeDescriptor.ValueComparisonMode.SuffixMatch: // Value ends with
+            case RequiredAttributeValueComparison.SuffixMatch: // Value ends with
                 return attributeValue.EndsWith(descriptor.Value.AssumeNotNull(), StringComparison.Ordinal);
-            case RequiredAttributeDescriptor.ValueComparisonMode.FullMatch: // Value equals
+            case RequiredAttributeValueComparison.FullMatch: // Value equals
                 return string.Equals(attributeValue, descriptor.Value, StringComparison.Ordinal);
             default:
                 Debug.Assert(false, "Unknown value comparison.");

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagMatchingRuleDescriptor.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagMatchingRuleDescriptor.cs
@@ -93,15 +93,15 @@ public sealed class TagMatchingRuleDescriptor : TagHelperObject<TagMatchingRuleD
             var name = attribute.Name switch
             {
                 null => "*",
-                var prefix when attribute.NameComparison == RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch => $"^{prefix}",
+                var prefix when attribute.NameComparison == RequiredAttributeNameComparison.PrefixMatch => $"^{prefix}",
                 var full => full,
             };
 
             var value = attribute.Value switch
             {
                 null => "",
-                var prefix when attribute.ValueComparison == RequiredAttributeDescriptor.ValueComparisonMode.PrefixMatch => $"^={prefix}",
-                var suffix when attribute.ValueComparison == RequiredAttributeDescriptor.ValueComparisonMode.SuffixMatch => $"$={suffix}",
+                var prefix when attribute.ValueComparison == RequiredAttributeValueComparison.PrefixMatch => $"^={prefix}",
+                var suffix when attribute.ValueComparison == RequiredAttributeValueComparison.SuffixMatch => $"$={suffix}",
                 var full => $"={full}",
             };
             return name + value;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/test/BindTagHelperDescriptorProviderTest.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/test/BindTagHelperDescriptorProviderTest.cs
@@ -108,9 +108,9 @@ namespace Test
                 Assert.Empty(requiredAttribute.Diagnostics);
                 Assert.Equal("@bind-MyProperty", requiredAttribute.DisplayName);
                 Assert.Equal("@bind-MyProperty", requiredAttribute.Name);
-                Assert.Equal(RequiredAttributeDescriptor.NameComparisonMode.FullMatch, requiredAttribute.NameComparison);
+                Assert.Equal(RequiredAttributeNameComparison.FullMatch, requiredAttribute.NameComparison);
                 Assert.Null(requiredAttribute.Value);
-                Assert.Equal(RequiredAttributeDescriptor.ValueComparisonMode.None, requiredAttribute.ValueComparison);
+                Assert.Equal(RequiredAttributeValueComparison.None, requiredAttribute.ValueComparison);
             },
             rule =>
             {
@@ -126,18 +126,18 @@ namespace Test
                         Assert.Empty(requiredAttribute.Diagnostics);
                         Assert.Equal("@bind-MyProperty:get", requiredAttribute.DisplayName);
                         Assert.Equal("@bind-MyProperty:get", requiredAttribute.Name);
-                        Assert.Equal(RequiredAttributeDescriptor.NameComparisonMode.FullMatch, requiredAttribute.NameComparison);
+                        Assert.Equal(RequiredAttributeNameComparison.FullMatch, requiredAttribute.NameComparison);
                         Assert.Null(requiredAttribute.Value);
-                        Assert.Equal(RequiredAttributeDescriptor.ValueComparisonMode.None, requiredAttribute.ValueComparison);
+                        Assert.Equal(RequiredAttributeValueComparison.None, requiredAttribute.ValueComparison);
                     },
                     requiredAttribute =>
                     {
                         Assert.Empty(requiredAttribute.Diagnostics);
                         Assert.Equal("@bind-MyProperty:set", requiredAttribute.DisplayName);
                         Assert.Equal("@bind-MyProperty:set", requiredAttribute.Name);
-                        Assert.Equal(RequiredAttributeDescriptor.NameComparisonMode.FullMatch, requiredAttribute.NameComparison);
+                        Assert.Equal(RequiredAttributeNameComparison.FullMatch, requiredAttribute.NameComparison);
                         Assert.Null(requiredAttribute.Value);
-                        Assert.Equal(RequiredAttributeDescriptor.ValueComparisonMode.None, requiredAttribute.ValueComparison);
+                        Assert.Equal(RequiredAttributeValueComparison.None, requiredAttribute.ValueComparison);
                     });
             });
 
@@ -332,9 +332,9 @@ namespace Test
                 Assert.Empty(requiredAttribute.Diagnostics);
                 Assert.Equal("@bind-MyProperty", requiredAttribute.DisplayName);
                 Assert.Equal("@bind-MyProperty", requiredAttribute.Name);
-                Assert.Equal(RequiredAttributeDescriptor.NameComparisonMode.FullMatch, requiredAttribute.NameComparison);
+                Assert.Equal(RequiredAttributeNameComparison.FullMatch, requiredAttribute.NameComparison);
                 Assert.Null(requiredAttribute.Value);
-                Assert.Equal(RequiredAttributeDescriptor.ValueComparisonMode.None, requiredAttribute.ValueComparison);
+                Assert.Equal(RequiredAttributeValueComparison.None, requiredAttribute.ValueComparison);
             },
             rule =>
             {
@@ -350,18 +350,18 @@ namespace Test
                         Assert.Empty(requiredAttribute.Diagnostics);
                         Assert.Equal("@bind-MyProperty:get", requiredAttribute.DisplayName);
                         Assert.Equal("@bind-MyProperty:get", requiredAttribute.Name);
-                        Assert.Equal(RequiredAttributeDescriptor.NameComparisonMode.FullMatch, requiredAttribute.NameComparison);
+                        Assert.Equal(RequiredAttributeNameComparison.FullMatch, requiredAttribute.NameComparison);
                         Assert.Null(requiredAttribute.Value);
-                        Assert.Equal(RequiredAttributeDescriptor.ValueComparisonMode.None, requiredAttribute.ValueComparison);
+                        Assert.Equal(RequiredAttributeValueComparison.None, requiredAttribute.ValueComparison);
                     },
                     requiredAttribute =>
                     {
                         Assert.Empty(requiredAttribute.Diagnostics);
                         Assert.Equal("@bind-MyProperty:set", requiredAttribute.DisplayName);
                         Assert.Equal("@bind-MyProperty:set", requiredAttribute.Name);
-                        Assert.Equal(RequiredAttributeDescriptor.NameComparisonMode.FullMatch, requiredAttribute.NameComparison);
+                        Assert.Equal(RequiredAttributeNameComparison.FullMatch, requiredAttribute.NameComparison);
                         Assert.Null(requiredAttribute.Value);
-                        Assert.Equal(RequiredAttributeDescriptor.ValueComparisonMode.None, requiredAttribute.ValueComparison);
+                        Assert.Equal(RequiredAttributeValueComparison.None, requiredAttribute.ValueComparison);
                     });
             });
 
@@ -516,9 +516,9 @@ namespace Test
                 Assert.Empty(requiredAttribute.Diagnostics);
                 Assert.Equal("@bind", requiredAttribute.DisplayName);
                 Assert.Equal("@bind", requiredAttribute.Name);
-                Assert.Equal(RequiredAttributeDescriptor.NameComparisonMode.FullMatch, requiredAttribute.NameComparison);
+                Assert.Equal(RequiredAttributeNameComparison.FullMatch, requiredAttribute.NameComparison);
                 Assert.Null(requiredAttribute.Value);
-                Assert.Equal(RequiredAttributeDescriptor.ValueComparisonMode.None, requiredAttribute.ValueComparison);
+                Assert.Equal(RequiredAttributeValueComparison.None, requiredAttribute.ValueComparison);
 
                 var attribute = Assert.Single(bind.BoundAttributes, a => a.Name.StartsWith("@bind", StringComparison.Ordinal));
                 AssertAttribute(attribute);
@@ -537,9 +537,9 @@ namespace Test
                         Assert.Empty(requiredAttribute.Diagnostics);
                         Assert.Equal("@bind:get", requiredAttribute.DisplayName);
                         Assert.Equal("@bind:get", requiredAttribute.Name);
-                        Assert.Equal(RequiredAttributeDescriptor.NameComparisonMode.FullMatch, requiredAttribute.NameComparison);
+                        Assert.Equal(RequiredAttributeNameComparison.FullMatch, requiredAttribute.NameComparison);
                         Assert.Null(requiredAttribute.Value);
-                        Assert.Equal(RequiredAttributeDescriptor.ValueComparisonMode.None, requiredAttribute.ValueComparison);
+                        Assert.Equal(RequiredAttributeValueComparison.None, requiredAttribute.ValueComparison);
 
                         var attribute = Assert.Single(bind.BoundAttributes, a => a.Name.StartsWith("@bind", StringComparison.Ordinal));
                         AssertAttribute(attribute);
@@ -549,9 +549,9 @@ namespace Test
                         Assert.Empty(requiredAttribute.Diagnostics);
                         Assert.Equal("@bind:set", requiredAttribute.DisplayName);
                         Assert.Equal("@bind:set", requiredAttribute.Name);
-                        Assert.Equal(RequiredAttributeDescriptor.NameComparisonMode.FullMatch, requiredAttribute.NameComparison);
+                        Assert.Equal(RequiredAttributeNameComparison.FullMatch, requiredAttribute.NameComparison);
                         Assert.Null(requiredAttribute.Value);
-                        Assert.Equal(RequiredAttributeDescriptor.ValueComparisonMode.None, requiredAttribute.ValueComparison);
+                        Assert.Equal(RequiredAttributeValueComparison.None, requiredAttribute.ValueComparison);
 
                         var attribute = Assert.Single(bind.BoundAttributes, a => a.Name.StartsWith("@bind", StringComparison.Ordinal));
                         AssertAttribute(attribute);
@@ -903,9 +903,9 @@ namespace Test
                     {
                         Assert.Equal("type", a.DisplayName);
                         Assert.Equal("type", a.Name);
-                        Assert.Equal(RequiredAttributeDescriptor.NameComparisonMode.FullMatch, a.NameComparison);
+                        Assert.Equal(RequiredAttributeNameComparison.FullMatch, a.NameComparison);
                         Assert.Equal("checkbox", a.Value);
-                        Assert.Equal(RequiredAttributeDescriptor.ValueComparisonMode.FullMatch, a.ValueComparison);
+                        Assert.Equal(RequiredAttributeValueComparison.FullMatch, a.ValueComparison);
                     },
                     a =>
                     {
@@ -924,9 +924,9 @@ namespace Test
                     {
                         Assert.Equal("type", a.DisplayName);
                         Assert.Equal("type", a.Name);
-                        Assert.Equal(RequiredAttributeDescriptor.NameComparisonMode.FullMatch, a.NameComparison);
+                        Assert.Equal(RequiredAttributeNameComparison.FullMatch, a.NameComparison);
                         Assert.Equal("checkbox", a.Value);
-                        Assert.Equal(RequiredAttributeDescriptor.ValueComparisonMode.FullMatch, a.ValueComparison);
+                        Assert.Equal(RequiredAttributeValueComparison.FullMatch, a.ValueComparison);
                     },
                     a =>
                     {
@@ -1000,9 +1000,9 @@ namespace Test
                     {
                         Assert.Equal("type", a.DisplayName);
                         Assert.Equal("type", a.Name);
-                        Assert.Equal(RequiredAttributeDescriptor.NameComparisonMode.FullMatch, a.NameComparison);
+                        Assert.Equal(RequiredAttributeNameComparison.FullMatch, a.NameComparison);
                         Assert.Equal("checkbox", a.Value);
-                        Assert.Equal(RequiredAttributeDescriptor.ValueComparisonMode.FullMatch, a.ValueComparison);
+                        Assert.Equal(RequiredAttributeValueComparison.FullMatch, a.ValueComparison);
                     },
                     a =>
                     {
@@ -1021,9 +1021,9 @@ namespace Test
                     {
                         Assert.Equal("type", a.DisplayName);
                         Assert.Equal("type", a.Name);
-                        Assert.Equal(RequiredAttributeDescriptor.NameComparisonMode.FullMatch, a.NameComparison);
+                        Assert.Equal(RequiredAttributeNameComparison.FullMatch, a.NameComparison);
                         Assert.Equal("checkbox", a.Value);
-                        Assert.Equal(RequiredAttributeDescriptor.ValueComparisonMode.FullMatch, a.ValueComparison);
+                        Assert.Equal(RequiredAttributeValueComparison.FullMatch, a.ValueComparison);
                     },
                     a =>
                     {
@@ -1148,9 +1148,9 @@ namespace Test
         Assert.Empty(requiredAttribute.Diagnostics);
         Assert.Equal("@bind-...", requiredAttribute.DisplayName);
         Assert.Equal("@bind-", requiredAttribute.Name);
-        Assert.Equal(RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch, requiredAttribute.NameComparison);
+        Assert.Equal(RequiredAttributeNameComparison.PrefixMatch, requiredAttribute.NameComparison);
         Assert.Null(requiredAttribute.Value);
-        Assert.Equal(RequiredAttributeDescriptor.ValueComparisonMode.None, requiredAttribute.ValueComparison);
+        Assert.Equal(RequiredAttributeValueComparison.None, requiredAttribute.ValueComparison);
 
         var attribute = Assert.Single(bind.BoundAttributes, a => a.Name.StartsWith("@bind", StringComparison.Ordinal));
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/test/DefaultTagHelperDescriptorFactoryTest.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/test/DefaultTagHelperDescriptorFactoryTest.cs
@@ -154,8 +154,7 @@ public class DefaultTagHelperDescriptorFactoryTest : TagHelperDescriptorProvider
                         {
                             builder => builder
                                 .Name("name")
-                                .Value("value")
-                                .ValueComparison(RequiredAttributeValueComparison.FullMatch)
+                                .Value("value", RequiredAttributeValueComparison.FullMatch)
                                 .AddDiagnostic(RazorDiagnosticFactory.CreateTagHelper_CouldNotFindMatchingEndBrace("[name='value'")),
                         }
                     },
@@ -183,8 +182,7 @@ public class DefaultTagHelperDescriptorFactoryTest : TagHelperDescriptorProvider
                         {
                             builder => builder
                                 .Name("name")
-                                .Value("value")
-                                .ValueComparison(RequiredAttributeValueComparison.FullMatch)
+                                .Value("value", RequiredAttributeValueComparison.FullMatch)
                                 .AddDiagnostic(RazorDiagnosticFactory.CreateTagHelper_CouldNotFindMatchingEndBrace("[name=value ")),
                         }
                     },
@@ -224,15 +222,12 @@ public class DefaultTagHelperDescriptorFactoryTest : TagHelperDescriptorProvider
         get
         {
             Func<string, RequiredAttributeNameComparison, Action<RequiredAttributeDescriptorBuilder>> plain =
-                (name, nameComparison) => (builder) => builder
-                    .Name(name)
-                    .NameComparison(nameComparison);
+                (name, nameComparison) => builder => builder.Name(name, nameComparison);
 
             Func<string, string, RequiredAttributeValueComparison, Action<RequiredAttributeDescriptorBuilder>> css =
-                (name, value, valueComparison) => (builder) => builder
+                (name, value, valueComparison) => builder => builder
                     .Name(name)
-                    .Value(value)
-                    .ValueComparison(valueComparison);
+                    .Value(value, valueComparison);
 
             return new TheoryData<string, IEnumerable<Action<RequiredAttributeDescriptorBuilder>>>
                 {
@@ -954,8 +949,7 @@ public class DefaultTagHelperDescriptorFactoryTest : TagHelperDescriptorProvider
                             {
                                 builder => builder
                                     .RequireAttributeDescriptor(attribute => attribute
-                                        .Name("class")
-                                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch)),
+                                        .Name("class", RequiredAttributeNameComparison.PrefixMatch)),
                             })
                     },
                     {
@@ -970,11 +964,9 @@ public class DefaultTagHelperDescriptorFactoryTest : TagHelperDescriptorProvider
                             {
                                 builder => builder
                                     .RequireAttributeDescriptor(attribute => attribute
-                                        .Name("class")
-                                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch))
+                                        .Name("class", RequiredAttributeNameComparison.PrefixMatch))
                                     .RequireAttributeDescriptor(attribute => attribute
-                                        .Name("style")
-                                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch)),
+                                        .Name("style", RequiredAttributeNameComparison.PrefixMatch)),
                             })
                     },
                 };

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/test/DefaultTagHelperDescriptorFactoryTest.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/test/DefaultTagHelperDescriptorFactoryTest.cs
@@ -89,7 +89,7 @@ public class DefaultTagHelperDescriptorFactoryTest : TagHelperDescriptorProvider
                         {
                             builder => builder
                                 .Name("name")
-                                .ValueComparisonMode(RequiredAttributeDescriptor.ValueComparisonMode.FullMatch)
+                                .ValueComparison(RequiredAttributeValueComparison.FullMatch)
                                 .AddDiagnostic(RazorDiagnosticFactory.CreateTagHelper_InvalidRequiredAttributeMismatchedQuotes('\'', "[name='unended]")),
                         }
                     },
@@ -99,7 +99,7 @@ public class DefaultTagHelperDescriptorFactoryTest : TagHelperDescriptorProvider
                         {
                             builder => builder
                                 .Name("name")
-                                .ValueComparisonMode(RequiredAttributeDescriptor.ValueComparisonMode.FullMatch)
+                                .ValueComparison(RequiredAttributeValueComparison.FullMatch)
                                 .AddDiagnostic(RazorDiagnosticFactory.CreateTagHelper_InvalidRequiredAttributeMismatchedQuotes('\'', "[name='unended")),
                         }
                     },
@@ -155,7 +155,7 @@ public class DefaultTagHelperDescriptorFactoryTest : TagHelperDescriptorProvider
                             builder => builder
                                 .Name("name")
                                 .Value("value")
-                                .ValueComparisonMode(RequiredAttributeDescriptor.ValueComparisonMode.FullMatch)
+                                .ValueComparison(RequiredAttributeValueComparison.FullMatch)
                                 .AddDiagnostic(RazorDiagnosticFactory.CreateTagHelper_CouldNotFindMatchingEndBrace("[name='value'")),
                         }
                     },
@@ -184,7 +184,7 @@ public class DefaultTagHelperDescriptorFactoryTest : TagHelperDescriptorProvider
                             builder => builder
                                 .Name("name")
                                 .Value("value")
-                                .ValueComparisonMode(RequiredAttributeDescriptor.ValueComparisonMode.FullMatch)
+                                .ValueComparison(RequiredAttributeValueComparison.FullMatch)
                                 .AddDiagnostic(RazorDiagnosticFactory.CreateTagHelper_CouldNotFindMatchingEndBrace("[name=value ")),
                         }
                     },
@@ -223,64 +223,64 @@ public class DefaultTagHelperDescriptorFactoryTest : TagHelperDescriptorProvider
     {
         get
         {
-            Func<string, RequiredAttributeDescriptor.NameComparisonMode, Action<RequiredAttributeDescriptorBuilder>> plain =
+            Func<string, RequiredAttributeNameComparison, Action<RequiredAttributeDescriptorBuilder>> plain =
                 (name, nameComparison) => (builder) => builder
                     .Name(name)
-                    .NameComparisonMode(nameComparison);
+                    .NameComparison(nameComparison);
 
-            Func<string, string, RequiredAttributeDescriptor.ValueComparisonMode, Action<RequiredAttributeDescriptorBuilder>> css =
+            Func<string, string, RequiredAttributeValueComparison, Action<RequiredAttributeDescriptorBuilder>> css =
                 (name, value, valueComparison) => (builder) => builder
                     .Name(name)
                     .Value(value)
-                    .ValueComparisonMode(valueComparison);
+                    .ValueComparison(valueComparison);
 
             return new TheoryData<string, IEnumerable<Action<RequiredAttributeDescriptorBuilder>>>
                 {
                     { null, Enumerable.Empty<Action<RequiredAttributeDescriptorBuilder>>() },
                     { string.Empty, Enumerable.Empty<Action<RequiredAttributeDescriptorBuilder>>() },
-                    { "name", new[] { plain("name", RequiredAttributeDescriptor.NameComparisonMode.FullMatch) } },
-                    { "name-*", new[] { plain("name-", RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch) } },
-                    { "  name-*   ", new[] { plain("name-", RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch) } },
+                    { "name", new[] { plain("name", RequiredAttributeNameComparison.FullMatch) } },
+                    { "name-*", new[] { plain("name-", RequiredAttributeNameComparison.PrefixMatch) } },
+                    { "  name-*   ", new[] { plain("name-", RequiredAttributeNameComparison.PrefixMatch) } },
                     {
                         "asp-route-*,valid  ,  name-*   ,extra",
                         new[]
                         {
-                            plain("asp-route-", RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch),
-                            plain("valid", RequiredAttributeDescriptor.NameComparisonMode.FullMatch),
-                            plain("name-", RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch),
-                            plain("extra", RequiredAttributeDescriptor.NameComparisonMode.FullMatch),
+                            plain("asp-route-", RequiredAttributeNameComparison.PrefixMatch),
+                            plain("valid", RequiredAttributeNameComparison.FullMatch),
+                            plain("name-", RequiredAttributeNameComparison.PrefixMatch),
+                            plain("extra", RequiredAttributeNameComparison.FullMatch),
                         }
                     },
-                    { "[name]", new[] { css("name", null, RequiredAttributeDescriptor.ValueComparisonMode.None) } },
-                    { "[ name ]", new[] { css("name", null, RequiredAttributeDescriptor.ValueComparisonMode.None) } },
-                    { " [ name ] ", new[] { css("name", null, RequiredAttributeDescriptor.ValueComparisonMode.None) } },
-                    { "[name=]", new[] { css("name", "", RequiredAttributeDescriptor.ValueComparisonMode.FullMatch) } },
-                    { "[name='']", new[] { css("name", "", RequiredAttributeDescriptor.ValueComparisonMode.FullMatch) } },
-                    { "[name ^=]", new[] { css("name", "", RequiredAttributeDescriptor.ValueComparisonMode.PrefixMatch) } },
-                    { "[name=hello]", new[] { css("name", "hello", RequiredAttributeDescriptor.ValueComparisonMode.FullMatch) } },
-                    { "[name= hello]", new[] { css("name", "hello", RequiredAttributeDescriptor.ValueComparisonMode.FullMatch) } },
-                    { "[name='hello']", new[] { css("name", "hello", RequiredAttributeDescriptor.ValueComparisonMode.FullMatch) } },
-                    { "[name=\"hello\"]", new[] { css("name", "hello", RequiredAttributeDescriptor.ValueComparisonMode.FullMatch) } },
-                    { " [ name  $= \" hello\" ]  ", new[] { css("name", " hello", RequiredAttributeDescriptor.ValueComparisonMode.SuffixMatch) } },
+                    { "[name]", new[] { css("name", null, RequiredAttributeValueComparison.None) } },
+                    { "[ name ]", new[] { css("name", null, RequiredAttributeValueComparison.None) } },
+                    { " [ name ] ", new[] { css("name", null, RequiredAttributeValueComparison.None) } },
+                    { "[name=]", new[] { css("name", "", RequiredAttributeValueComparison.FullMatch) } },
+                    { "[name='']", new[] { css("name", "", RequiredAttributeValueComparison.FullMatch) } },
+                    { "[name ^=]", new[] { css("name", "", RequiredAttributeValueComparison.PrefixMatch) } },
+                    { "[name=hello]", new[] { css("name", "hello", RequiredAttributeValueComparison.FullMatch) } },
+                    { "[name= hello]", new[] { css("name", "hello", RequiredAttributeValueComparison.FullMatch) } },
+                    { "[name='hello']", new[] { css("name", "hello", RequiredAttributeValueComparison.FullMatch) } },
+                    { "[name=\"hello\"]", new[] { css("name", "hello", RequiredAttributeValueComparison.FullMatch) } },
+                    { " [ name  $= \" hello\" ]  ", new[] { css("name", " hello", RequiredAttributeValueComparison.SuffixMatch) } },
                     {
                         "[name=\"hello\"],[other^=something ], [val = 'cool']",
                         new[]
                         {
-                            css("name", "hello", RequiredAttributeDescriptor.ValueComparisonMode.FullMatch),
-                            css("other", "something", RequiredAttributeDescriptor.ValueComparisonMode.PrefixMatch),
-                            css("val", "cool", RequiredAttributeDescriptor.ValueComparisonMode.FullMatch) }
+                            css("name", "hello", RequiredAttributeValueComparison.FullMatch),
+                            css("other", "something", RequiredAttributeValueComparison.PrefixMatch),
+                            css("val", "cool", RequiredAttributeValueComparison.FullMatch) }
                     },
                     {
                         "asp-route-*,[name=\"hello\"],valid  ,[other^=something ],   name-*   ,[val = 'cool'],extra",
                         new[]
                         {
-                            plain("asp-route-", RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch),
-                            css("name", "hello", RequiredAttributeDescriptor.ValueComparisonMode.FullMatch),
-                            plain("valid", RequiredAttributeDescriptor.NameComparisonMode.FullMatch),
-                            css("other", "something", RequiredAttributeDescriptor.ValueComparisonMode.PrefixMatch),
-                            plain("name-", RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch),
-                            css("val", "cool", RequiredAttributeDescriptor.ValueComparisonMode.FullMatch),
-                            plain("extra", RequiredAttributeDescriptor.NameComparisonMode.FullMatch),
+                            plain("asp-route-", RequiredAttributeNameComparison.PrefixMatch),
+                            css("name", "hello", RequiredAttributeValueComparison.FullMatch),
+                            plain("valid", RequiredAttributeNameComparison.FullMatch),
+                            css("other", "something", RequiredAttributeValueComparison.PrefixMatch),
+                            plain("name-", RequiredAttributeNameComparison.PrefixMatch),
+                            css("val", "cool", RequiredAttributeValueComparison.FullMatch),
+                            plain("extra", RequiredAttributeNameComparison.FullMatch),
                         }
                     },
                 };
@@ -955,7 +955,7 @@ public class DefaultTagHelperDescriptorFactoryTest : TagHelperDescriptorProvider
                                 builder => builder
                                     .RequireAttributeDescriptor(attribute => attribute
                                         .Name("class")
-                                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch)),
+                                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch)),
                             })
                     },
                     {
@@ -971,10 +971,10 @@ public class DefaultTagHelperDescriptorFactoryTest : TagHelperDescriptorProvider
                                 builder => builder
                                     .RequireAttributeDescriptor(attribute => attribute
                                         .Name("class")
-                                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch))
+                                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch))
                                     .RequireAttributeDescriptor(attribute => attribute
                                         .Name("style")
-                                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch)),
+                                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch)),
                             })
                     },
                 };

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/test/EventHandlerTagHelperDescriptorProviderTest.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/test/EventHandlerTagHelperDescriptorProviderTest.cs
@@ -81,9 +81,9 @@ public class EventHandlerTagHelperDescriptorProviderTest : TagHelperDescriptorPr
         Assert.Empty(requiredAttribute.Diagnostics);
         Assert.Equal("@onclick", requiredAttribute.DisplayName);
         Assert.Equal("@onclick", requiredAttribute.Name);
-        Assert.Equal(RequiredAttributeDescriptor.NameComparisonMode.FullMatch, requiredAttribute.NameComparison);
+        Assert.Equal(RequiredAttributeNameComparison.FullMatch, requiredAttribute.NameComparison);
         Assert.Null(requiredAttribute.Value);
-        Assert.Equal(RequiredAttributeDescriptor.ValueComparisonMode.None, requiredAttribute.ValueComparison);
+        Assert.Equal(RequiredAttributeValueComparison.None, requiredAttribute.ValueComparison);
 
         var attribute = Assert.Single(item.BoundAttributes);
 
@@ -191,9 +191,9 @@ public class EventHandlerTagHelperDescriptorProviderTest : TagHelperDescriptorPr
         Assert.Empty(catchAllRequiredAttribute.Diagnostics);
         Assert.Equal("@onclick", catchAllRequiredAttribute.DisplayName);
         Assert.Equal("@onclick", catchAllRequiredAttribute.Name);
-        Assert.Equal(RequiredAttributeDescriptor.NameComparisonMode.FullMatch, catchAllRequiredAttribute.NameComparison);
+        Assert.Equal(RequiredAttributeNameComparison.FullMatch, catchAllRequiredAttribute.NameComparison);
         Assert.Null(catchAllRequiredAttribute.Value);
-        Assert.Equal(RequiredAttributeDescriptor.ValueComparisonMode.None, catchAllRequiredAttribute.ValueComparison);
+        Assert.Equal(RequiredAttributeValueComparison.None, catchAllRequiredAttribute.ValueComparison);
 
         var preventDefaultRule = item.TagMatchingRules[1];
         Assert.Empty(preventDefaultRule.Diagnostics);
@@ -206,9 +206,9 @@ public class EventHandlerTagHelperDescriptorProviderTest : TagHelperDescriptorPr
         Assert.Empty(preventDefaultRequiredAttribute.Diagnostics);
         Assert.Equal("@onclick:preventDefault", preventDefaultRequiredAttribute.DisplayName);
         Assert.Equal("@onclick:preventDefault", preventDefaultRequiredAttribute.Name);
-        Assert.Equal(RequiredAttributeDescriptor.NameComparisonMode.FullMatch, preventDefaultRequiredAttribute.NameComparison);
+        Assert.Equal(RequiredAttributeNameComparison.FullMatch, preventDefaultRequiredAttribute.NameComparison);
         Assert.Null(preventDefaultRequiredAttribute.Value);
-        Assert.Equal(RequiredAttributeDescriptor.ValueComparisonMode.None, preventDefaultRequiredAttribute.ValueComparison);
+        Assert.Equal(RequiredAttributeValueComparison.None, preventDefaultRequiredAttribute.ValueComparison);
 
         var stopPropagationRule = item.TagMatchingRules[2];
         Assert.Empty(stopPropagationRule.Diagnostics);
@@ -221,9 +221,9 @@ public class EventHandlerTagHelperDescriptorProviderTest : TagHelperDescriptorPr
         Assert.Empty(stopPropagationRequiredAttribute.Diagnostics);
         Assert.Equal("@onclick:stopPropagation", stopPropagationRequiredAttribute.DisplayName);
         Assert.Equal("@onclick:stopPropagation", stopPropagationRequiredAttribute.Name);
-        Assert.Equal(RequiredAttributeDescriptor.NameComparisonMode.FullMatch, stopPropagationRequiredAttribute.NameComparison);
+        Assert.Equal(RequiredAttributeNameComparison.FullMatch, stopPropagationRequiredAttribute.NameComparison);
         Assert.Null(stopPropagationRequiredAttribute.Value);
-        Assert.Equal(RequiredAttributeDescriptor.ValueComparisonMode.None, stopPropagationRequiredAttribute.ValueComparison);
+        Assert.Equal(RequiredAttributeValueComparison.None, stopPropagationRequiredAttribute.ValueComparison);
 
         var attribute = Assert.Single(item.BoundAttributes);
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/test/KeyTagHelperDescriptorProviderTest.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/test/KeyTagHelperDescriptorProviderTest.cs
@@ -59,9 +59,9 @@ public class KeyTagHelperDescriptorProviderTest : TagHelperDescriptorProviderTes
         Assert.Empty(requiredAttribute.Diagnostics);
         Assert.Equal("@key", requiredAttribute.DisplayName);
         Assert.Equal("@key", requiredAttribute.Name);
-        Assert.Equal(RequiredAttributeDescriptor.NameComparisonMode.FullMatch, requiredAttribute.NameComparison);
+        Assert.Equal(RequiredAttributeNameComparison.FullMatch, requiredAttribute.NameComparison);
         Assert.Null(requiredAttribute.Value);
-        Assert.Equal(RequiredAttributeDescriptor.ValueComparisonMode.None, requiredAttribute.ValueComparison);
+        Assert.Equal(RequiredAttributeValueComparison.None, requiredAttribute.ValueComparison);
 
         var attribute = Assert.Single(item.BoundAttributes);
         Assert.Empty(attribute.Diagnostics);

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/test/RefTagHelperDescriptorProviderTest.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/test/RefTagHelperDescriptorProviderTest.cs
@@ -59,9 +59,9 @@ public class RefTagHelperDescriptorProviderTest : TagHelperDescriptorProviderTes
         Assert.Empty(requiredAttribute.Diagnostics);
         Assert.Equal("@ref", requiredAttribute.DisplayName);
         Assert.Equal("@ref", requiredAttribute.Name);
-        Assert.Equal(RequiredAttributeDescriptor.NameComparisonMode.FullMatch, requiredAttribute.NameComparison);
+        Assert.Equal(RequiredAttributeNameComparison.FullMatch, requiredAttribute.NameComparison);
         Assert.Null(requiredAttribute.Value);
-        Assert.Equal(RequiredAttributeDescriptor.ValueComparisonMode.None, requiredAttribute.ValueComparison);
+        Assert.Equal(RequiredAttributeValueComparison.None, requiredAttribute.ValueComparison);
 
         var attribute = Assert.Single(item.BoundAttributes);
         Assert.Empty(attribute.Diagnostics);

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/test/SplatTagHelperDescriptorProviderTest.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/test/SplatTagHelperDescriptorProviderTest.cs
@@ -57,9 +57,9 @@ public class SplatTagHelperDescriptorProviderTest : TagHelperDescriptorProviderT
         Assert.Empty(requiredAttribute.Diagnostics);
         Assert.Equal("@attributes", requiredAttribute.DisplayName);
         Assert.Equal("@attributes", requiredAttribute.Name);
-        Assert.Equal(RequiredAttributeDescriptor.NameComparisonMode.FullMatch, requiredAttribute.NameComparison);
+        Assert.Equal(RequiredAttributeNameComparison.FullMatch, requiredAttribute.NameComparison);
         Assert.Null(requiredAttribute.Value);
-        Assert.Equal(RequiredAttributeDescriptor.ValueComparisonMode.None, requiredAttribute.ValueComparison);
+        Assert.Equal(RequiredAttributeValueComparison.None, requiredAttribute.ValueComparison);
 
         var attribute = Assert.Single(item.BoundAttributes);
         Assert.Empty(attribute.Diagnostics);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/MessagePack/Formatters/TagHelpers/RequiredAttributeFormatter.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/MessagePack/Formatters/TagHelpers/RequiredAttributeFormatter.cs
@@ -5,7 +5,6 @@ using System.Collections.Immutable;
 using MessagePack;
 using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Language;
-using static Microsoft.AspNetCore.Razor.Language.RequiredAttributeDescriptor;
 
 namespace Microsoft.CodeAnalysis.Razor.Serialization.MessagePack.Formatters.TagHelpers;
 
@@ -22,10 +21,10 @@ internal sealed class RequiredAttributeFormatter : ValueFormatter<RequiredAttrib
         reader.ReadArrayHeaderAndVerify(8);
 
         var name = CachedStringFormatter.Instance.Deserialize(ref reader, options);
-        var nameComparison = (NameComparisonMode)reader.ReadInt32();
+        var nameComparison = (RequiredAttributeNameComparison)reader.ReadInt32();
         var caseSensitive = reader.ReadBoolean();
         var value = CachedStringFormatter.Instance.Deserialize(ref reader, options);
-        var valueComparison = (ValueComparisonMode)reader.ReadInt32();
+        var valueComparison = (RequiredAttributeValueComparison)reader.ReadInt32();
         var displayName = CachedStringFormatter.Instance.Deserialize(ref reader, options).AssumeNotNull();
 
         var metadata = reader.Deserialize<MetadataCollection>(options);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/MessagePack/Formatters/TagHelpers/RequiredAttributeFormatter.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/MessagePack/Formatters/TagHelpers/RequiredAttributeFormatter.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.Razor.Serialization.MessagePack.Formatters.TagH
 
 internal sealed class RequiredAttributeFormatter : ValueFormatter<RequiredAttributeDescriptor>
 {
-    private const int PropertyCount = 7;
+    private const int PropertyCount = 6;
 
     public static readonly ValueFormatter<RequiredAttributeDescriptor> Instance = new RequiredAttributeFormatter();
 
@@ -27,13 +27,10 @@ internal sealed class RequiredAttributeFormatter : ValueFormatter<RequiredAttrib
         var value = CachedStringFormatter.Instance.Deserialize(ref reader, options);
         var valueComparison = (RequiredAttributeValueComparison)reader.ReadInt32();
 
-        var metadata = reader.Deserialize<MetadataCollection>(options);
         var diagnostics = reader.Deserialize<ImmutableArray<RazorDiagnostic>>(options);
 
         return new RequiredAttributeDescriptor(
-            flags, name!, nameComparison,
-            value, valueComparison,
-            diagnostics, metadata);
+            flags, name!, nameComparison, value, valueComparison, diagnostics);
     }
 
     public override void Serialize(ref MessagePackWriter writer, RequiredAttributeDescriptor value, SerializerCachingOptions options)
@@ -46,7 +43,6 @@ internal sealed class RequiredAttributeFormatter : ValueFormatter<RequiredAttrib
         CachedStringFormatter.Instance.Serialize(ref writer, value.Value, options);
         writer.Write((int)value.ValueComparison);
 
-        writer.Serialize(value.Metadata, options);
         writer.Serialize(value.Diagnostics, options);
     }
 
@@ -60,7 +56,6 @@ internal sealed class RequiredAttributeFormatter : ValueFormatter<RequiredAttrib
         CachedStringFormatter.Instance.Skim(ref reader, options); // Value
         reader.Skip(); // ValueComparison
 
-        MetadataCollectionFormatter.Instance.Skim(ref reader, options); // Metadata
         RazorDiagnosticFormatter.Instance.SkimArray(ref reader, options); // Diagnostics
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/MessagePack/Formatters/TagHelpers/RequiredAttributeFormatter.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/MessagePack/Formatters/TagHelpers/RequiredAttributeFormatter.cs
@@ -3,14 +3,13 @@
 
 using System.Collections.Immutable;
 using MessagePack;
-using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Language;
 
 namespace Microsoft.CodeAnalysis.Razor.Serialization.MessagePack.Formatters.TagHelpers;
 
 internal sealed class RequiredAttributeFormatter : ValueFormatter<RequiredAttributeDescriptor>
 {
-    private const int PropertyCount = 8;
+    private const int PropertyCount = 7;
 
     public static readonly ValueFormatter<RequiredAttributeDescriptor> Instance = new RequiredAttributeFormatter();
 
@@ -27,7 +26,6 @@ internal sealed class RequiredAttributeFormatter : ValueFormatter<RequiredAttrib
         var nameComparison = (RequiredAttributeNameComparison)reader.ReadInt32();
         var value = CachedStringFormatter.Instance.Deserialize(ref reader, options);
         var valueComparison = (RequiredAttributeValueComparison)reader.ReadInt32();
-        var displayName = CachedStringFormatter.Instance.Deserialize(ref reader, options).AssumeNotNull();
 
         var metadata = reader.Deserialize<MetadataCollection>(options);
         var diagnostics = reader.Deserialize<ImmutableArray<RazorDiagnostic>>(options);
@@ -35,7 +33,7 @@ internal sealed class RequiredAttributeFormatter : ValueFormatter<RequiredAttrib
         return new RequiredAttributeDescriptor(
             flags, name!, nameComparison,
             value, valueComparison,
-            displayName, diagnostics, metadata);
+            diagnostics, metadata);
     }
 
     public override void Serialize(ref MessagePackWriter writer, RequiredAttributeDescriptor value, SerializerCachingOptions options)
@@ -47,7 +45,6 @@ internal sealed class RequiredAttributeFormatter : ValueFormatter<RequiredAttrib
         writer.Write((int)value.NameComparison);
         CachedStringFormatter.Instance.Serialize(ref writer, value.Value, options);
         writer.Write((int)value.ValueComparison);
-        CachedStringFormatter.Instance.Serialize(ref writer, value.DisplayName, options);
 
         writer.Serialize(value.Metadata, options);
         writer.Serialize(value.Diagnostics, options);
@@ -62,7 +59,6 @@ internal sealed class RequiredAttributeFormatter : ValueFormatter<RequiredAttrib
         reader.Skip(); // NameComparison
         CachedStringFormatter.Instance.Skim(ref reader, options); // Value
         reader.Skip(); // ValueComparison
-        CachedStringFormatter.Instance.Skim(ref reader, options); // DisplayName
 
         MetadataCollectionFormatter.Instance.Skim(ref reader, options); // Metadata
         RazorDiagnosticFormatter.Instance.SkimArray(ref reader, options); // Diagnostics

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/MessagePack/SerializationFormat.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/MessagePack/SerializationFormat.cs
@@ -9,5 +9,5 @@ internal static class SerializationFormat
     // or any of the types that compose it changes. This includes: RazorConfiguration,
     // ProjectWorkspaceState, TagHelperDescriptor, and DocumentSnapshotHandle.
     // NOTE: If this version is changed, a coordinated insertion is required between Roslyn and Razor for the C# extension.
-    public const int Version = 10;
+    public const int Version = 11;
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/SimpleTagHelpers.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/SimpleTagHelpers.cs
@@ -172,22 +172,16 @@ internal static class SimpleTagHelpers
         directiveAttribute3.TagMatchingRule(rule =>
         {
             rule.TagName = "*";
-            rule.RequireAttributeDescriptor(b =>
-            {
-                b.Name = "@onclick";
-                b.SetMetadata(MetadataCollection.Create(IsDirectiveAttribute));
-                b.NameComparison = RequiredAttributeNameComparison.FullMatch;
-            });
+            rule.RequireAttributeDescriptor(attribute => attribute
+                .Name("@onclick", RequiredAttributeNameComparison.FullMatch)
+                .IsDirectiveAttribute());
         });
         directiveAttribute3.TagMatchingRule(rule =>
         {
             rule.TagName = "*";
-            rule.RequireAttributeDescriptor(b =>
-            {
-                b.Name = "@onclick";
-                b.SetMetadata(MetadataCollection.Create(IsDirectiveAttribute));
-                b.NameComparison = RequiredAttributeNameComparison.PrefixMatch;
-            });
+            rule.RequireAttributeDescriptor(attribute => attribute
+                .Name("@onclick", RequiredAttributeNameComparison.PrefixMatch)
+                .IsDirectiveAttribute());
         });
         directiveAttribute3.BindAttribute(attribute =>
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/SimpleTagHelpers.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/SimpleTagHelpers.cs
@@ -101,7 +101,7 @@ internal static class SimpleTagHelpers
             rule.RequireAttributeDescriptor(b =>
             {
                 b.Name = "@test";
-                b.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch;
+                b.NameComparison = RequiredAttributeNameComparison.PrefixMatch;
             });
         });
         directiveAttribute1.TagMatchingRule(rule =>
@@ -110,7 +110,7 @@ internal static class SimpleTagHelpers
             rule.RequireAttributeDescriptor(b =>
             {
                 b.Name = "@test";
-                b.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                b.NameComparison = RequiredAttributeNameComparison.FullMatch;
             });
         });
         directiveAttribute1.BindAttribute(attribute =>
@@ -138,7 +138,7 @@ internal static class SimpleTagHelpers
             rule.RequireAttributeDescriptor(b =>
             {
                 b.Name = "@minimized";
-                b.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch;
+                b.NameComparison = RequiredAttributeNameComparison.PrefixMatch;
             });
         });
         directiveAttribute2.TagMatchingRule(rule =>
@@ -147,7 +147,7 @@ internal static class SimpleTagHelpers
             rule.RequireAttributeDescriptor(b =>
             {
                 b.Name = "@minimized";
-                b.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                b.NameComparison = RequiredAttributeNameComparison.FullMatch;
             });
         });
         directiveAttribute2.BindAttribute(attribute =>
@@ -176,7 +176,7 @@ internal static class SimpleTagHelpers
             {
                 b.Name = "@onclick";
                 b.SetMetadata(MetadataCollection.Create(IsDirectiveAttribute));
-                b.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                b.NameComparison = RequiredAttributeNameComparison.FullMatch;
             });
         });
         directiveAttribute3.TagMatchingRule(rule =>
@@ -186,7 +186,7 @@ internal static class SimpleTagHelpers
             {
                 b.Name = "@onclick";
                 b.SetMetadata(MetadataCollection.Create(IsDirectiveAttribute));
-                b.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch;
+                b.NameComparison = RequiredAttributeNameComparison.PrefixMatch;
             });
         });
         directiveAttribute3.BindAttribute(attribute =>

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/LanguageServerTagHelperCompletionServiceTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/LanguageServerTagHelperCompletionServiceTest.cs
@@ -100,7 +100,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .RequireAttributeDescriptor(builder =>
                     {
                         builder.Name = "asp-route-";
-                        builder.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch;
+                        builder.NameComparison = RequiredAttributeNameComparison.PrefixMatch;
                     }))
                 .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("form")
@@ -1333,7 +1333,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .RequireAttributeDescriptor(builder =>
                     {
                         builder.Name = "asp-route-";
-                        builder.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch;
+                        builder.NameComparison = RequiredAttributeNameComparison.PrefixMatch;
                     }))
                 .Build(),
         ];
@@ -1373,7 +1373,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .RequireAttributeDescriptor(builder =>
                     {
                         builder.Name = "asp-route-";
-                        builder.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch;
+                        builder.NameComparison = RequiredAttributeNameComparison.PrefixMatch;
                     }))
                 .Build(),
         ];
@@ -1406,7 +1406,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .RequireAttributeDescriptor(builder =>
                     {
                         builder.Name = "type";
-                        builder.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch;
+                        builder.NameComparison = RequiredAttributeNameComparison.PrefixMatch;
                     }))
                 .Build(),
         ];

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/TagHelperDeltaResultSerializationTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/TagHelperDeltaResultSerializationTest.cs
@@ -69,13 +69,10 @@ public class TagHelperDeltaResultSerializationTest(ITestOutputHelper testOutput)
             [
                 builder => builder
                     .RequireAttributeDescriptor(attribute => attribute
-                        .Name("required-attribute-one")
-                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch))
+                        .Name("required-attribute-one", RequiredAttributeNameComparison.PrefixMatch))
                     .RequireAttributeDescriptor(attribute => attribute
-                        .Name("required-attribute-two")
-                        .NameComparison(RequiredAttributeNameComparison.FullMatch)
-                        .Value("something")
-                        .ValueComparison(RequiredAttributeValueComparison.PrefixMatch))
+                        .Name("required-attribute-two", RequiredAttributeNameComparison.FullMatch)
+                        .Value("something", RequiredAttributeValueComparison.PrefixMatch))
                     .RequireParentTag("parent-name")
                     .RequireTagStructure(TagStructure.WithoutEndTag),
             ],
@@ -119,13 +116,10 @@ public class TagHelperDeltaResultSerializationTest(ITestOutputHelper testOutput)
             [
                 builder => builder
                     .RequireAttributeDescriptor(attribute => attribute
-                        .Name("required-attribute-one")
-                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch))
+                        .Name("required-attribute-one", RequiredAttributeNameComparison.PrefixMatch))
                     .RequireAttributeDescriptor(attribute => attribute
-                        .Name("required-attribute-two")
-                        .NameComparison(RequiredAttributeNameComparison.FullMatch)
-                        .Value("something")
-                        .ValueComparison(RequiredAttributeValueComparison.PrefixMatch))
+                        .Name("required-attribute-two", RequiredAttributeNameComparison.FullMatch)
+                        .Value("something", RequiredAttributeValueComparison.PrefixMatch))
                     .RequireParentTag("parent-name")
                     .RequireTagStructure(TagStructure.WithoutEndTag),
             ],
@@ -169,13 +163,10 @@ public class TagHelperDeltaResultSerializationTest(ITestOutputHelper testOutput)
             [
                 builder => builder
                     .RequireAttributeDescriptor(attribute => attribute
-                        .Name("required-attribute-one")
-                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch))
+                        .Name("required-attribute-one", RequiredAttributeNameComparison.PrefixMatch))
                     .RequireAttributeDescriptor(attribute => attribute
-                        .Name("required-attribute-two")
-                        .NameComparison(RequiredAttributeNameComparison.FullMatch)
-                        .Value("something")
-                        .ValueComparison(RequiredAttributeValueComparison.PrefixMatch))
+                        .Name("required-attribute-two", RequiredAttributeNameComparison.FullMatch)
+                        .Value("something", RequiredAttributeValueComparison.PrefixMatch))
                     .RequireParentTag("parent-name"),
             ],
             configureAction: builder => builder.AllowChildTag("allowed-child-one")
@@ -224,8 +215,7 @@ public class TagHelperDeltaResultSerializationTest(ITestOutputHelper testOutput)
             [
                 builder => builder
                     .RequireAttributeDescriptor(attribute => attribute
-                        .Name("required-attribute-one")
-                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch))
+                        .Name("required-attribute-one", RequiredAttributeNameComparison.PrefixMatch))
             ],
             configureAction: builder => builder
                 .AllowChildTag("allowed-child-one")

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/TagHelperDeltaResultSerializationTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/TagHelperDeltaResultSerializationTest.cs
@@ -70,12 +70,12 @@ public class TagHelperDeltaResultSerializationTest(ITestOutputHelper testOutput)
                 builder => builder
                     .RequireAttributeDescriptor(attribute => attribute
                         .Name("required-attribute-one")
-                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch))
+                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch))
                     .RequireAttributeDescriptor(attribute => attribute
                         .Name("required-attribute-two")
-                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)
+                        .NameComparison(RequiredAttributeNameComparison.FullMatch)
                         .Value("something")
-                        .ValueComparisonMode(RequiredAttributeDescriptor.ValueComparisonMode.PrefixMatch))
+                        .ValueComparison(RequiredAttributeValueComparison.PrefixMatch))
                     .RequireParentTag("parent-name")
                     .RequireTagStructure(TagStructure.WithoutEndTag),
             ],
@@ -120,12 +120,12 @@ public class TagHelperDeltaResultSerializationTest(ITestOutputHelper testOutput)
                 builder => builder
                     .RequireAttributeDescriptor(attribute => attribute
                         .Name("required-attribute-one")
-                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch))
+                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch))
                     .RequireAttributeDescriptor(attribute => attribute
                         .Name("required-attribute-two")
-                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)
+                        .NameComparison(RequiredAttributeNameComparison.FullMatch)
                         .Value("something")
-                        .ValueComparisonMode(RequiredAttributeDescriptor.ValueComparisonMode.PrefixMatch))
+                        .ValueComparison(RequiredAttributeValueComparison.PrefixMatch))
                     .RequireParentTag("parent-name")
                     .RequireTagStructure(TagStructure.WithoutEndTag),
             ],
@@ -170,12 +170,12 @@ public class TagHelperDeltaResultSerializationTest(ITestOutputHelper testOutput)
                 builder => builder
                     .RequireAttributeDescriptor(attribute => attribute
                         .Name("required-attribute-one")
-                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch))
+                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch))
                     .RequireAttributeDescriptor(attribute => attribute
                         .Name("required-attribute-two")
-                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)
+                        .NameComparison(RequiredAttributeNameComparison.FullMatch)
                         .Value("something")
-                        .ValueComparisonMode(RequiredAttributeDescriptor.ValueComparisonMode.PrefixMatch))
+                        .ValueComparison(RequiredAttributeValueComparison.PrefixMatch))
                     .RequireParentTag("parent-name"),
             ],
             configureAction: builder => builder.AllowChildTag("allowed-child-one")
@@ -225,7 +225,7 @@ public class TagHelperDeltaResultSerializationTest(ITestOutputHelper testOutput)
                 builder => builder
                     .RequireAttributeDescriptor(attribute => attribute
                         .Name("required-attribute-one")
-                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch))
+                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch))
             ],
             configureAction: builder => builder
                 .AllowChildTag("allowed-child-one")

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/TagHelperDescriptorSerializationTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/TagHelperDescriptorSerializationTest.cs
@@ -66,13 +66,10 @@ public class TagHelperDescriptorSerializationTest(ITestOutputHelper testOutput) 
             [
                 builder => builder
                     .RequireAttributeDescriptor(attribute => attribute
-                        .Name("required-attribute-one")
-                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch))
+                        .Name("required-attribute-one", RequiredAttributeNameComparison.PrefixMatch))
                     .RequireAttributeDescriptor(attribute => attribute
-                        .Name("required-attribute-two")
-                        .NameComparison(RequiredAttributeNameComparison.FullMatch)
-                        .Value("something")
-                        .ValueComparison(RequiredAttributeValueComparison.PrefixMatch))
+                        .Name("required-attribute-two", RequiredAttributeNameComparison.FullMatch)
+                        .Value("something", RequiredAttributeValueComparison.PrefixMatch))
                     .RequireParentTag("parent-name")
                     .RequireTagStructure(TagStructure.WithoutEndTag),
             ],
@@ -110,13 +107,10 @@ public class TagHelperDescriptorSerializationTest(ITestOutputHelper testOutput) 
             [
                 builder => builder
                     .RequireAttributeDescriptor(attribute => attribute
-                        .Name("required-attribute-one")
-                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch))
+                        .Name("required-attribute-one", RequiredAttributeNameComparison.PrefixMatch))
                     .RequireAttributeDescriptor(attribute => attribute
-                        .Name("required-attribute-two")
-                        .NameComparison(RequiredAttributeNameComparison.FullMatch)
-                        .Value("something")
-                        .ValueComparison(RequiredAttributeValueComparison.PrefixMatch))
+                        .Name("required-attribute-two", RequiredAttributeNameComparison.FullMatch)
+                        .Value("something", RequiredAttributeValueComparison.PrefixMatch))
                     .RequireParentTag("parent-name")
                     .RequireTagStructure(TagStructure.WithoutEndTag),
             ],
@@ -154,13 +148,10 @@ public class TagHelperDescriptorSerializationTest(ITestOutputHelper testOutput) 
             [
                 builder => builder
                     .RequireAttributeDescriptor(attribute => attribute
-                        .Name("required-attribute-one")
-                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch))
+                        .Name("required-attribute-one", RequiredAttributeNameComparison.PrefixMatch))
                     .RequireAttributeDescriptor(attribute => attribute
-                        .Name("required-attribute-two")
-                        .NameComparison(RequiredAttributeNameComparison.FullMatch)
-                        .Value("something")
-                        .ValueComparison(RequiredAttributeValueComparison.PrefixMatch))
+                        .Name("required-attribute-two", RequiredAttributeNameComparison.FullMatch)
+                        .Value("something", RequiredAttributeValueComparison.PrefixMatch))
                     .RequireParentTag("parent-name"),
             ],
             configureAction: builder => builder
@@ -204,8 +195,7 @@ public class TagHelperDescriptorSerializationTest(ITestOutputHelper testOutput) 
             [
                 builder => builder
                     .RequireAttributeDescriptor(attribute => attribute
-                        .Name("required-attribute-one")
-                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch))
+                        .Name("required-attribute-one", RequiredAttributeNameComparison.PrefixMatch))
             ],
             configureAction: builder => builder
                 .AllowChildTag("allowed-child-one")

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/TagHelperDescriptorSerializationTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/TagHelperDescriptorSerializationTest.cs
@@ -67,12 +67,12 @@ public class TagHelperDescriptorSerializationTest(ITestOutputHelper testOutput) 
                 builder => builder
                     .RequireAttributeDescriptor(attribute => attribute
                         .Name("required-attribute-one")
-                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch))
+                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch))
                     .RequireAttributeDescriptor(attribute => attribute
                         .Name("required-attribute-two")
-                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)
+                        .NameComparison(RequiredAttributeNameComparison.FullMatch)
                         .Value("something")
-                        .ValueComparisonMode(RequiredAttributeDescriptor.ValueComparisonMode.PrefixMatch))
+                        .ValueComparison(RequiredAttributeValueComparison.PrefixMatch))
                     .RequireParentTag("parent-name")
                     .RequireTagStructure(TagStructure.WithoutEndTag),
             ],
@@ -111,12 +111,12 @@ public class TagHelperDescriptorSerializationTest(ITestOutputHelper testOutput) 
                 builder => builder
                     .RequireAttributeDescriptor(attribute => attribute
                         .Name("required-attribute-one")
-                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch))
+                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch))
                     .RequireAttributeDescriptor(attribute => attribute
                         .Name("required-attribute-two")
-                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)
+                        .NameComparison(RequiredAttributeNameComparison.FullMatch)
                         .Value("something")
-                        .ValueComparisonMode(RequiredAttributeDescriptor.ValueComparisonMode.PrefixMatch))
+                        .ValueComparison(RequiredAttributeValueComparison.PrefixMatch))
                     .RequireParentTag("parent-name")
                     .RequireTagStructure(TagStructure.WithoutEndTag),
             ],
@@ -155,12 +155,12 @@ public class TagHelperDescriptorSerializationTest(ITestOutputHelper testOutput) 
                 builder => builder
                     .RequireAttributeDescriptor(attribute => attribute
                         .Name("required-attribute-one")
-                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch))
+                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch))
                     .RequireAttributeDescriptor(attribute => attribute
                         .Name("required-attribute-two")
-                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)
+                        .NameComparison(RequiredAttributeNameComparison.FullMatch)
                         .Value("something")
-                        .ValueComparisonMode(RequiredAttributeDescriptor.ValueComparisonMode.PrefixMatch))
+                        .ValueComparison(RequiredAttributeValueComparison.PrefixMatch))
                     .RequireParentTag("parent-name"),
             ],
             configureAction: builder => builder
@@ -205,7 +205,7 @@ public class TagHelperDescriptorSerializationTest(ITestOutputHelper testOutput) 
                 builder => builder
                     .RequireAttributeDescriptor(attribute => attribute
                         .Name("required-attribute-one")
-                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch))
+                        .NameComparison(RequiredAttributeNameComparison.PrefixMatch))
             ],
             configureAction: builder => builder
                 .AllowChildTag("allowed-child-one")
@@ -310,7 +310,8 @@ public class TagHelperDescriptorSerializationTest(ITestOutputHelper testOutput) 
         {
             foreach (var ruleBuilder in ruleBuilders)
             {
-                builder.TagMatchingRuleDescriptor(innerRuleBuilder => {
+                builder.TagMatchingRuleDescriptor(innerRuleBuilder =>
+                {
                     innerRuleBuilder.RequireTagName(tagName);
                     ruleBuilder(innerRuleBuilder);
                 });

--- a/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Completion/LegacyTagHelperCompletionServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Completion/LegacyTagHelperCompletionServiceTest.cs
@@ -101,7 +101,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                     .RequireAttributeDescriptor(builder =>
                     {
                         builder.Name = "asp-route-";
-                        builder.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch;
+                        builder.NameComparison = RequiredAttributeNameComparison.PrefixMatch;
                     }))
                 .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("form")

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders_TagHelpers.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders_TagHelpers.cs
@@ -129,9 +129,9 @@ internal static partial class ObjectReaders
 
             static RequiredAttributeDescriptor ReadFromProperties(JsonDataReader reader)
             {
+                var flags = (RequiredAttributeDescriptorFlags)reader.ReadInt32(nameof(RequiredAttributeDescriptor.Flags));
                 var name = reader.ReadString(nameof(RequiredAttributeDescriptor.Name));
                 var nameComparison = (RequiredAttributeNameComparison)reader.ReadInt32OrZero(nameof(RequiredAttributeDescriptor.NameComparison));
-                var caseSensitive = reader.ReadBooleanOrTrue(nameof(RequiredAttributeDescriptor.CaseSensitive));
                 var value = reader.ReadStringOrNull(nameof(RequiredAttributeDescriptor.Value));
                 var valueComparison = (RequiredAttributeValueComparison)reader.ReadInt32OrZero(nameof(RequiredAttributeDescriptor.ValueComparison));
                 var displayName = reader.ReadNonNullString(nameof(RequiredAttributeDescriptor.DisplayName));
@@ -140,8 +140,7 @@ internal static partial class ObjectReaders
                 var diagnostics = reader.ReadImmutableArrayOrEmpty(nameof(RequiredAttributeDescriptor.Diagnostics), ReadDiagnostic);
 
                 return new RequiredAttributeDescriptor(
-                    Cached(name)!, nameComparison,
-                    caseSensitive,
+                    flags, Cached(name)!, nameComparison,
                     Cached(value), valueComparison,
                     Cached(displayName), diagnostics, metadata);
             }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders_TagHelpers.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders_TagHelpers.cs
@@ -134,7 +134,6 @@ internal static partial class ObjectReaders
                 var nameComparison = (RequiredAttributeNameComparison)reader.ReadInt32OrZero(nameof(RequiredAttributeDescriptor.NameComparison));
                 var value = reader.ReadStringOrNull(nameof(RequiredAttributeDescriptor.Value));
                 var valueComparison = (RequiredAttributeValueComparison)reader.ReadInt32OrZero(nameof(RequiredAttributeDescriptor.ValueComparison));
-                var displayName = reader.ReadNonNullString(nameof(RequiredAttributeDescriptor.DisplayName));
 
                 var metadata = ReadMetadata(reader, nameof(RequiredAttributeDescriptor.Metadata));
                 var diagnostics = reader.ReadImmutableArrayOrEmpty(nameof(RequiredAttributeDescriptor.Diagnostics), ReadDiagnostic);
@@ -142,7 +141,7 @@ internal static partial class ObjectReaders
                 return new RequiredAttributeDescriptor(
                     flags, Cached(name)!, nameComparison,
                     Cached(value), valueComparison,
-                    Cached(displayName), diagnostics, metadata);
+                    diagnostics, metadata);
             }
         }
 

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders_TagHelpers.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders_TagHelpers.cs
@@ -135,13 +135,10 @@ internal static partial class ObjectReaders
                 var value = reader.ReadStringOrNull(nameof(RequiredAttributeDescriptor.Value));
                 var valueComparison = (RequiredAttributeValueComparison)reader.ReadInt32OrZero(nameof(RequiredAttributeDescriptor.ValueComparison));
 
-                var metadata = ReadMetadata(reader, nameof(RequiredAttributeDescriptor.Metadata));
                 var diagnostics = reader.ReadImmutableArrayOrEmpty(nameof(RequiredAttributeDescriptor.Diagnostics), ReadDiagnostic);
 
                 return new RequiredAttributeDescriptor(
-                    flags, Cached(name)!, nameComparison,
-                    Cached(value), valueComparison,
-                    diagnostics, metadata);
+                    flags, Cached(name)!, nameComparison, Cached(value), valueComparison, diagnostics);
             }
         }
 

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders_TagHelpers.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders_TagHelpers.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Razor.Language;
 #if JSONSERIALIZATION_ENABLETAGHELPERCACHE
 using Microsoft.CodeAnalysis.Razor.Utilities;
 #endif
-using static Microsoft.AspNetCore.Razor.Language.RequiredAttributeDescriptor;
 
 namespace Microsoft.AspNetCore.Razor.Serialization.Json;
 
@@ -131,10 +130,10 @@ internal static partial class ObjectReaders
             static RequiredAttributeDescriptor ReadFromProperties(JsonDataReader reader)
             {
                 var name = reader.ReadString(nameof(RequiredAttributeDescriptor.Name));
-                var nameComparison = (NameComparisonMode)reader.ReadInt32OrZero(nameof(RequiredAttributeDescriptor.NameComparison));
+                var nameComparison = (RequiredAttributeNameComparison)reader.ReadInt32OrZero(nameof(RequiredAttributeDescriptor.NameComparison));
                 var caseSensitive = reader.ReadBooleanOrTrue(nameof(RequiredAttributeDescriptor.CaseSensitive));
                 var value = reader.ReadStringOrNull(nameof(RequiredAttributeDescriptor.Value));
-                var valueComparison = (ValueComparisonMode)reader.ReadInt32OrZero(nameof(RequiredAttributeDescriptor.ValueComparison));
+                var valueComparison = (RequiredAttributeValueComparison)reader.ReadInt32OrZero(nameof(RequiredAttributeDescriptor.ValueComparison));
                 var displayName = reader.ReadNonNullString(nameof(RequiredAttributeDescriptor.DisplayName));
 
                 var metadata = ReadMetadata(reader, nameof(RequiredAttributeDescriptor.Metadata));

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters_TagHelpers.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters_TagHelpers.cs
@@ -89,9 +89,9 @@ internal static partial class ObjectWriters
         {
             writer.WriteObject(value, static (writer, value) =>
             {
+                writer.Write(nameof(value.Flags), (int)value.Flags);
                 writer.Write(nameof(value.Name), value.Name);
                 writer.WriteIfNotZero(nameof(value.NameComparison), (int)value.NameComparison);
-                writer.WriteIfNotTrue(nameof(value.CaseSensitive), value.CaseSensitive);
                 writer.WriteIfNotNull(nameof(value.Value), value.Value);
                 writer.WriteIfNotZero(nameof(value.ValueComparison), (int)value.ValueComparison);
                 writer.WriteIfNotNull(nameof(value.DisplayName), value.DisplayName);

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters_TagHelpers.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters_TagHelpers.cs
@@ -94,8 +94,6 @@ internal static partial class ObjectWriters
                 writer.WriteIfNotZero(nameof(value.NameComparison), (int)value.NameComparison);
                 writer.WriteIfNotNull(nameof(value.Value), value.Value);
                 writer.WriteIfNotZero(nameof(value.ValueComparison), (int)value.ValueComparison);
-
-                WriteMetadata(writer, nameof(value.Metadata), value.Metadata);
                 writer.WriteArrayIfNotDefaultOrEmpty(nameof(value.Diagnostics), value.Diagnostics, Write);
             });
         }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters_TagHelpers.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters_TagHelpers.cs
@@ -94,7 +94,6 @@ internal static partial class ObjectWriters
                 writer.WriteIfNotZero(nameof(value.NameComparison), (int)value.NameComparison);
                 writer.WriteIfNotNull(nameof(value.Value), value.Value);
                 writer.WriteIfNotZero(nameof(value.ValueComparison), (int)value.ValueComparison);
-                writer.WriteIfNotNull(nameof(value.DisplayName), value.DisplayName);
 
                 WriteMetadata(writer, nameof(value.Metadata), value.Metadata);
                 writer.WriteArrayIfNotDefaultOrEmpty(nameof(value.Diagnostics), value.Diagnostics, Write);

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/SerializationFormat.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/SerializationFormat.cs
@@ -9,5 +9,5 @@ internal static class SerializationFormat
     // or any of the types that compose it changes. This includes: RazorConfiguration,
     // ProjectWorkspaceState, TagHelperDescriptor, and DocumentSnapshotHandle.
     // NOTE: If this version is changed, a coordinated insertion is required between Roslyn and Razor for the C# extension.
-    public const int Version = 10;
+    public const int Version = 11;
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/TestRequiredAttributeDescriptorBuilderExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/TestRequiredAttributeDescriptorBuilderExtensions.cs
@@ -47,6 +47,14 @@ public static class TestRequiredAttributeDescriptorBuilderExtensions
         return builder;
     }
 
+    public static RequiredAttributeDescriptorBuilder IsDirectiveAttribute(
+        this RequiredAttributeDescriptorBuilder builder, bool isDirectiveAttribute = true)
+    {
+        builder.IsDirectiveAttribute = isDirectiveAttribute;
+
+        return builder;
+    }
+
     public static RequiredAttributeDescriptorBuilder AddDiagnostic(
         this RequiredAttributeDescriptorBuilder builder, RazorDiagnostic diagnostic)
     {

--- a/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/TestRequiredAttributeDescriptorBuilderExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/TestRequiredAttributeDescriptorBuilderExtensions.cs
@@ -21,16 +21,11 @@ public static class TestRequiredAttributeDescriptorBuilderExtensions
         return builder;
     }
 
-    public static RequiredAttributeDescriptorBuilder NameComparisonMode(
+    public static RequiredAttributeDescriptorBuilder NameComparison(
         this RequiredAttributeDescriptorBuilder builder,
-        RequiredAttributeDescriptor.NameComparisonMode nameComparison)
+        RequiredAttributeNameComparison nameComparison)
     {
-        if (builder == null)
-        {
-            throw new ArgumentNullException(nameof(builder));
-        }
-
-        builder.NameComparisonMode = nameComparison;
+        builder.NameComparison = nameComparison;
 
         return builder;
     }
@@ -47,16 +42,11 @@ public static class TestRequiredAttributeDescriptorBuilderExtensions
         return builder;
     }
 
-    public static RequiredAttributeDescriptorBuilder ValueComparisonMode(
+    public static RequiredAttributeDescriptorBuilder ValueComparison(
         this RequiredAttributeDescriptorBuilder builder,
-        RequiredAttributeDescriptor.ValueComparisonMode valueComparison)
+        RequiredAttributeValueComparison valueComparison)
     {
-        if (builder == null)
-        {
-            throw new ArgumentNullException(nameof(builder));
-        }
-
-        builder.ValueComparisonMode = valueComparison;
+        builder.ValueComparison = valueComparison;
 
         return builder;
     }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/TestRequiredAttributeDescriptorBuilderExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/TestRequiredAttributeDescriptorBuilderExtensions.cs
@@ -1,57 +1,54 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
-using System;
-
 namespace Microsoft.AspNetCore.Razor.Language;
 
 public static class TestRequiredAttributeDescriptorBuilderExtensions
 {
-    public static RequiredAttributeDescriptorBuilder Name(this RequiredAttributeDescriptorBuilder builder, string name)
+    public static RequiredAttributeDescriptorBuilder Name(
+        this RequiredAttributeDescriptorBuilder builder, string name, RequiredAttributeNameComparison? nameComparison = null)
     {
-        if (builder == null)
-        {
-            throw new ArgumentNullException(nameof(builder));
-        }
-
         builder.Name = name;
+
+        if (nameComparison is RequiredAttributeNameComparison nameComparisonValue)
+        {
+            builder.NameComparison = nameComparisonValue;
+        }
 
         return builder;
     }
 
     public static RequiredAttributeDescriptorBuilder NameComparison(
-        this RequiredAttributeDescriptorBuilder builder,
-        RequiredAttributeNameComparison nameComparison)
+        this RequiredAttributeDescriptorBuilder builder, RequiredAttributeNameComparison nameComparison)
     {
         builder.NameComparison = nameComparison;
 
         return builder;
     }
 
-    public static RequiredAttributeDescriptorBuilder Value(this RequiredAttributeDescriptorBuilder builder, string value)
+    public static RequiredAttributeDescriptorBuilder Value(
+        this RequiredAttributeDescriptorBuilder builder, string value, RequiredAttributeValueComparison? valueComparison = null)
     {
-        if (builder == null)
-        {
-            throw new ArgumentNullException(nameof(builder));
-        }
-
         builder.Value = value;
+
+        if (valueComparison is RequiredAttributeValueComparison valueComparisonValue)
+        {
+            builder.ValueComparison = valueComparisonValue;
+        }
 
         return builder;
     }
 
     public static RequiredAttributeDescriptorBuilder ValueComparison(
-        this RequiredAttributeDescriptorBuilder builder,
-        RequiredAttributeValueComparison valueComparison)
+        this RequiredAttributeDescriptorBuilder builder, RequiredAttributeValueComparison valueComparison)
     {
         builder.ValueComparison = valueComparison;
 
         return builder;
     }
 
-    public static RequiredAttributeDescriptorBuilder AddDiagnostic(this RequiredAttributeDescriptorBuilder builder, RazorDiagnostic diagnostic)
+    public static RequiredAttributeDescriptorBuilder AddDiagnostic(
+        this RequiredAttributeDescriptorBuilder builder, RazorDiagnostic diagnostic)
     {
         builder.Diagnostics.Add(diagnostic);
 

--- a/src/Shared/files/Compiler/taghelpers.json
+++ b/src/Shared/files/Compiler/taghelpers.json
@@ -3812,10 +3812,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4545064052966077203,
-      "Data2": 5281744655842642689,
-      "Data3": -1736328996792404140,
-      "Data4": -8420568105166294591
+      "Data1": 6231362703914857332,
+      "Data2": 5117075734903187732,
+      "Data3": -6764100699663594424,
+      "Data4": -4585122510622479232
     },
     "Kind": "Components.EventHandler",
     "Name": "onabort",
@@ -3828,11 +3828,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onabort",
-            "DisplayName": "@onabort",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onabort"
           }
         ]
       },
@@ -3840,11 +3837,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onabort:preventDefault",
-            "DisplayName": "@onabort:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onabort:preventDefault"
           }
         ]
       },
@@ -3852,11 +3846,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onabort:stopPropagation",
-            "DisplayName": "@onabort:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onabort:stopPropagation"
           }
         ]
       }

--- a/src/Shared/files/Tooling/BlazorServerApp.TagHelpers.json
+++ b/src/Shared/files/Tooling/BlazorServerApp.TagHelpers.json
@@ -6242,10 +6242,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6465587773490381159,
-      "Data2": 7535074613755532958,
-      "Data3": -6597400106414466904,
-      "Data4": -4718295965203228666
+      "Data1": 7756367481906268265,
+      "Data2": 4671361768386158253,
+      "Data3": 2789671614261878448,
+      "Data4": 5184967120032673317
     },
     "Kind": "Components.EventHandler",
     "Name": "onfocus",
@@ -6264,11 +6264,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfocus",
-            "DisplayName": "@onfocus",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfocus"
           }
         ]
       },
@@ -6276,11 +6273,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfocus:preventDefault",
-            "DisplayName": "@onfocus:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfocus:preventDefault"
           }
         ]
       },
@@ -6288,11 +6282,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfocus:stopPropagation",
-            "DisplayName": "@onfocus:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfocus:stopPropagation"
           }
         ]
       }
@@ -6354,10 +6345,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3922960561969939214,
-      "Data2": 2174238041354609490,
-      "Data3": 6278244008069449085,
-      "Data4": 7975697877211154135
+      "Data1": 1581744359623088405,
+      "Data2": -4135005204086187936,
+      "Data3": 4919498241361652040,
+      "Data4": -8834548284992434702
     },
     "Kind": "Components.EventHandler",
     "Name": "onblur",
@@ -6376,11 +6367,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onblur",
-            "DisplayName": "@onblur",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onblur"
           }
         ]
       },
@@ -6388,11 +6376,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onblur:preventDefault",
-            "DisplayName": "@onblur:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onblur:preventDefault"
           }
         ]
       },
@@ -6400,11 +6385,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onblur:stopPropagation",
-            "DisplayName": "@onblur:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onblur:stopPropagation"
           }
         ]
       }
@@ -6466,10 +6448,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3827718291310388734,
-      "Data2": -2988755441088730532,
-      "Data3": 926934914465422300,
-      "Data4": 1954337354554334265
+      "Data1": 2650573076430746801,
+      "Data2": -6695267901749062826,
+      "Data3": 7725460289800588623,
+      "Data4": -8863822650139558469
     },
     "Kind": "Components.EventHandler",
     "Name": "onfocusin",
@@ -6488,11 +6470,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfocusin",
-            "DisplayName": "@onfocusin",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfocusin"
           }
         ]
       },
@@ -6500,11 +6479,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfocusin:preventDefault",
-            "DisplayName": "@onfocusin:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfocusin:preventDefault"
           }
         ]
       },
@@ -6512,11 +6488,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfocusin:stopPropagation",
-            "DisplayName": "@onfocusin:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfocusin:stopPropagation"
           }
         ]
       }
@@ -6578,10 +6551,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3522629918317327344,
-      "Data2": -1485009587756691819,
-      "Data3": 1807056340270892927,
-      "Data4": 5991603992002843538
+      "Data1": -8732421790743259059,
+      "Data2": 44892016888241177,
+      "Data3": -6799566395080392730,
+      "Data4": 5755161441263324207
     },
     "Kind": "Components.EventHandler",
     "Name": "onfocusout",
@@ -6600,11 +6573,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfocusout",
-            "DisplayName": "@onfocusout",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfocusout"
           }
         ]
       },
@@ -6612,11 +6582,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfocusout:preventDefault",
-            "DisplayName": "@onfocusout:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfocusout:preventDefault"
           }
         ]
       },
@@ -6624,11 +6591,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfocusout:stopPropagation",
-            "DisplayName": "@onfocusout:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfocusout:stopPropagation"
           }
         ]
       }
@@ -6690,10 +6654,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4719679284010052614,
-      "Data2": -6037487177636854366,
-      "Data3": 3980125903044192178,
-      "Data4": -1160956382569708684
+      "Data1": 3868760391425953950,
+      "Data2": 4808107747950119367,
+      "Data3": 7581788992614682504,
+      "Data4": 1920925735740296778
     },
     "Kind": "Components.EventHandler",
     "Name": "onmouseover",
@@ -6712,11 +6676,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmouseover",
-            "DisplayName": "@onmouseover",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmouseover"
           }
         ]
       },
@@ -6724,11 +6685,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmouseover:preventDefault",
-            "DisplayName": "@onmouseover:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmouseover:preventDefault"
           }
         ]
       },
@@ -6736,11 +6694,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmouseover:stopPropagation",
-            "DisplayName": "@onmouseover:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmouseover:stopPropagation"
           }
         ]
       }
@@ -6802,10 +6757,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2517308608647479670,
-      "Data2": -5139125921065721692,
-      "Data3": 3322751183034831620,
-      "Data4": -5611729191927699236
+      "Data1": 2696712939949400862,
+      "Data2": 7787297469290954341,
+      "Data3": -1396469448332678055,
+      "Data4": 2738142089239072697
     },
     "Kind": "Components.EventHandler",
     "Name": "onmouseout",
@@ -6824,11 +6779,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmouseout",
-            "DisplayName": "@onmouseout",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmouseout"
           }
         ]
       },
@@ -6836,11 +6788,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmouseout:preventDefault",
-            "DisplayName": "@onmouseout:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmouseout:preventDefault"
           }
         ]
       },
@@ -6848,11 +6797,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmouseout:stopPropagation",
-            "DisplayName": "@onmouseout:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmouseout:stopPropagation"
           }
         ]
       }
@@ -6914,10 +6860,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8999018585483935701,
-      "Data2": -3890567381620569097,
-      "Data3": -5100889117651095789,
-      "Data4": -6863457054907620445
+      "Data1": -3066013168973622183,
+      "Data2": -7605159302916020619,
+      "Data3": -764602412609534474,
+      "Data4": -6487779888646630513
     },
     "Kind": "Components.EventHandler",
     "Name": "onmousemove",
@@ -6936,11 +6882,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmousemove",
-            "DisplayName": "@onmousemove",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmousemove"
           }
         ]
       },
@@ -6948,11 +6891,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmousemove:preventDefault",
-            "DisplayName": "@onmousemove:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmousemove:preventDefault"
           }
         ]
       },
@@ -6960,11 +6900,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmousemove:stopPropagation",
-            "DisplayName": "@onmousemove:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmousemove:stopPropagation"
           }
         ]
       }
@@ -7026,10 +6963,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7527427037382849112,
-      "Data2": 4042853249102039431,
-      "Data3": -4167170694211966184,
-      "Data4": -2180020198076536278
+      "Data1": 1808523310964034743,
+      "Data2": -327746865236310198,
+      "Data3": -1710177024350520986,
+      "Data4": 6135743918060119820
     },
     "Kind": "Components.EventHandler",
     "Name": "onmousedown",
@@ -7048,11 +6985,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmousedown",
-            "DisplayName": "@onmousedown",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmousedown"
           }
         ]
       },
@@ -7060,11 +6994,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmousedown:preventDefault",
-            "DisplayName": "@onmousedown:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmousedown:preventDefault"
           }
         ]
       },
@@ -7072,11 +7003,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmousedown:stopPropagation",
-            "DisplayName": "@onmousedown:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmousedown:stopPropagation"
           }
         ]
       }
@@ -7138,10 +7066,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1499097655157122654,
-      "Data2": 4011670832160661146,
-      "Data3": -3017464299655988853,
-      "Data4": 5331598497616975675
+      "Data1": 1298692492797548955,
+      "Data2": -4751663228930372883,
+      "Data3": 8307350365002462573,
+      "Data4": -5937810021146395414
     },
     "Kind": "Components.EventHandler",
     "Name": "onmouseup",
@@ -7160,11 +7088,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmouseup",
-            "DisplayName": "@onmouseup",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmouseup"
           }
         ]
       },
@@ -7172,11 +7097,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmouseup:preventDefault",
-            "DisplayName": "@onmouseup:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmouseup:preventDefault"
           }
         ]
       },
@@ -7184,11 +7106,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmouseup:stopPropagation",
-            "DisplayName": "@onmouseup:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmouseup:stopPropagation"
           }
         ]
       }
@@ -7250,10 +7169,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5842743917841288001,
-      "Data2": -2264286113015980950,
-      "Data3": -7244925475129355886,
-      "Data4": 4299288348001316974
+      "Data1": 7515376299517898575,
+      "Data2": 5599409375142926441,
+      "Data3": -7423307300559022961,
+      "Data4": 3472773143067950141
     },
     "Kind": "Components.EventHandler",
     "Name": "onclick",
@@ -7272,11 +7191,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onclick",
-            "DisplayName": "@onclick",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onclick"
           }
         ]
       },
@@ -7284,11 +7200,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onclick:preventDefault",
-            "DisplayName": "@onclick:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onclick:preventDefault"
           }
         ]
       },
@@ -7296,11 +7209,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onclick:stopPropagation",
-            "DisplayName": "@onclick:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onclick:stopPropagation"
           }
         ]
       }
@@ -7362,10 +7272,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2620506878031740205,
-      "Data2": 141975143151795759,
-      "Data3": 5121298285083402139,
-      "Data4": -1960590552236709803
+      "Data1": -2772212653354189905,
+      "Data2": 7393569250623318129,
+      "Data3": 4684579253192899904,
+      "Data4": 4210922651460914317
     },
     "Kind": "Components.EventHandler",
     "Name": "ondblclick",
@@ -7384,11 +7294,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondblclick",
-            "DisplayName": "@ondblclick",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondblclick"
           }
         ]
       },
@@ -7396,11 +7303,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondblclick:preventDefault",
-            "DisplayName": "@ondblclick:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondblclick:preventDefault"
           }
         ]
       },
@@ -7408,11 +7312,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondblclick:stopPropagation",
-            "DisplayName": "@ondblclick:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondblclick:stopPropagation"
           }
         ]
       }
@@ -7474,10 +7375,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1018886666421110275,
-      "Data2": 812524389814512043,
-      "Data3": -5025771482729477954,
-      "Data4": -1403302363189702754
+      "Data1": 6515487081599624679,
+      "Data2": -4533411601634152783,
+      "Data3": 5890257223739975359,
+      "Data4": -4501817798754885101
     },
     "Kind": "Components.EventHandler",
     "Name": "onwheel",
@@ -7496,11 +7397,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onwheel",
-            "DisplayName": "@onwheel",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onwheel"
           }
         ]
       },
@@ -7508,11 +7406,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onwheel:preventDefault",
-            "DisplayName": "@onwheel:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onwheel:preventDefault"
           }
         ]
       },
@@ -7520,11 +7415,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onwheel:stopPropagation",
-            "DisplayName": "@onwheel:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onwheel:stopPropagation"
           }
         ]
       }
@@ -7586,10 +7478,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8455769333687009820,
-      "Data2": 5742320475525345635,
-      "Data3": 2267392040673083720,
-      "Data4": 1353306075721455459
+      "Data1": -3801941383488879291,
+      "Data2": -1169958730967302380,
+      "Data3": -13958226014568852,
+      "Data4": -2417959717834381885
     },
     "Kind": "Components.EventHandler",
     "Name": "onmousewheel",
@@ -7608,11 +7500,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmousewheel",
-            "DisplayName": "@onmousewheel",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmousewheel"
           }
         ]
       },
@@ -7620,11 +7509,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmousewheel:preventDefault",
-            "DisplayName": "@onmousewheel:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmousewheel:preventDefault"
           }
         ]
       },
@@ -7632,11 +7518,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmousewheel:stopPropagation",
-            "DisplayName": "@onmousewheel:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmousewheel:stopPropagation"
           }
         ]
       }
@@ -7698,10 +7581,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5866507126627341590,
-      "Data2": 2936673807454416411,
-      "Data3": -5290716116845906785,
-      "Data4": 8363257237998436509
+      "Data1": -7442336933729017063,
+      "Data2": 4483326832156297520,
+      "Data3": -5508976924547051487,
+      "Data4": -45032086890243036
     },
     "Kind": "Components.EventHandler",
     "Name": "oncontextmenu",
@@ -7720,11 +7603,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncontextmenu",
-            "DisplayName": "@oncontextmenu",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncontextmenu"
           }
         ]
       },
@@ -7732,11 +7612,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncontextmenu:preventDefault",
-            "DisplayName": "@oncontextmenu:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncontextmenu:preventDefault"
           }
         ]
       },
@@ -7744,11 +7621,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncontextmenu:stopPropagation",
-            "DisplayName": "@oncontextmenu:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncontextmenu:stopPropagation"
           }
         ]
       }
@@ -7810,10 +7684,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7181065197870870517,
-      "Data2": 3084007880969192524,
-      "Data3": -227946195396508294,
-      "Data4": 5704366182847069435
+      "Data1": 3954714164417701965,
+      "Data2": 1459182891191603725,
+      "Data3": -4291160916985533379,
+      "Data4": 2377370201866045785
     },
     "Kind": "Components.EventHandler",
     "Name": "ondrag",
@@ -7832,11 +7706,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondrag",
-            "DisplayName": "@ondrag",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondrag"
           }
         ]
       },
@@ -7844,11 +7715,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondrag:preventDefault",
-            "DisplayName": "@ondrag:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondrag:preventDefault"
           }
         ]
       },
@@ -7856,11 +7724,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondrag:stopPropagation",
-            "DisplayName": "@ondrag:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondrag:stopPropagation"
           }
         ]
       }
@@ -7922,10 +7787,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 9138138522320706846,
-      "Data2": 8917470108640680039,
-      "Data3": -1090110288218714537,
-      "Data4": 8156552988483215598
+      "Data1": 1275046029666432707,
+      "Data2": -1696692434672145526,
+      "Data3": -4783389193191472006,
+      "Data4": 2833414270163841498
     },
     "Kind": "Components.EventHandler",
     "Name": "ondragend",
@@ -7944,11 +7809,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragend",
-            "DisplayName": "@ondragend",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragend"
           }
         ]
       },
@@ -7956,11 +7818,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragend:preventDefault",
-            "DisplayName": "@ondragend:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragend:preventDefault"
           }
         ]
       },
@@ -7968,11 +7827,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragend:stopPropagation",
-            "DisplayName": "@ondragend:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragend:stopPropagation"
           }
         ]
       }
@@ -8034,10 +7890,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5993047465740969478,
-      "Data2": -645794873687625372,
-      "Data3": 4411793638442113045,
-      "Data4": -2182860268158911274
+      "Data1": -4465082524160719946,
+      "Data2": 5564708710106663122,
+      "Data3": -7068707593933951007,
+      "Data4": 4333790149045627747
     },
     "Kind": "Components.EventHandler",
     "Name": "ondragenter",
@@ -8056,11 +7912,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragenter",
-            "DisplayName": "@ondragenter",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragenter"
           }
         ]
       },
@@ -8068,11 +7921,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragenter:preventDefault",
-            "DisplayName": "@ondragenter:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragenter:preventDefault"
           }
         ]
       },
@@ -8080,11 +7930,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragenter:stopPropagation",
-            "DisplayName": "@ondragenter:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragenter:stopPropagation"
           }
         ]
       }
@@ -8146,10 +7993,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 643961210950863711,
-      "Data2": -8679857167680824771,
-      "Data3": 3651588027436503457,
-      "Data4": -4711680326248175511
+      "Data1": 4012767897210204537,
+      "Data2": 8784809102802840351,
+      "Data3": 7790828592783864307,
+      "Data4": -5611451063148354513
     },
     "Kind": "Components.EventHandler",
     "Name": "ondragleave",
@@ -8168,11 +8015,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragleave",
-            "DisplayName": "@ondragleave",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragleave"
           }
         ]
       },
@@ -8180,11 +8024,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragleave:preventDefault",
-            "DisplayName": "@ondragleave:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragleave:preventDefault"
           }
         ]
       },
@@ -8192,11 +8033,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragleave:stopPropagation",
-            "DisplayName": "@ondragleave:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragleave:stopPropagation"
           }
         ]
       }
@@ -8258,10 +8096,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5307007483605923523,
-      "Data2": 595504818010280652,
-      "Data3": -231275281916851905,
-      "Data4": -6168021898791241900
+      "Data1": -6729734067485428197,
+      "Data2": -4916836462062428723,
+      "Data3": 3501409768987253806,
+      "Data4": -1280276650643352707
     },
     "Kind": "Components.EventHandler",
     "Name": "ondragover",
@@ -8280,11 +8118,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragover",
-            "DisplayName": "@ondragover",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragover"
           }
         ]
       },
@@ -8292,11 +8127,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragover:preventDefault",
-            "DisplayName": "@ondragover:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragover:preventDefault"
           }
         ]
       },
@@ -8304,11 +8136,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragover:stopPropagation",
-            "DisplayName": "@ondragover:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragover:stopPropagation"
           }
         ]
       }
@@ -8370,10 +8199,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4997880789409733277,
-      "Data2": 4062967912102442479,
-      "Data3": -3274980429523621759,
-      "Data4": 8344879387406235935
+      "Data1": 4122933880334929956,
+      "Data2": -8908183127397875379,
+      "Data3": 516508357497277326,
+      "Data4": -5807166263811845095
     },
     "Kind": "Components.EventHandler",
     "Name": "ondragstart",
@@ -8392,11 +8221,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragstart",
-            "DisplayName": "@ondragstart",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragstart"
           }
         ]
       },
@@ -8404,11 +8230,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragstart:preventDefault",
-            "DisplayName": "@ondragstart:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragstart:preventDefault"
           }
         ]
       },
@@ -8416,11 +8239,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragstart:stopPropagation",
-            "DisplayName": "@ondragstart:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragstart:stopPropagation"
           }
         ]
       }
@@ -8482,10 +8302,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5117519943565302600,
-      "Data2": -282535833899837640,
-      "Data3": -587826129906022188,
-      "Data4": -5186587993067057403
+      "Data1": 37080997944192416,
+      "Data2": 1718280037524681516,
+      "Data3": 4838552461993205165,
+      "Data4": -8358752140866981531
     },
     "Kind": "Components.EventHandler",
     "Name": "ondrop",
@@ -8504,11 +8324,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondrop",
-            "DisplayName": "@ondrop",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondrop"
           }
         ]
       },
@@ -8516,11 +8333,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondrop:preventDefault",
-            "DisplayName": "@ondrop:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondrop:preventDefault"
           }
         ]
       },
@@ -8528,11 +8342,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondrop:stopPropagation",
-            "DisplayName": "@ondrop:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondrop:stopPropagation"
           }
         ]
       }
@@ -8594,10 +8405,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4488320895469629587,
-      "Data2": -4354446904858488124,
-      "Data3": 3476068273635033022,
-      "Data4": -2378627222450335552
+      "Data1": -5695471201493630372,
+      "Data2": 3361071607005196109,
+      "Data3": 8198541436761552517,
+      "Data4": -3725002596021844538
     },
     "Kind": "Components.EventHandler",
     "Name": "onkeydown",
@@ -8616,11 +8427,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onkeydown",
-            "DisplayName": "@onkeydown",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onkeydown"
           }
         ]
       },
@@ -8628,11 +8436,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onkeydown:preventDefault",
-            "DisplayName": "@onkeydown:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onkeydown:preventDefault"
           }
         ]
       },
@@ -8640,11 +8445,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onkeydown:stopPropagation",
-            "DisplayName": "@onkeydown:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onkeydown:stopPropagation"
           }
         ]
       }
@@ -8706,10 +8508,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3065544849487249174,
-      "Data2": 7275382063339441280,
-      "Data3": 4257418289076185769,
-      "Data4": 4650954062822818606
+      "Data1": 4350959430786754746,
+      "Data2": -9078228800772060397,
+      "Data3": 819888687764490586,
+      "Data4": 8535246224647563509
     },
     "Kind": "Components.EventHandler",
     "Name": "onkeyup",
@@ -8728,11 +8530,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onkeyup",
-            "DisplayName": "@onkeyup",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onkeyup"
           }
         ]
       },
@@ -8740,11 +8539,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onkeyup:preventDefault",
-            "DisplayName": "@onkeyup:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onkeyup:preventDefault"
           }
         ]
       },
@@ -8752,11 +8548,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onkeyup:stopPropagation",
-            "DisplayName": "@onkeyup:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onkeyup:stopPropagation"
           }
         ]
       }
@@ -8818,10 +8611,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2684959576086536102,
-      "Data2": -2060164410703761768,
-      "Data3": 6053754243341442598,
-      "Data4": -7692618678005444574
+      "Data1": -725548579405184658,
+      "Data2": -6535506164743575046,
+      "Data3": 8263445445269342667,
+      "Data4": 3172072190528067677
     },
     "Kind": "Components.EventHandler",
     "Name": "onkeypress",
@@ -8840,11 +8633,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onkeypress",
-            "DisplayName": "@onkeypress",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onkeypress"
           }
         ]
       },
@@ -8852,11 +8642,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onkeypress:preventDefault",
-            "DisplayName": "@onkeypress:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onkeypress:preventDefault"
           }
         ]
       },
@@ -8864,11 +8651,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onkeypress:stopPropagation",
-            "DisplayName": "@onkeypress:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onkeypress:stopPropagation"
           }
         ]
       }
@@ -8930,10 +8714,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7584621526987209222,
-      "Data2": 6296633483679274967,
-      "Data3": 4108917095665830259,
-      "Data4": 8728791231176131261
+      "Data1": 2750665642620846827,
+      "Data2": 2379607347507513163,
+      "Data3": 7912531573529910790,
+      "Data4": 1619801212456263377
     },
     "Kind": "Components.EventHandler",
     "Name": "onchange",
@@ -8952,11 +8736,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onchange",
-            "DisplayName": "@onchange",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onchange"
           }
         ]
       },
@@ -8964,11 +8745,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onchange:preventDefault",
-            "DisplayName": "@onchange:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onchange:preventDefault"
           }
         ]
       },
@@ -8976,11 +8754,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onchange:stopPropagation",
-            "DisplayName": "@onchange:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onchange:stopPropagation"
           }
         ]
       }
@@ -9042,10 +8817,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4023366590626973548,
-      "Data2": -4000437393701196393,
-      "Data3": -5453294020141143770,
-      "Data4": -7793400469412774879
+      "Data1": 7956086812437468860,
+      "Data2": 8398666118527217065,
+      "Data3": 1036461523852485843,
+      "Data4": 6957683076048402148
     },
     "Kind": "Components.EventHandler",
     "Name": "oninput",
@@ -9064,11 +8839,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oninput",
-            "DisplayName": "@oninput",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oninput"
           }
         ]
       },
@@ -9076,11 +8848,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oninput:preventDefault",
-            "DisplayName": "@oninput:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oninput:preventDefault"
           }
         ]
       },
@@ -9088,11 +8857,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oninput:stopPropagation",
-            "DisplayName": "@oninput:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oninput:stopPropagation"
           }
         ]
       }
@@ -9154,10 +8920,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5302080963814639005,
-      "Data2": -5382300485274367385,
-      "Data3": 4309544325908333913,
-      "Data4": -8220266761205956267
+      "Data1": 7258253448709741201,
+      "Data2": 59901431278232754,
+      "Data3": 6517522619436310047,
+      "Data4": -2008372240602824646
     },
     "Kind": "Components.EventHandler",
     "Name": "oninvalid",
@@ -9176,11 +8942,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oninvalid",
-            "DisplayName": "@oninvalid",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oninvalid"
           }
         ]
       },
@@ -9188,11 +8951,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oninvalid:preventDefault",
-            "DisplayName": "@oninvalid:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oninvalid:preventDefault"
           }
         ]
       },
@@ -9200,11 +8960,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oninvalid:stopPropagation",
-            "DisplayName": "@oninvalid:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oninvalid:stopPropagation"
           }
         ]
       }
@@ -9266,10 +9023,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8734858102839951686,
-      "Data2": -2347259868355024479,
-      "Data3": 2145930144175565539,
-      "Data4": 6083241797791414271
+      "Data1": 3728761286269864650,
+      "Data2": -7039450577971693787,
+      "Data3": -7575638715751532021,
+      "Data4": -8668345252408510048
     },
     "Kind": "Components.EventHandler",
     "Name": "onreset",
@@ -9288,11 +9045,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onreset",
-            "DisplayName": "@onreset",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onreset"
           }
         ]
       },
@@ -9300,11 +9054,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onreset:preventDefault",
-            "DisplayName": "@onreset:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onreset:preventDefault"
           }
         ]
       },
@@ -9312,11 +9063,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onreset:stopPropagation",
-            "DisplayName": "@onreset:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onreset:stopPropagation"
           }
         ]
       }
@@ -9378,10 +9126,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2088011628329944041,
-      "Data2": -4999546565367881781,
-      "Data3": 7471613055237126019,
-      "Data4": 8330518124309523037
+      "Data1": -3465479507326581212,
+      "Data2": -8546908106230079139,
+      "Data3": -8025354871830854038,
+      "Data4": 4552653405480265278
     },
     "Kind": "Components.EventHandler",
     "Name": "onselect",
@@ -9400,11 +9148,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onselect",
-            "DisplayName": "@onselect",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onselect"
           }
         ]
       },
@@ -9412,11 +9157,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onselect:preventDefault",
-            "DisplayName": "@onselect:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onselect:preventDefault"
           }
         ]
       },
@@ -9424,11 +9166,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onselect:stopPropagation",
-            "DisplayName": "@onselect:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onselect:stopPropagation"
           }
         ]
       }
@@ -9490,10 +9229,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5288273382229968961,
-      "Data2": -42001991506114637,
-      "Data3": -3758671851226525360,
-      "Data4": -7595366435962408260
+      "Data1": -8177842478699745176,
+      "Data2": 6757565716557471835,
+      "Data3": 5630715953478024269,
+      "Data4": 4191274753605657515
     },
     "Kind": "Components.EventHandler",
     "Name": "onselectstart",
@@ -9512,11 +9251,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onselectstart",
-            "DisplayName": "@onselectstart",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onselectstart"
           }
         ]
       },
@@ -9524,11 +9260,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onselectstart:preventDefault",
-            "DisplayName": "@onselectstart:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onselectstart:preventDefault"
           }
         ]
       },
@@ -9536,11 +9269,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onselectstart:stopPropagation",
-            "DisplayName": "@onselectstart:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onselectstart:stopPropagation"
           }
         ]
       }
@@ -9602,10 +9332,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 906694272796350418,
-      "Data2": -9007971882201471679,
-      "Data3": -524300612543727045,
-      "Data4": -3973740341548814289
+      "Data1": 4201710967835402096,
+      "Data2": 914878302245184461,
+      "Data3": 8577859159953483797,
+      "Data4": -5555731126375187004
     },
     "Kind": "Components.EventHandler",
     "Name": "onselectionchange",
@@ -9624,11 +9354,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onselectionchange",
-            "DisplayName": "@onselectionchange",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onselectionchange"
           }
         ]
       },
@@ -9636,11 +9363,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onselectionchange:preventDefault",
-            "DisplayName": "@onselectionchange:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onselectionchange:preventDefault"
           }
         ]
       },
@@ -9648,11 +9372,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onselectionchange:stopPropagation",
-            "DisplayName": "@onselectionchange:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onselectionchange:stopPropagation"
           }
         ]
       }
@@ -9714,10 +9435,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6767276106165310419,
-      "Data2": -5621542771004110853,
-      "Data3": 3866828061693883018,
-      "Data4": 3959111927254083025
+      "Data1": 8845201359840709004,
+      "Data2": 7813685888668420766,
+      "Data3": 9084635839906091490,
+      "Data4": 1072908476906996978
     },
     "Kind": "Components.EventHandler",
     "Name": "onsubmit",
@@ -9736,11 +9457,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onsubmit",
-            "DisplayName": "@onsubmit",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onsubmit"
           }
         ]
       },
@@ -9748,11 +9466,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onsubmit:preventDefault",
-            "DisplayName": "@onsubmit:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onsubmit:preventDefault"
           }
         ]
       },
@@ -9760,11 +9475,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onsubmit:stopPropagation",
-            "DisplayName": "@onsubmit:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onsubmit:stopPropagation"
           }
         ]
       }
@@ -9826,10 +9538,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7962864395333347053,
-      "Data2": -7068272891191157547,
-      "Data3": -8482247690341826270,
-      "Data4": 1177052501507779085
+      "Data1": -2949799726828237617,
+      "Data2": -1454520691929073682,
+      "Data3": 4298676781348239319,
+      "Data4": 2419035598076121131
     },
     "Kind": "Components.EventHandler",
     "Name": "onbeforecopy",
@@ -9848,11 +9560,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforecopy",
-            "DisplayName": "@onbeforecopy",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforecopy"
           }
         ]
       },
@@ -9860,11 +9569,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforecopy:preventDefault",
-            "DisplayName": "@onbeforecopy:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforecopy:preventDefault"
           }
         ]
       },
@@ -9872,11 +9578,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforecopy:stopPropagation",
-            "DisplayName": "@onbeforecopy:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforecopy:stopPropagation"
           }
         ]
       }
@@ -9938,10 +9641,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 733722938788303854,
-      "Data2": 5718205123590306890,
-      "Data3": 4968932478876794348,
-      "Data4": 7931037784533220902
+      "Data1": 3152513784606086920,
+      "Data2": 5365789533721691537,
+      "Data3": 7252192591268789912,
+      "Data4": -6920214444067520753
     },
     "Kind": "Components.EventHandler",
     "Name": "onbeforecut",
@@ -9960,11 +9663,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforecut",
-            "DisplayName": "@onbeforecut",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforecut"
           }
         ]
       },
@@ -9972,11 +9672,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforecut:preventDefault",
-            "DisplayName": "@onbeforecut:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforecut:preventDefault"
           }
         ]
       },
@@ -9984,11 +9681,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforecut:stopPropagation",
-            "DisplayName": "@onbeforecut:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforecut:stopPropagation"
           }
         ]
       }
@@ -10050,10 +9744,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5195515156876521644,
-      "Data2": -83820529944840325,
-      "Data3": 5098380854634285425,
-      "Data4": 2254230579666312180
+      "Data1": -8861496688291646060,
+      "Data2": 2805524358976157285,
+      "Data3": 6374960559609521788,
+      "Data4": 7226537736972539059
     },
     "Kind": "Components.EventHandler",
     "Name": "onbeforepaste",
@@ -10072,11 +9766,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforepaste",
-            "DisplayName": "@onbeforepaste",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforepaste"
           }
         ]
       },
@@ -10084,11 +9775,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforepaste:preventDefault",
-            "DisplayName": "@onbeforepaste:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforepaste:preventDefault"
           }
         ]
       },
@@ -10096,11 +9784,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforepaste:stopPropagation",
-            "DisplayName": "@onbeforepaste:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforepaste:stopPropagation"
           }
         ]
       }
@@ -10162,10 +9847,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5785815391833969144,
-      "Data2": 7426433522232774266,
-      "Data3": 9038206878593963880,
-      "Data4": 3254114237675633096
+      "Data1": -8626848167101745014,
+      "Data2": 3966555281626017056,
+      "Data3": -5951636133072827499,
+      "Data4": 3047801738079777874
     },
     "Kind": "Components.EventHandler",
     "Name": "oncopy",
@@ -10184,11 +9869,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncopy",
-            "DisplayName": "@oncopy",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncopy"
           }
         ]
       },
@@ -10196,11 +9878,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncopy:preventDefault",
-            "DisplayName": "@oncopy:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncopy:preventDefault"
           }
         ]
       },
@@ -10208,11 +9887,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncopy:stopPropagation",
-            "DisplayName": "@oncopy:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncopy:stopPropagation"
           }
         ]
       }
@@ -10274,10 +9950,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2609897972982771624,
-      "Data2": 7922590185429854174,
-      "Data3": -3390296626931518695,
-      "Data4": -2409953976955017726
+      "Data1": -7717909661062912834,
+      "Data2": -1911582831453205076,
+      "Data3": -5753336294880146643,
+      "Data4": 9068395589504098086
     },
     "Kind": "Components.EventHandler",
     "Name": "oncut",
@@ -10296,11 +9972,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncut",
-            "DisplayName": "@oncut",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncut"
           }
         ]
       },
@@ -10308,11 +9981,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncut:preventDefault",
-            "DisplayName": "@oncut:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncut:preventDefault"
           }
         ]
       },
@@ -10320,11 +9990,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncut:stopPropagation",
-            "DisplayName": "@oncut:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncut:stopPropagation"
           }
         ]
       }
@@ -10386,10 +10053,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7376445045194540373,
-      "Data2": -9112356877100429819,
-      "Data3": -2380530598642118551,
-      "Data4": -7873051073718984526
+      "Data1": -834694988918037064,
+      "Data2": 7141015023115209858,
+      "Data3": -8769299413647402344,
+      "Data4": 8771782198266708024
     },
     "Kind": "Components.EventHandler",
     "Name": "onpaste",
@@ -10408,11 +10075,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpaste",
-            "DisplayName": "@onpaste",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpaste"
           }
         ]
       },
@@ -10420,11 +10084,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpaste:preventDefault",
-            "DisplayName": "@onpaste:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpaste:preventDefault"
           }
         ]
       },
@@ -10432,11 +10093,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpaste:stopPropagation",
-            "DisplayName": "@onpaste:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpaste:stopPropagation"
           }
         ]
       }
@@ -10498,10 +10156,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5056866497218561842,
-      "Data2": 4051360251600008758,
-      "Data3": -1883731599349537376,
-      "Data4": 5490887723705191254
+      "Data1": 1887899279637686951,
+      "Data2": -4526926489206940881,
+      "Data3": -8927258063520387995,
+      "Data4": -4783537552387912745
     },
     "Kind": "Components.EventHandler",
     "Name": "ontouchcancel",
@@ -10520,11 +10178,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchcancel",
-            "DisplayName": "@ontouchcancel",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchcancel"
           }
         ]
       },
@@ -10532,11 +10187,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchcancel:preventDefault",
-            "DisplayName": "@ontouchcancel:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchcancel:preventDefault"
           }
         ]
       },
@@ -10544,11 +10196,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchcancel:stopPropagation",
-            "DisplayName": "@ontouchcancel:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchcancel:stopPropagation"
           }
         ]
       }
@@ -10610,10 +10259,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4280006762647084968,
-      "Data2": 4784687432975891540,
-      "Data3": -2610726941771164358,
-      "Data4": 9101273155625600638
+      "Data1": 8560639872540961780,
+      "Data2": -3269456626971729916,
+      "Data3": -8590133097090199829,
+      "Data4": 515289147762243151
     },
     "Kind": "Components.EventHandler",
     "Name": "ontouchend",
@@ -10632,11 +10281,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchend",
-            "DisplayName": "@ontouchend",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchend"
           }
         ]
       },
@@ -10644,11 +10290,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchend:preventDefault",
-            "DisplayName": "@ontouchend:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchend:preventDefault"
           }
         ]
       },
@@ -10656,11 +10299,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchend:stopPropagation",
-            "DisplayName": "@ontouchend:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchend:stopPropagation"
           }
         ]
       }
@@ -10722,10 +10362,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4150334943984926387,
-      "Data2": -1730547721487666194,
-      "Data3": 5915207751029640734,
-      "Data4": 2626361866656274122
+      "Data1": -5904773329601617829,
+      "Data2": 8887450734407251845,
+      "Data3": -4466800216474584719,
+      "Data4": -2492459147247230080
     },
     "Kind": "Components.EventHandler",
     "Name": "ontouchmove",
@@ -10744,11 +10384,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchmove",
-            "DisplayName": "@ontouchmove",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchmove"
           }
         ]
       },
@@ -10756,11 +10393,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchmove:preventDefault",
-            "DisplayName": "@ontouchmove:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchmove:preventDefault"
           }
         ]
       },
@@ -10768,11 +10402,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchmove:stopPropagation",
-            "DisplayName": "@ontouchmove:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchmove:stopPropagation"
           }
         ]
       }
@@ -10834,10 +10465,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1471835487647021681,
-      "Data2": -1804324470531860128,
-      "Data3": -4436570376778556838,
-      "Data4": 6623868717126983394
+      "Data1": -5095158942688265405,
+      "Data2": -950867729521133715,
+      "Data3": -2618960688732805155,
+      "Data4": -3315152510855737936
     },
     "Kind": "Components.EventHandler",
     "Name": "ontouchstart",
@@ -10856,11 +10487,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchstart",
-            "DisplayName": "@ontouchstart",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchstart"
           }
         ]
       },
@@ -10868,11 +10496,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchstart:preventDefault",
-            "DisplayName": "@ontouchstart:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchstart:preventDefault"
           }
         ]
       },
@@ -10880,11 +10505,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchstart:stopPropagation",
-            "DisplayName": "@ontouchstart:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchstart:stopPropagation"
           }
         ]
       }
@@ -10946,10 +10568,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7460631154571318862,
-      "Data2": -2424658594096228664,
-      "Data3": -8924327641613131363,
-      "Data4": 7709986489448240830
+      "Data1": -2478831531341165059,
+      "Data2": 5659782789634069521,
+      "Data3": -3025440267621218215,
+      "Data4": 1269289870381824840
     },
     "Kind": "Components.EventHandler",
     "Name": "ontouchenter",
@@ -10968,11 +10590,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchenter",
-            "DisplayName": "@ontouchenter",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchenter"
           }
         ]
       },
@@ -10980,11 +10599,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchenter:preventDefault",
-            "DisplayName": "@ontouchenter:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchenter:preventDefault"
           }
         ]
       },
@@ -10992,11 +10608,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchenter:stopPropagation",
-            "DisplayName": "@ontouchenter:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchenter:stopPropagation"
           }
         ]
       }
@@ -11058,10 +10671,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1206477914866130555,
-      "Data2": -827543412384579740,
-      "Data3": 5664104254253767115,
-      "Data4": 1325744795667415854
+      "Data1": -1815806742509291223,
+      "Data2": 5212591657949041317,
+      "Data3": -1480415875989112825,
+      "Data4": 3256266571010234631
     },
     "Kind": "Components.EventHandler",
     "Name": "ontouchleave",
@@ -11080,11 +10693,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchleave",
-            "DisplayName": "@ontouchleave",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchleave"
           }
         ]
       },
@@ -11092,11 +10702,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchleave:preventDefault",
-            "DisplayName": "@ontouchleave:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchleave:preventDefault"
           }
         ]
       },
@@ -11104,11 +10711,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchleave:stopPropagation",
-            "DisplayName": "@ontouchleave:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchleave:stopPropagation"
           }
         ]
       }
@@ -11170,10 +10774,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5071805037143667245,
-      "Data2": 2784887102994723699,
-      "Data3": -5821858542529465344,
-      "Data4": -6075492442609413063
+      "Data1": 5672967777770031425,
+      "Data2": -376566120727816777,
+      "Data3": 2268642067837911846,
+      "Data4": 2392712752812117270
     },
     "Kind": "Components.EventHandler",
     "Name": "ongotpointercapture",
@@ -11192,11 +10796,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ongotpointercapture",
-            "DisplayName": "@ongotpointercapture",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ongotpointercapture"
           }
         ]
       },
@@ -11204,11 +10805,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ongotpointercapture:preventDefault",
-            "DisplayName": "@ongotpointercapture:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ongotpointercapture:preventDefault"
           }
         ]
       },
@@ -11216,11 +10814,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ongotpointercapture:stopPropagation",
-            "DisplayName": "@ongotpointercapture:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ongotpointercapture:stopPropagation"
           }
         ]
       }
@@ -11282,10 +10877,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4234935237194607603,
-      "Data2": 4666086240833797740,
-      "Data3": -8190592873098651197,
-      "Data4": 4815966663442635767
+      "Data1": 3028730947464123862,
+      "Data2": -8540430467318665965,
+      "Data3": 9781937082342472,
+      "Data4": -581478029785154891
     },
     "Kind": "Components.EventHandler",
     "Name": "onlostpointercapture",
@@ -11304,11 +10899,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onlostpointercapture",
-            "DisplayName": "@onlostpointercapture",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onlostpointercapture"
           }
         ]
       },
@@ -11316,11 +10908,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onlostpointercapture:preventDefault",
-            "DisplayName": "@onlostpointercapture:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onlostpointercapture:preventDefault"
           }
         ]
       },
@@ -11328,11 +10917,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onlostpointercapture:stopPropagation",
-            "DisplayName": "@onlostpointercapture:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onlostpointercapture:stopPropagation"
           }
         ]
       }
@@ -11394,10 +10980,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1501806557496147984,
-      "Data2": 8800865181144088021,
-      "Data3": 7245324866050579704,
-      "Data4": 4143059404539196834
+      "Data1": 7845628483365683860,
+      "Data2": -5913790109310439740,
+      "Data3": -8720446747065225516,
+      "Data4": 1929662876628459636
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointercancel",
@@ -11416,11 +11002,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointercancel",
-            "DisplayName": "@onpointercancel",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointercancel"
           }
         ]
       },
@@ -11428,11 +11011,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointercancel:preventDefault",
-            "DisplayName": "@onpointercancel:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointercancel:preventDefault"
           }
         ]
       },
@@ -11440,11 +11020,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointercancel:stopPropagation",
-            "DisplayName": "@onpointercancel:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointercancel:stopPropagation"
           }
         ]
       }
@@ -11506,10 +11083,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7021801142064366064,
-      "Data2": 4913943734187142819,
-      "Data3": 5353043824189147667,
-      "Data4": -5986691567274862652
+      "Data1": -216707529035281372,
+      "Data2": -3117341644638562078,
+      "Data3": -4183753490145480877,
+      "Data4": 1472509256766718844
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointerdown",
@@ -11528,11 +11105,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerdown",
-            "DisplayName": "@onpointerdown",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerdown"
           }
         ]
       },
@@ -11540,11 +11114,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerdown:preventDefault",
-            "DisplayName": "@onpointerdown:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerdown:preventDefault"
           }
         ]
       },
@@ -11552,11 +11123,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerdown:stopPropagation",
-            "DisplayName": "@onpointerdown:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerdown:stopPropagation"
           }
         ]
       }
@@ -11618,10 +11186,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6482496106735241507,
-      "Data2": -5632006137845861053,
-      "Data3": -5902478731819820985,
-      "Data4": -4861547872203913897
+      "Data1": 2260637205253726152,
+      "Data2": -8060130148801738811,
+      "Data3": 646199905011539017,
+      "Data4": -7865235666950476596
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointerenter",
@@ -11640,11 +11208,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerenter",
-            "DisplayName": "@onpointerenter",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerenter"
           }
         ]
       },
@@ -11652,11 +11217,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerenter:preventDefault",
-            "DisplayName": "@onpointerenter:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerenter:preventDefault"
           }
         ]
       },
@@ -11664,11 +11226,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerenter:stopPropagation",
-            "DisplayName": "@onpointerenter:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerenter:stopPropagation"
           }
         ]
       }
@@ -11730,10 +11289,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2362876619405756834,
-      "Data2": 1690387501013985772,
-      "Data3": 6018500545669392927,
-      "Data4": 6825138873003342529
+      "Data1": 4184583511621321741,
+      "Data2": -6857794456245992267,
+      "Data3": 8553662770336563648,
+      "Data4": 1609561285393407441
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointerleave",
@@ -11752,11 +11311,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerleave",
-            "DisplayName": "@onpointerleave",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerleave"
           }
         ]
       },
@@ -11764,11 +11320,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerleave:preventDefault",
-            "DisplayName": "@onpointerleave:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerleave:preventDefault"
           }
         ]
       },
@@ -11776,11 +11329,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerleave:stopPropagation",
-            "DisplayName": "@onpointerleave:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerleave:stopPropagation"
           }
         ]
       }
@@ -11842,10 +11392,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8413602580205111867,
-      "Data2": -5700767381511039156,
-      "Data3": -298499902154277031,
-      "Data4": -1971877250491053743
+      "Data1": 2933060349965538891,
+      "Data2": -86443873687553606,
+      "Data3": -6969305787118913496,
+      "Data4": -5820738653097049369
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointermove",
@@ -11864,11 +11414,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointermove",
-            "DisplayName": "@onpointermove",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointermove"
           }
         ]
       },
@@ -11876,11 +11423,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointermove:preventDefault",
-            "DisplayName": "@onpointermove:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointermove:preventDefault"
           }
         ]
       },
@@ -11888,11 +11432,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointermove:stopPropagation",
-            "DisplayName": "@onpointermove:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointermove:stopPropagation"
           }
         ]
       }
@@ -11954,10 +11495,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2144864367700287499,
-      "Data2": 4423494774394580856,
-      "Data3": -8162909701359617749,
-      "Data4": -1934638848813298266
+      "Data1": -9205787528656567433,
+      "Data2": -3947676511011768939,
+      "Data3": 117079125349801751,
+      "Data4": 3683354846131714950
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointerout",
@@ -11976,11 +11517,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerout",
-            "DisplayName": "@onpointerout",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerout"
           }
         ]
       },
@@ -11988,11 +11526,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerout:preventDefault",
-            "DisplayName": "@onpointerout:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerout:preventDefault"
           }
         ]
       },
@@ -12000,11 +11535,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerout:stopPropagation",
-            "DisplayName": "@onpointerout:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerout:stopPropagation"
           }
         ]
       }
@@ -12066,10 +11598,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4832915731373040927,
-      "Data2": -3645379124209717938,
-      "Data3": 5090595826452547610,
-      "Data4": -5721662004122803061
+      "Data1": 8818214489996007175,
+      "Data2": -4925138631425293750,
+      "Data3": -1480114291692531514,
+      "Data4": -6337142051836672460
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointerover",
@@ -12088,11 +11620,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerover",
-            "DisplayName": "@onpointerover",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerover"
           }
         ]
       },
@@ -12100,11 +11629,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerover:preventDefault",
-            "DisplayName": "@onpointerover:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerover:preventDefault"
           }
         ]
       },
@@ -12112,11 +11638,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerover:stopPropagation",
-            "DisplayName": "@onpointerover:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerover:stopPropagation"
           }
         ]
       }
@@ -12178,10 +11701,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6602855428127841735,
-      "Data2": -6959804828078026469,
-      "Data3": 3921474775593284583,
-      "Data4": -579299129316613531
+      "Data1": -908745030288218206,
+      "Data2": -8680826874224246041,
+      "Data3": -7295190511835496782,
+      "Data4": 5785409659034269360
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointerup",
@@ -12200,11 +11723,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerup",
-            "DisplayName": "@onpointerup",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerup"
           }
         ]
       },
@@ -12212,11 +11732,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerup:preventDefault",
-            "DisplayName": "@onpointerup:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerup:preventDefault"
           }
         ]
       },
@@ -12224,11 +11741,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerup:stopPropagation",
-            "DisplayName": "@onpointerup:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerup:stopPropagation"
           }
         ]
       }
@@ -12290,10 +11804,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8517356995865596965,
-      "Data2": -992787950199641001,
-      "Data3": 8023591749468715182,
-      "Data4": -477094535197733868
+      "Data1": 597509705648306802,
+      "Data2": -1009920724167413106,
+      "Data3": -232780640317493311,
+      "Data4": 6014844300002998195
     },
     "Kind": "Components.EventHandler",
     "Name": "oncanplay",
@@ -12312,11 +11826,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncanplay",
-            "DisplayName": "@oncanplay",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncanplay"
           }
         ]
       },
@@ -12324,11 +11835,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncanplay:preventDefault",
-            "DisplayName": "@oncanplay:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncanplay:preventDefault"
           }
         ]
       },
@@ -12336,11 +11844,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncanplay:stopPropagation",
-            "DisplayName": "@oncanplay:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncanplay:stopPropagation"
           }
         ]
       }
@@ -12402,10 +11907,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4629118218007658177,
-      "Data2": -7241108023393395784,
-      "Data3": 3229008464593641698,
-      "Data4": -5784998754638029759
+      "Data1": 1563749393086200965,
+      "Data2": 2050836795833668873,
+      "Data3": -989381319795094955,
+      "Data4": -1524232521253519084
     },
     "Kind": "Components.EventHandler",
     "Name": "oncanplaythrough",
@@ -12424,11 +11929,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncanplaythrough",
-            "DisplayName": "@oncanplaythrough",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncanplaythrough"
           }
         ]
       },
@@ -12436,11 +11938,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncanplaythrough:preventDefault",
-            "DisplayName": "@oncanplaythrough:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncanplaythrough:preventDefault"
           }
         ]
       },
@@ -12448,11 +11947,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncanplaythrough:stopPropagation",
-            "DisplayName": "@oncanplaythrough:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncanplaythrough:stopPropagation"
           }
         ]
       }
@@ -12514,10 +12010,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5707088807687139046,
-      "Data2": -3539020173421035295,
-      "Data3": 5998176378940967845,
-      "Data4": -8845294488404047632
+      "Data1": 5625767768405582002,
+      "Data2": 24896169926263381,
+      "Data3": -4842676361291035700,
+      "Data4": 9165536465751222767
     },
     "Kind": "Components.EventHandler",
     "Name": "oncuechange",
@@ -12536,11 +12032,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncuechange",
-            "DisplayName": "@oncuechange",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncuechange"
           }
         ]
       },
@@ -12548,11 +12041,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncuechange:preventDefault",
-            "DisplayName": "@oncuechange:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncuechange:preventDefault"
           }
         ]
       },
@@ -12560,11 +12050,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncuechange:stopPropagation",
-            "DisplayName": "@oncuechange:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncuechange:stopPropagation"
           }
         ]
       }
@@ -12626,10 +12113,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1788598345103024084,
-      "Data2": -682840718304328422,
-      "Data3": -5710148236194371533,
-      "Data4": 7470660248046215027
+      "Data1": -1197712727938784758,
+      "Data2": 3087824575286214565,
+      "Data3": 1141678722384107854,
+      "Data4": -947572748547100552
     },
     "Kind": "Components.EventHandler",
     "Name": "ondurationchange",
@@ -12648,11 +12135,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondurationchange",
-            "DisplayName": "@ondurationchange",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondurationchange"
           }
         ]
       },
@@ -12660,11 +12144,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondurationchange:preventDefault",
-            "DisplayName": "@ondurationchange:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondurationchange:preventDefault"
           }
         ]
       },
@@ -12672,11 +12153,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondurationchange:stopPropagation",
-            "DisplayName": "@ondurationchange:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondurationchange:stopPropagation"
           }
         ]
       }
@@ -12738,10 +12216,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3625429067103254419,
-      "Data2": 4539422050649057828,
-      "Data3": -7631501157482005911,
-      "Data4": 4204638230042759551
+      "Data1": 2110307085623062660,
+      "Data2": 3704942906086902591,
+      "Data3": -3549841174821185962,
+      "Data4": 7224247509302026181
     },
     "Kind": "Components.EventHandler",
     "Name": "onemptied",
@@ -12760,11 +12238,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onemptied",
-            "DisplayName": "@onemptied",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onemptied"
           }
         ]
       },
@@ -12772,11 +12247,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onemptied:preventDefault",
-            "DisplayName": "@onemptied:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onemptied:preventDefault"
           }
         ]
       },
@@ -12784,11 +12256,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onemptied:stopPropagation",
-            "DisplayName": "@onemptied:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onemptied:stopPropagation"
           }
         ]
       }
@@ -12850,10 +12319,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -9146971396433179074,
-      "Data2": -5282983060336594145,
-      "Data3": -4779369206026873005,
-      "Data4": -94348007343300824
+      "Data1": -2812702189194482510,
+      "Data2": 8719419989612082587,
+      "Data3": -8130085253735277928,
+      "Data4": 8437591615263849664
     },
     "Kind": "Components.EventHandler",
     "Name": "onpause",
@@ -12872,11 +12341,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpause",
-            "DisplayName": "@onpause",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpause"
           }
         ]
       },
@@ -12884,11 +12350,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpause:preventDefault",
-            "DisplayName": "@onpause:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpause:preventDefault"
           }
         ]
       },
@@ -12896,11 +12359,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpause:stopPropagation",
-            "DisplayName": "@onpause:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpause:stopPropagation"
           }
         ]
       }
@@ -12962,10 +12422,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1059137068162022950,
-      "Data2": -4215602002842057386,
-      "Data3": 6301567405147335341,
-      "Data4": 4696929276391390537
+      "Data1": -6799031362624936639,
+      "Data2": 8315715059813277310,
+      "Data3": 5310514860263637462,
+      "Data4": 6858095182633393517
     },
     "Kind": "Components.EventHandler",
     "Name": "onplay",
@@ -12984,11 +12444,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onplay",
-            "DisplayName": "@onplay",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onplay"
           }
         ]
       },
@@ -12996,11 +12453,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onplay:preventDefault",
-            "DisplayName": "@onplay:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onplay:preventDefault"
           }
         ]
       },
@@ -13008,11 +12462,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onplay:stopPropagation",
-            "DisplayName": "@onplay:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onplay:stopPropagation"
           }
         ]
       }
@@ -13074,10 +12525,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5784475203072407219,
-      "Data2": 2860983261650190928,
-      "Data3": 631687845329009811,
-      "Data4": -5326089256190954983
+      "Data1": 456177832137915634,
+      "Data2": 4112037173566234524,
+      "Data3": 8022027208429988491,
+      "Data4": 3949024042815656355
     },
     "Kind": "Components.EventHandler",
     "Name": "onplaying",
@@ -13096,11 +12547,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onplaying",
-            "DisplayName": "@onplaying",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onplaying"
           }
         ]
       },
@@ -13108,11 +12556,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onplaying:preventDefault",
-            "DisplayName": "@onplaying:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onplaying:preventDefault"
           }
         ]
       },
@@ -13120,11 +12565,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onplaying:stopPropagation",
-            "DisplayName": "@onplaying:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onplaying:stopPropagation"
           }
         ]
       }
@@ -13186,10 +12628,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1968719276996210829,
-      "Data2": -4888372353790097486,
-      "Data3": -384622165291078470,
-      "Data4": 4454151101341103385
+      "Data1": 1793539141473295205,
+      "Data2": 7272299608771447969,
+      "Data3": 1240226868090028358,
+      "Data4": 409595658957971928
     },
     "Kind": "Components.EventHandler",
     "Name": "onratechange",
@@ -13208,11 +12650,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onratechange",
-            "DisplayName": "@onratechange",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onratechange"
           }
         ]
       },
@@ -13220,11 +12659,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onratechange:preventDefault",
-            "DisplayName": "@onratechange:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onratechange:preventDefault"
           }
         ]
       },
@@ -13232,11 +12668,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onratechange:stopPropagation",
-            "DisplayName": "@onratechange:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onratechange:stopPropagation"
           }
         ]
       }
@@ -13298,10 +12731,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5575277420642292460,
-      "Data2": 4804308430389093007,
-      "Data3": 3918461850642287482,
-      "Data4": 5057274518924628615
+      "Data1": -6298640516333693293,
+      "Data2": 165284671843731667,
+      "Data3": 7038747940179385231,
+      "Data4": 8533269373292519771
     },
     "Kind": "Components.EventHandler",
     "Name": "onseeked",
@@ -13320,11 +12753,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onseeked",
-            "DisplayName": "@onseeked",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onseeked"
           }
         ]
       },
@@ -13332,11 +12762,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onseeked:preventDefault",
-            "DisplayName": "@onseeked:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onseeked:preventDefault"
           }
         ]
       },
@@ -13344,11 +12771,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onseeked:stopPropagation",
-            "DisplayName": "@onseeked:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onseeked:stopPropagation"
           }
         ]
       }
@@ -13410,10 +12834,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5063494710674516762,
-      "Data2": 7410013601124139843,
-      "Data3": -583553163367105336,
-      "Data4": 3213876888019643959
+      "Data1": 4371224297912146233,
+      "Data2": 662981942941723474,
+      "Data3": 4068827719627220507,
+      "Data4": 4262271680669633938
     },
     "Kind": "Components.EventHandler",
     "Name": "onseeking",
@@ -13432,11 +12856,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onseeking",
-            "DisplayName": "@onseeking",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onseeking"
           }
         ]
       },
@@ -13444,11 +12865,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onseeking:preventDefault",
-            "DisplayName": "@onseeking:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onseeking:preventDefault"
           }
         ]
       },
@@ -13456,11 +12874,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onseeking:stopPropagation",
-            "DisplayName": "@onseeking:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onseeking:stopPropagation"
           }
         ]
       }
@@ -13522,10 +12937,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6084103135700216292,
-      "Data2": 6429144624448735926,
-      "Data3": -8281887254098985812,
-      "Data4": -2690585504040709743
+      "Data1": 8418522423022648744,
+      "Data2": -5553550722435554854,
+      "Data3": -6887005598565493503,
+      "Data4": 5539966644246142070
     },
     "Kind": "Components.EventHandler",
     "Name": "onstalled",
@@ -13544,11 +12959,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onstalled",
-            "DisplayName": "@onstalled",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onstalled"
           }
         ]
       },
@@ -13556,11 +12968,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onstalled:preventDefault",
-            "DisplayName": "@onstalled:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onstalled:preventDefault"
           }
         ]
       },
@@ -13568,11 +12977,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onstalled:stopPropagation",
-            "DisplayName": "@onstalled:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onstalled:stopPropagation"
           }
         ]
       }
@@ -13634,10 +13040,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 246405243843322072,
-      "Data2": -8822349407240274097,
-      "Data3": -80538699882916434,
-      "Data4": 1570202605183528156
+      "Data1": 6375862742289006475,
+      "Data2": 4196488797078149107,
+      "Data3": 6985120193522486216,
+      "Data4": -354156214012934039
     },
     "Kind": "Components.EventHandler",
     "Name": "onstop",
@@ -13656,11 +13062,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onstop",
-            "DisplayName": "@onstop",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onstop"
           }
         ]
       },
@@ -13668,11 +13071,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onstop:preventDefault",
-            "DisplayName": "@onstop:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onstop:preventDefault"
           }
         ]
       },
@@ -13680,11 +13080,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onstop:stopPropagation",
-            "DisplayName": "@onstop:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onstop:stopPropagation"
           }
         ]
       }
@@ -13746,10 +13143,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 293528524221976117,
-      "Data2": -3366951729747817650,
-      "Data3": -5475163449206969678,
-      "Data4": 3690320208582785874
+      "Data1": 7139603334329658168,
+      "Data2": 7050470994770810191,
+      "Data3": 995373201037867242,
+      "Data4": 7534379394298243389
     },
     "Kind": "Components.EventHandler",
     "Name": "onsuspend",
@@ -13768,11 +13165,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onsuspend",
-            "DisplayName": "@onsuspend",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onsuspend"
           }
         ]
       },
@@ -13780,11 +13174,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onsuspend:preventDefault",
-            "DisplayName": "@onsuspend:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onsuspend:preventDefault"
           }
         ]
       },
@@ -13792,11 +13183,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onsuspend:stopPropagation",
-            "DisplayName": "@onsuspend:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onsuspend:stopPropagation"
           }
         ]
       }
@@ -13858,10 +13246,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 305507146321625271,
-      "Data2": 7173741238827226407,
-      "Data3": -1333007376625119472,
-      "Data4": -3143059708732953577
+      "Data1": -1561969976401522850,
+      "Data2": -1455625447617632445,
+      "Data3": -7956498546583677365,
+      "Data4": -3432426082148839000
     },
     "Kind": "Components.EventHandler",
     "Name": "ontimeupdate",
@@ -13880,11 +13268,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontimeupdate",
-            "DisplayName": "@ontimeupdate",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontimeupdate"
           }
         ]
       },
@@ -13892,11 +13277,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontimeupdate:preventDefault",
-            "DisplayName": "@ontimeupdate:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontimeupdate:preventDefault"
           }
         ]
       },
@@ -13904,11 +13286,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontimeupdate:stopPropagation",
-            "DisplayName": "@ontimeupdate:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontimeupdate:stopPropagation"
           }
         ]
       }
@@ -13970,10 +13349,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1832092438189817910,
-      "Data2": -4154991746732791329,
-      "Data3": 976892343367997206,
-      "Data4": 45633615304561987
+      "Data1": -2724374662765077754,
+      "Data2": -6142356503895085930,
+      "Data3": 866855408181259060,
+      "Data4": 6313757166293681300
     },
     "Kind": "Components.EventHandler",
     "Name": "onvolumechange",
@@ -13992,11 +13371,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onvolumechange",
-            "DisplayName": "@onvolumechange",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onvolumechange"
           }
         ]
       },
@@ -14004,11 +13380,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onvolumechange:preventDefault",
-            "DisplayName": "@onvolumechange:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onvolumechange:preventDefault"
           }
         ]
       },
@@ -14016,11 +13389,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onvolumechange:stopPropagation",
-            "DisplayName": "@onvolumechange:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onvolumechange:stopPropagation"
           }
         ]
       }
@@ -14082,10 +13452,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6993783120374000756,
-      "Data2": 5847247330045731879,
-      "Data3": -7208229469270431962,
-      "Data4": -7864315108729487104
+      "Data1": -3914619019929869581,
+      "Data2": 7588497898572274612,
+      "Data3": -1748436399065574566,
+      "Data4": 873247220543938061
     },
     "Kind": "Components.EventHandler",
     "Name": "onwaiting",
@@ -14104,11 +13474,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onwaiting",
-            "DisplayName": "@onwaiting",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onwaiting"
           }
         ]
       },
@@ -14116,11 +13483,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onwaiting:preventDefault",
-            "DisplayName": "@onwaiting:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onwaiting:preventDefault"
           }
         ]
       },
@@ -14128,11 +13492,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onwaiting:stopPropagation",
-            "DisplayName": "@onwaiting:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onwaiting:stopPropagation"
           }
         ]
       }
@@ -14194,10 +13555,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6285200834579135833,
-      "Data2": 2035732230181430265,
-      "Data3": 3609790375995416568,
-      "Data4": -6613225275514344390
+      "Data1": 3003709538961851823,
+      "Data2": -539286278510220104,
+      "Data3": -5783511530780800957,
+      "Data4": 5791659915024644696
     },
     "Kind": "Components.EventHandler",
     "Name": "onloadstart",
@@ -14216,11 +13577,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onloadstart",
-            "DisplayName": "@onloadstart",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onloadstart"
           }
         ]
       },
@@ -14228,11 +13586,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onloadstart:preventDefault",
-            "DisplayName": "@onloadstart:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onloadstart:preventDefault"
           }
         ]
       },
@@ -14240,11 +13595,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onloadstart:stopPropagation",
-            "DisplayName": "@onloadstart:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onloadstart:stopPropagation"
           }
         ]
       }
@@ -14306,10 +13658,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1694150034442696923,
-      "Data2": 1069671084818358101,
-      "Data3": -3214492484340375293,
-      "Data4": -1326598221796717690
+      "Data1": 6557012966266168103,
+      "Data2": -5085191965710100207,
+      "Data3": -8692537269468653783,
+      "Data4": -2369578530952739569
     },
     "Kind": "Components.EventHandler",
     "Name": "ontimeout",
@@ -14328,11 +13680,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontimeout",
-            "DisplayName": "@ontimeout",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontimeout"
           }
         ]
       },
@@ -14340,11 +13689,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontimeout:preventDefault",
-            "DisplayName": "@ontimeout:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontimeout:preventDefault"
           }
         ]
       },
@@ -14352,11 +13698,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontimeout:stopPropagation",
-            "DisplayName": "@ontimeout:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontimeout:stopPropagation"
           }
         ]
       }
@@ -14418,10 +13761,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2380563678566474524,
-      "Data2": -1136715120141684409,
-      "Data3": -1984682432189711320,
-      "Data4": 2062459213259058505
+      "Data1": 1023908298817455823,
+      "Data2": 4392461925726520032,
+      "Data3": -1926208243144249774,
+      "Data4": 1006149178022971635
     },
     "Kind": "Components.EventHandler",
     "Name": "onabort",
@@ -14440,11 +13783,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onabort",
-            "DisplayName": "@onabort",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onabort"
           }
         ]
       },
@@ -14452,11 +13792,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onabort:preventDefault",
-            "DisplayName": "@onabort:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onabort:preventDefault"
           }
         ]
       },
@@ -14464,11 +13801,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onabort:stopPropagation",
-            "DisplayName": "@onabort:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onabort:stopPropagation"
           }
         ]
       }
@@ -14530,10 +13864,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1893109679458908558,
-      "Data2": -7955171739830713350,
-      "Data3": -7143377721943900835,
-      "Data4": -2818643425800890408
+      "Data1": -7936914368769015974,
+      "Data2": -761830969525665011,
+      "Data3": -5637698390404798419,
+      "Data4": 3158476541407622483
     },
     "Kind": "Components.EventHandler",
     "Name": "onload",
@@ -14552,11 +13886,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onload",
-            "DisplayName": "@onload",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onload"
           }
         ]
       },
@@ -14564,11 +13895,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onload:preventDefault",
-            "DisplayName": "@onload:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onload:preventDefault"
           }
         ]
       },
@@ -14576,11 +13904,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onload:stopPropagation",
-            "DisplayName": "@onload:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onload:stopPropagation"
           }
         ]
       }
@@ -14642,10 +13967,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1773103568781512608,
-      "Data2": -5445138843615588881,
-      "Data3": -6756415198543367473,
-      "Data4": 1971274505118157439
+      "Data1": 321798331866738642,
+      "Data2": -3698458883468328747,
+      "Data3": 9010524984050329064,
+      "Data4": -1376137053268627041
     },
     "Kind": "Components.EventHandler",
     "Name": "onloadend",
@@ -14664,11 +13989,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onloadend",
-            "DisplayName": "@onloadend",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onloadend"
           }
         ]
       },
@@ -14676,11 +13998,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onloadend:preventDefault",
-            "DisplayName": "@onloadend:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onloadend:preventDefault"
           }
         ]
       },
@@ -14688,11 +14007,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onloadend:stopPropagation",
-            "DisplayName": "@onloadend:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onloadend:stopPropagation"
           }
         ]
       }
@@ -14754,10 +14070,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1761524245764503792,
-      "Data2": -5978964798168000293,
-      "Data3": 9011375316736691779,
-      "Data4": -441653473004576
+      "Data1": -938823542195163838,
+      "Data2": 2132861549125267032,
+      "Data3": 9197470792389970000,
+      "Data4": 5489250089869939875
     },
     "Kind": "Components.EventHandler",
     "Name": "onprogress",
@@ -14776,11 +14092,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onprogress",
-            "DisplayName": "@onprogress",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onprogress"
           }
         ]
       },
@@ -14788,11 +14101,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onprogress:preventDefault",
-            "DisplayName": "@onprogress:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onprogress:preventDefault"
           }
         ]
       },
@@ -14800,11 +14110,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onprogress:stopPropagation",
-            "DisplayName": "@onprogress:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onprogress:stopPropagation"
           }
         ]
       }
@@ -14866,10 +14173,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6760573744222223865,
-      "Data2": -3878583513165488469,
-      "Data3": 4521116122300886525,
-      "Data4": 2947477448943339481
+      "Data1": 2321159976019710224,
+      "Data2": -6090944940594085609,
+      "Data3": -1479546888462106019,
+      "Data4": -4991408080709265856
     },
     "Kind": "Components.EventHandler",
     "Name": "onerror",
@@ -14888,11 +14195,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onerror",
-            "DisplayName": "@onerror",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onerror"
           }
         ]
       },
@@ -14900,11 +14204,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onerror:preventDefault",
-            "DisplayName": "@onerror:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onerror:preventDefault"
           }
         ]
       },
@@ -14912,11 +14213,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onerror:stopPropagation",
-            "DisplayName": "@onerror:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onerror:stopPropagation"
           }
         ]
       }
@@ -14978,10 +14276,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7664205254589202189,
-      "Data2": -3453900203848537869,
-      "Data3": 5381695674163240261,
-      "Data4": 5140689584628676755
+      "Data1": 1407749156939258083,
+      "Data2": 4173151636267777169,
+      "Data3": 1730232655422234376,
+      "Data4": 61305051789758759
     },
     "Kind": "Components.EventHandler",
     "Name": "onactivate",
@@ -15000,11 +14298,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onactivate",
-            "DisplayName": "@onactivate",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onactivate"
           }
         ]
       },
@@ -15012,11 +14307,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onactivate:preventDefault",
-            "DisplayName": "@onactivate:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onactivate:preventDefault"
           }
         ]
       },
@@ -15024,11 +14316,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onactivate:stopPropagation",
-            "DisplayName": "@onactivate:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onactivate:stopPropagation"
           }
         ]
       }
@@ -15090,10 +14379,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1693746754447189996,
-      "Data2": -4305422666207016239,
-      "Data3": 3716145686732648141,
-      "Data4": -1211307605170481463
+      "Data1": 4188604919184013268,
+      "Data2": 8925582915854504166,
+      "Data3": -6904130197990754686,
+      "Data4": 8864247796775754578
     },
     "Kind": "Components.EventHandler",
     "Name": "onbeforeactivate",
@@ -15112,11 +14401,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforeactivate",
-            "DisplayName": "@onbeforeactivate",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforeactivate"
           }
         ]
       },
@@ -15124,11 +14410,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforeactivate:preventDefault",
-            "DisplayName": "@onbeforeactivate:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforeactivate:preventDefault"
           }
         ]
       },
@@ -15136,11 +14419,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforeactivate:stopPropagation",
-            "DisplayName": "@onbeforeactivate:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforeactivate:stopPropagation"
           }
         ]
       }
@@ -15202,10 +14482,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1312066357581846522,
-      "Data2": -6727246692053051819,
-      "Data3": 6349367685571933293,
-      "Data4": -5989922618684855487
+      "Data1": -3368900116442162642,
+      "Data2": -4008618755236315614,
+      "Data3": -8892547446402454463,
+      "Data4": -4738690517919174922
     },
     "Kind": "Components.EventHandler",
     "Name": "onbeforedeactivate",
@@ -15224,11 +14504,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforedeactivate",
-            "DisplayName": "@onbeforedeactivate",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforedeactivate"
           }
         ]
       },
@@ -15236,11 +14513,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforedeactivate:preventDefault",
-            "DisplayName": "@onbeforedeactivate:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforedeactivate:preventDefault"
           }
         ]
       },
@@ -15248,11 +14522,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforedeactivate:stopPropagation",
-            "DisplayName": "@onbeforedeactivate:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforedeactivate:stopPropagation"
           }
         ]
       }
@@ -15314,10 +14585,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8647793524939028632,
-      "Data2": 955743316717787413,
-      "Data3": 5859052869483680726,
-      "Data4": 7506331123294323471
+      "Data1": 5763950840506831167,
+      "Data2": -1108177224752352901,
+      "Data3": -8532981253554330149,
+      "Data4": 6698450276499615577
     },
     "Kind": "Components.EventHandler",
     "Name": "ondeactivate",
@@ -15336,11 +14607,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondeactivate",
-            "DisplayName": "@ondeactivate",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondeactivate"
           }
         ]
       },
@@ -15348,11 +14616,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondeactivate:preventDefault",
-            "DisplayName": "@ondeactivate:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondeactivate:preventDefault"
           }
         ]
       },
@@ -15360,11 +14625,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondeactivate:stopPropagation",
-            "DisplayName": "@ondeactivate:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondeactivate:stopPropagation"
           }
         ]
       }
@@ -15426,10 +14688,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1906284907089214848,
-      "Data2": 443188841020385088,
-      "Data3": -5028477845044567293,
-      "Data4": -1850545874622278529
+      "Data1": -8710104582295061303,
+      "Data2": 6008241716655040706,
+      "Data3": 3461205574063701356,
+      "Data4": -3113622049051360909
     },
     "Kind": "Components.EventHandler",
     "Name": "onended",
@@ -15448,11 +14710,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onended",
-            "DisplayName": "@onended",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onended"
           }
         ]
       },
@@ -15460,11 +14719,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onended:preventDefault",
-            "DisplayName": "@onended:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onended:preventDefault"
           }
         ]
       },
@@ -15472,11 +14728,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onended:stopPropagation",
-            "DisplayName": "@onended:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onended:stopPropagation"
           }
         ]
       }
@@ -15538,10 +14791,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -396938278057026480,
-      "Data2": -7643873025564860557,
-      "Data3": -1229704884769523426,
-      "Data4": 5165627441129530916
+      "Data1": 3609022854687126428,
+      "Data2": 8954097604677361417,
+      "Data3": 5334362522706571566,
+      "Data4": 2190056543920748504
     },
     "Kind": "Components.EventHandler",
     "Name": "onfullscreenchange",
@@ -15560,11 +14813,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfullscreenchange",
-            "DisplayName": "@onfullscreenchange",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfullscreenchange"
           }
         ]
       },
@@ -15572,11 +14822,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfullscreenchange:preventDefault",
-            "DisplayName": "@onfullscreenchange:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfullscreenchange:preventDefault"
           }
         ]
       },
@@ -15584,11 +14831,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfullscreenchange:stopPropagation",
-            "DisplayName": "@onfullscreenchange:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfullscreenchange:stopPropagation"
           }
         ]
       }
@@ -15650,10 +14894,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8455409692328489706,
-      "Data2": -8430176529168880915,
-      "Data3": 3283677877177499758,
-      "Data4": 413805143971355079
+      "Data1": 2459889448836591393,
+      "Data2": 1023566024835001176,
+      "Data3": -6905697785392261442,
+      "Data4": -7814112676068715670
     },
     "Kind": "Components.EventHandler",
     "Name": "onfullscreenerror",
@@ -15672,11 +14916,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfullscreenerror",
-            "DisplayName": "@onfullscreenerror",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfullscreenerror"
           }
         ]
       },
@@ -15684,11 +14925,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfullscreenerror:preventDefault",
-            "DisplayName": "@onfullscreenerror:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfullscreenerror:preventDefault"
           }
         ]
       },
@@ -15696,11 +14934,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfullscreenerror:stopPropagation",
-            "DisplayName": "@onfullscreenerror:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfullscreenerror:stopPropagation"
           }
         ]
       }
@@ -15762,10 +14997,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4454430292558936412,
-      "Data2": -1109499151669397957,
-      "Data3": -4197866983520898941,
-      "Data4": -1538235480261615795
+      "Data1": -3414266411669795424,
+      "Data2": 7545432735130369547,
+      "Data3": 3341415072117202837,
+      "Data4": 4875251933120522605
     },
     "Kind": "Components.EventHandler",
     "Name": "onloadeddata",
@@ -15784,11 +15019,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onloadeddata",
-            "DisplayName": "@onloadeddata",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onloadeddata"
           }
         ]
       },
@@ -15796,11 +15028,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onloadeddata:preventDefault",
-            "DisplayName": "@onloadeddata:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onloadeddata:preventDefault"
           }
         ]
       },
@@ -15808,11 +15037,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onloadeddata:stopPropagation",
-            "DisplayName": "@onloadeddata:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onloadeddata:stopPropagation"
           }
         ]
       }
@@ -15874,10 +15100,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6862941353545766880,
-      "Data2": 7918769923840348038,
-      "Data3": -1948391046523206943,
-      "Data4": 2940449063330701396
+      "Data1": -3472902045475719250,
+      "Data2": -2055598071130817822,
+      "Data3": -5591603234971527784,
+      "Data4": 126809892683880422
     },
     "Kind": "Components.EventHandler",
     "Name": "onloadedmetadata",
@@ -15896,11 +15122,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onloadedmetadata",
-            "DisplayName": "@onloadedmetadata",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onloadedmetadata"
           }
         ]
       },
@@ -15908,11 +15131,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onloadedmetadata:preventDefault",
-            "DisplayName": "@onloadedmetadata:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onloadedmetadata:preventDefault"
           }
         ]
       },
@@ -15920,11 +15140,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onloadedmetadata:stopPropagation",
-            "DisplayName": "@onloadedmetadata:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onloadedmetadata:stopPropagation"
           }
         ]
       }
@@ -15986,10 +15203,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5319856823806878114,
-      "Data2": 6640686403219892770,
-      "Data3": 6596596643185515064,
-      "Data4": -8333154803890283708
+      "Data1": -3566988309395049772,
+      "Data2": -4026457463102598353,
+      "Data3": 4964986344152189005,
+      "Data4": -1313408849653798992
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointerlockchange",
@@ -16008,11 +15225,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerlockchange",
-            "DisplayName": "@onpointerlockchange",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerlockchange"
           }
         ]
       },
@@ -16020,11 +15234,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerlockchange:preventDefault",
-            "DisplayName": "@onpointerlockchange:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerlockchange:preventDefault"
           }
         ]
       },
@@ -16032,11 +15243,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerlockchange:stopPropagation",
-            "DisplayName": "@onpointerlockchange:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerlockchange:stopPropagation"
           }
         ]
       }
@@ -16098,10 +15306,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2405315184326742362,
-      "Data2": -4336956376583241421,
-      "Data3": 2067781814523124254,
-      "Data4": -8683903035252113557
+      "Data1": 7796902393503333813,
+      "Data2": 1277395406116519157,
+      "Data3": -6358470909369076950,
+      "Data4": 1073574195113734345
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointerlockerror",
@@ -16120,11 +15328,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerlockerror",
-            "DisplayName": "@onpointerlockerror",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerlockerror"
           }
         ]
       },
@@ -16132,11 +15337,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerlockerror:preventDefault",
-            "DisplayName": "@onpointerlockerror:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerlockerror:preventDefault"
           }
         ]
       },
@@ -16144,11 +15346,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerlockerror:stopPropagation",
-            "DisplayName": "@onpointerlockerror:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerlockerror:stopPropagation"
           }
         ]
       }
@@ -16210,10 +15409,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7823779853248095029,
-      "Data2": 2896948618275552326,
-      "Data3": 6015849736099765352,
-      "Data4": -8165407376096835581
+      "Data1": 6833964819070433640,
+      "Data2": -3059624890976171506,
+      "Data3": 455731902653736608,
+      "Data4": 8625665274916655878
     },
     "Kind": "Components.EventHandler",
     "Name": "onreadystatechange",
@@ -16232,11 +15431,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onreadystatechange",
-            "DisplayName": "@onreadystatechange",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onreadystatechange"
           }
         ]
       },
@@ -16244,11 +15440,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onreadystatechange:preventDefault",
-            "DisplayName": "@onreadystatechange:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onreadystatechange:preventDefault"
           }
         ]
       },
@@ -16256,11 +15449,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onreadystatechange:stopPropagation",
-            "DisplayName": "@onreadystatechange:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onreadystatechange:stopPropagation"
           }
         ]
       }
@@ -16322,10 +15512,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4086907535258678610,
-      "Data2": 2273919336126465370,
-      "Data3": 5801632512138309614,
-      "Data4": -4798362539997732828
+      "Data1": -7577092237198097063,
+      "Data2": -5870451528294498790,
+      "Data3": -8805537904184925429,
+      "Data4": -6237541219005732290
     },
     "Kind": "Components.EventHandler",
     "Name": "onscroll",
@@ -16344,11 +15534,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onscroll",
-            "DisplayName": "@onscroll",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onscroll"
           }
         ]
       },
@@ -16356,11 +15543,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onscroll:preventDefault",
-            "DisplayName": "@onscroll:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onscroll:preventDefault"
           }
         ]
       },
@@ -16368,11 +15552,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onscroll:stopPropagation",
-            "DisplayName": "@onscroll:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onscroll:stopPropagation"
           }
         ]
       }
@@ -16434,10 +15615,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4753124172124543843,
-      "Data2": 4390281967717981656,
-      "Data3": 7035810605520754206,
-      "Data4": -2512411399122211635
+      "Data1": -6472114395335910973,
+      "Data2": -8331289432436646235,
+      "Data3": 5908519752540617084,
+      "Data4": 8907552920547075756
     },
     "Kind": "Components.EventHandler",
     "Name": "ontoggle",
@@ -16456,11 +15637,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontoggle",
-            "DisplayName": "@ontoggle",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontoggle"
           }
         ]
       },
@@ -16468,11 +15646,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontoggle:preventDefault",
-            "DisplayName": "@ontoggle:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontoggle:preventDefault"
           }
         ]
       },
@@ -16480,11 +15655,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontoggle:stopPropagation",
-            "DisplayName": "@ontoggle:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontoggle:stopPropagation"
           }
         ]
       }
@@ -16546,10 +15718,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2178206861261052325,
-      "Data2": -4365524651956538386,
-      "Data3": -8951170454315403632,
-      "Data4": -5065903433088102374
+      "Data1": 654375644919202973,
+      "Data2": -7870112250023943631,
+      "Data3": 7601107499136478958,
+      "Data4": -776999553554073906
     },
     "Kind": "Components.Splat",
     "Name": "Attributes",
@@ -16564,11 +15736,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@attributes",
-            "DisplayName": "@attributes",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@attributes"
           }
         ]
       }
@@ -16596,10 +15765,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2691140916902589132,
-      "Data2": 5665331874949135993,
-      "Data3": 3532856183522419219,
-      "Data4": -8176119513396174649
+      "Data1": 6019007410227680746,
+      "Data2": 6529370774747507035,
+      "Data3": 2643330136043612035,
+      "Data4": 6285189147074107079
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper",
@@ -16613,9 +15782,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-action",
-            "CaseSensitive": false,
-            "DisplayName": "asp-action"
+            "Flags": 0,
+            "Name": "asp-action"
           }
         ]
       },
@@ -16624,9 +15792,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-controller",
-            "CaseSensitive": false,
-            "DisplayName": "asp-controller"
+            "Flags": 0,
+            "Name": "asp-controller"
           }
         ]
       },
@@ -16635,9 +15802,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-area",
-            "CaseSensitive": false,
-            "DisplayName": "asp-area"
+            "Flags": 0,
+            "Name": "asp-area"
           }
         ]
       },
@@ -16646,9 +15812,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-page",
-            "CaseSensitive": false,
-            "DisplayName": "asp-page"
+            "Flags": 0,
+            "Name": "asp-page"
           }
         ]
       },
@@ -16657,9 +15822,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-page-handler",
-            "CaseSensitive": false,
-            "DisplayName": "asp-page-handler"
+            "Flags": 0,
+            "Name": "asp-page-handler"
           }
         ]
       },
@@ -16668,9 +15832,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-fragment",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fragment"
+            "Flags": 0,
+            "Name": "asp-fragment"
           }
         ]
       },
@@ -16679,9 +15842,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-host",
-            "CaseSensitive": false,
-            "DisplayName": "asp-host"
+            "Flags": 0,
+            "Name": "asp-host"
           }
         ]
       },
@@ -16690,9 +15852,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-protocol",
-            "CaseSensitive": false,
-            "DisplayName": "asp-protocol"
+            "Flags": 0,
+            "Name": "asp-protocol"
           }
         ]
       },
@@ -16701,9 +15862,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-route",
-            "CaseSensitive": false,
-            "DisplayName": "asp-route"
+            "Flags": 0,
+            "Name": "asp-route"
           }
         ]
       },
@@ -16712,9 +15872,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-all-route-data",
-            "CaseSensitive": false,
-            "DisplayName": "asp-all-route-data"
+            "Flags": 0,
+            "Name": "asp-all-route-data"
           }
         ]
       },
@@ -16723,10 +15882,9 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "asp-route-",
-            "NameComparison": 1,
-            "CaseSensitive": false,
-            "DisplayName": "asp-route-..."
+            "NameComparison": 1
           }
         ]
       }
@@ -16993,10 +16151,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -28348962335892839,
-      "Data2": 8275825483240517839,
-      "Data3": -7245295817226371666,
-      "Data4": 8863523217590278409
+      "Data1": -7361191824948964288,
+      "Data2": 5838597263031670273,
+      "Data3": -3491605372221289836,
+      "Data4": 5254591964600441027
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.ComponentTagHelper",
@@ -17011,9 +16169,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "type",
-            "CaseSensitive": false,
-            "DisplayName": "type"
+            "Flags": 0,
+            "Name": "type"
           }
         ]
       }
@@ -17063,10 +16220,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2016379775888796934,
-      "Data2": 2394947512120564749,
-      "Data3": -14359009586197013,
-      "Data4": -4693251594565665943
+      "Data1": 2833982709163209824,
+      "Data2": 6080425675319721955,
+      "Data3": -1219739142242426218,
+      "Data4": 9048779914280802654
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper",
@@ -17080,9 +16237,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "name",
-            "CaseSensitive": false,
-            "DisplayName": "name"
+            "Flags": 0,
+            "Name": "name"
           }
         ]
       }
@@ -17276,10 +16432,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3254066323727996177,
-      "Data2": 6820812766149563592,
-      "Data3": 4757886940421704990,
-      "Data4": -8002294065430606632
+      "Data1": 201476584690134157,
+      "Data2": -2252498490816325968,
+      "Data3": 3396543412884836362,
+      "Data4": 1628506581201897551
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.FormActionTagHelper",
@@ -17293,9 +16449,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-action",
-            "CaseSensitive": false,
-            "DisplayName": "asp-action"
+            "Flags": 0,
+            "Name": "asp-action"
           }
         ]
       },
@@ -17304,9 +16459,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-controller",
-            "CaseSensitive": false,
-            "DisplayName": "asp-controller"
+            "Flags": 0,
+            "Name": "asp-controller"
           }
         ]
       },
@@ -17315,9 +16469,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-area",
-            "CaseSensitive": false,
-            "DisplayName": "asp-area"
+            "Flags": 0,
+            "Name": "asp-area"
           }
         ]
       },
@@ -17326,9 +16479,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-page",
-            "CaseSensitive": false,
-            "DisplayName": "asp-page"
+            "Flags": 0,
+            "Name": "asp-page"
           }
         ]
       },
@@ -17337,9 +16489,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-page-handler",
-            "CaseSensitive": false,
-            "DisplayName": "asp-page-handler"
+            "Flags": 0,
+            "Name": "asp-page-handler"
           }
         ]
       },
@@ -17348,9 +16499,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-fragment",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fragment"
+            "Flags": 0,
+            "Name": "asp-fragment"
           }
         ]
       },
@@ -17359,9 +16509,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-route",
-            "CaseSensitive": false,
-            "DisplayName": "asp-route"
+            "Flags": 0,
+            "Name": "asp-route"
           }
         ]
       },
@@ -17370,9 +16519,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-all-route-data",
-            "CaseSensitive": false,
-            "DisplayName": "asp-all-route-data"
+            "Flags": 0,
+            "Name": "asp-all-route-data"
           }
         ]
       },
@@ -17381,10 +16529,9 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "asp-route-",
-            "NameComparison": 1,
-            "CaseSensitive": false,
-            "DisplayName": "asp-route-..."
+            "NameComparison": 1
           }
         ]
       },
@@ -17394,16 +16541,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "image",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-action",
-            "CaseSensitive": false,
-            "DisplayName": "asp-action"
+            "Flags": 0,
+            "Name": "asp-action"
           }
         ]
       },
@@ -17413,16 +16558,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "image",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-controller",
-            "CaseSensitive": false,
-            "DisplayName": "asp-controller"
+            "Flags": 0,
+            "Name": "asp-controller"
           }
         ]
       },
@@ -17432,16 +16575,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "image",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-area",
-            "CaseSensitive": false,
-            "DisplayName": "asp-area"
+            "Flags": 0,
+            "Name": "asp-area"
           }
         ]
       },
@@ -17451,16 +16592,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "image",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-page",
-            "CaseSensitive": false,
-            "DisplayName": "asp-page"
+            "Flags": 0,
+            "Name": "asp-page"
           }
         ]
       },
@@ -17470,16 +16609,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "image",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-page-handler",
-            "CaseSensitive": false,
-            "DisplayName": "asp-page-handler"
+            "Flags": 0,
+            "Name": "asp-page-handler"
           }
         ]
       },
@@ -17489,16 +16626,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "image",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-fragment",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fragment"
+            "Flags": 0,
+            "Name": "asp-fragment"
           }
         ]
       },
@@ -17508,16 +16643,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "image",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-route",
-            "CaseSensitive": false,
-            "DisplayName": "asp-route"
+            "Flags": 0,
+            "Name": "asp-route"
           }
         ]
       },
@@ -17527,16 +16660,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "image",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-all-route-data",
-            "CaseSensitive": false,
-            "DisplayName": "asp-all-route-data"
+            "Flags": 0,
+            "Name": "asp-all-route-data"
           }
         ]
       },
@@ -17546,17 +16677,15 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "image",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
+            "Flags": 0,
             "Name": "asp-route-",
-            "NameComparison": 1,
-            "CaseSensitive": false,
-            "DisplayName": "asp-route-..."
+            "NameComparison": 1
           }
         ]
       },
@@ -17566,16 +16695,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "submit",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-action",
-            "CaseSensitive": false,
-            "DisplayName": "asp-action"
+            "Flags": 0,
+            "Name": "asp-action"
           }
         ]
       },
@@ -17585,16 +16712,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "submit",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-controller",
-            "CaseSensitive": false,
-            "DisplayName": "asp-controller"
+            "Flags": 0,
+            "Name": "asp-controller"
           }
         ]
       },
@@ -17604,16 +16729,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "submit",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-area",
-            "CaseSensitive": false,
-            "DisplayName": "asp-area"
+            "Flags": 0,
+            "Name": "asp-area"
           }
         ]
       },
@@ -17623,16 +16746,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "submit",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-page",
-            "CaseSensitive": false,
-            "DisplayName": "asp-page"
+            "Flags": 0,
+            "Name": "asp-page"
           }
         ]
       },
@@ -17642,16 +16763,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "submit",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-page-handler",
-            "CaseSensitive": false,
-            "DisplayName": "asp-page-handler"
+            "Flags": 0,
+            "Name": "asp-page-handler"
           }
         ]
       },
@@ -17661,16 +16780,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "submit",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-fragment",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fragment"
+            "Flags": 0,
+            "Name": "asp-fragment"
           }
         ]
       },
@@ -17680,16 +16797,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "submit",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-route",
-            "CaseSensitive": false,
-            "DisplayName": "asp-route"
+            "Flags": 0,
+            "Name": "asp-route"
           }
         ]
       },
@@ -17699,16 +16814,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "submit",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-all-route-data",
-            "CaseSensitive": false,
-            "DisplayName": "asp-all-route-data"
+            "Flags": 0,
+            "Name": "asp-all-route-data"
           }
         ]
       },
@@ -17718,17 +16831,15 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "submit",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
+            "Flags": 0,
             "Name": "asp-route-",
-            "NameComparison": 1,
-            "CaseSensitive": false,
-            "DisplayName": "asp-route-..."
+            "NameComparison": 1
           }
         ]
       }
@@ -17948,10 +17059,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -9150069793068366952,
-      "Data2": -2076058506947748682,
-      "Data3": -6403108197295115992,
-      "Data4": 7774763828166874621
+      "Data1": 9179967494552819525,
+      "Data2": 6585074578945390635,
+      "Data3": -6997189323706945042,
+      "Data4": 273872553236002495
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.ImageTagHelper",
@@ -17966,14 +17077,12 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-append-version",
-            "CaseSensitive": false,
-            "DisplayName": "asp-append-version"
+            "Flags": 0,
+            "Name": "asp-append-version"
           },
           {
-            "Name": "src",
-            "CaseSensitive": false,
-            "DisplayName": "src"
+            "Flags": 0,
+            "Name": "src"
           }
         ]
       }
@@ -18009,10 +17118,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6998767517752929417,
-      "Data2": 6917972083269696653,
-      "Data3": -8936279983879531903,
-      "Data4": -3136776488981870098
+      "Data1": -4916077896480662667,
+      "Data2": 8578665907178143482,
+      "Data3": 442901266186642545,
+      "Data4": 308621611143862925
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.InputTagHelper",
@@ -18027,9 +17136,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-for",
-            "CaseSensitive": false,
-            "DisplayName": "asp-for"
+            "Flags": 0,
+            "Name": "asp-for"
           }
         ]
       }
@@ -18095,10 +17203,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1957410200833230115,
-      "Data2": 7026930609365577114,
-      "Data3": 5200742074609957556,
-      "Data4": -1953559859184195059
+      "Data1": -8009014089682483608,
+      "Data2": -3290102827639500042,
+      "Data3": 8651229590282991544,
+      "Data4": 342592518686092618
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.LabelTagHelper",
@@ -18112,9 +17220,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-for",
-            "CaseSensitive": false,
-            "DisplayName": "asp-for"
+            "Flags": 0,
+            "Name": "asp-for"
           }
         ]
       }
@@ -18140,10 +17247,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7440377698719679753,
-      "Data2": -1268101387052113757,
-      "Data3": -3050263543566606420,
-      "Data4": 6215374089723061786
+      "Data1": -846633057315455572,
+      "Data2": 5821887012802470422,
+      "Data3": -999608594217935675,
+      "Data4": 1372762677744491873
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper",
@@ -18158,9 +17265,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-href-include",
-            "CaseSensitive": false,
-            "DisplayName": "asp-href-include"
+            "Flags": 0,
+            "Name": "asp-href-include"
           }
         ]
       },
@@ -18170,9 +17276,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-href-exclude",
-            "CaseSensitive": false,
-            "DisplayName": "asp-href-exclude"
+            "Flags": 0,
+            "Name": "asp-href-exclude"
           }
         ]
       },
@@ -18182,9 +17287,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-fallback-href",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fallback-href"
+            "Flags": 0,
+            "Name": "asp-fallback-href"
           }
         ]
       },
@@ -18194,9 +17298,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-fallback-href-include",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fallback-href-include"
+            "Flags": 0,
+            "Name": "asp-fallback-href-include"
           }
         ]
       },
@@ -18206,9 +17309,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-fallback-href-exclude",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fallback-href-exclude"
+            "Flags": 0,
+            "Name": "asp-fallback-href-exclude"
           }
         ]
       },
@@ -18218,9 +17320,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-fallback-test-class",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fallback-test-class"
+            "Flags": 0,
+            "Name": "asp-fallback-test-class"
           }
         ]
       },
@@ -18230,9 +17331,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-fallback-test-property",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fallback-test-property"
+            "Flags": 0,
+            "Name": "asp-fallback-test-property"
           }
         ]
       },
@@ -18242,9 +17342,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-fallback-test-value",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fallback-test-value"
+            "Flags": 0,
+            "Name": "asp-fallback-test-value"
           }
         ]
       },
@@ -18254,9 +17353,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-append-version",
-            "CaseSensitive": false,
-            "DisplayName": "asp-append-version"
+            "Flags": 0,
+            "Name": "asp-append-version"
           }
         ]
       }
@@ -18420,10 +17518,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1517696761464252137,
-      "Data2": -3159673581201677384,
-      "Data3": 991705095752170857,
-      "Data4": -601937397079391106
+      "Data1": 7797512062356151401,
+      "Data2": 3988488529001038306,
+      "Data3": -3608628895372162493,
+      "Data4": -5804420566910886403
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.PartialTagHelper",
@@ -18438,9 +17536,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "name",
-            "CaseSensitive": false,
-            "DisplayName": "name"
+            "Flags": 0,
+            "Name": "name"
           }
         ]
       }
@@ -18558,10 +17655,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6097127976709000527,
-      "Data2": 8994589850913287496,
-      "Data3": 5168171268406164167,
-      "Data4": 7786589343832471355
+      "Data1": 1691954087059002931,
+      "Data2": -2784552635095548989,
+      "Data3": -6103802819850743813,
+      "Data4": 5499192369138479899
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.ScriptTagHelper",
@@ -18575,9 +17672,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-src-include",
-            "CaseSensitive": false,
-            "DisplayName": "asp-src-include"
+            "Flags": 0,
+            "Name": "asp-src-include"
           }
         ]
       },
@@ -18586,9 +17682,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-src-exclude",
-            "CaseSensitive": false,
-            "DisplayName": "asp-src-exclude"
+            "Flags": 0,
+            "Name": "asp-src-exclude"
           }
         ]
       },
@@ -18597,9 +17692,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-fallback-src",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fallback-src"
+            "Flags": 0,
+            "Name": "asp-fallback-src"
           }
         ]
       },
@@ -18608,9 +17702,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-fallback-src-include",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fallback-src-include"
+            "Flags": 0,
+            "Name": "asp-fallback-src-include"
           }
         ]
       },
@@ -18619,9 +17712,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-fallback-src-exclude",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fallback-src-exclude"
+            "Flags": 0,
+            "Name": "asp-fallback-src-exclude"
           }
         ]
       },
@@ -18630,9 +17722,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-fallback-test",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fallback-test"
+            "Flags": 0,
+            "Name": "asp-fallback-test"
           }
         ]
       },
@@ -18641,9 +17732,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-append-version",
-            "CaseSensitive": false,
-            "DisplayName": "asp-append-version"
+            "Flags": 0,
+            "Name": "asp-append-version"
           }
         ]
       }
@@ -18749,10 +17839,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4854167366317579771,
-      "Data2": 2918566904182754138,
-      "Data3": 7713941763997143428,
-      "Data4": -3188734934031037136
+      "Data1": 7429763423409918391,
+      "Data2": 7228726334272683083,
+      "Data3": -3376598747110494221,
+      "Data4": 6429164794985549770
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.SelectTagHelper",
@@ -18766,9 +17856,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-for",
-            "CaseSensitive": false,
-            "DisplayName": "asp-for"
+            "Flags": 0,
+            "Name": "asp-for"
           }
         ]
       },
@@ -18777,9 +17866,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-items",
-            "CaseSensitive": false,
-            "DisplayName": "asp-items"
+            "Flags": 0,
+            "Name": "asp-items"
           }
         ]
       }
@@ -18825,10 +17913,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 456153802204140171,
-      "Data2": 3570126844946886368,
-      "Data3": -1678759803802258939,
-      "Data4": -4952702678738042897
+      "Data1": 4544129282491152965,
+      "Data2": 7540586689639312710,
+      "Data3": 429611759841984649,
+      "Data4": 3729826692770310385
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.TextAreaTagHelper",
@@ -18842,9 +17930,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-for",
-            "CaseSensitive": false,
-            "DisplayName": "asp-for"
+            "Flags": 0,
+            "Name": "asp-for"
           }
         ]
       }
@@ -18880,10 +17967,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 122407907830255608,
-      "Data2": -700700567307428018,
-      "Data3": 3600322002542077017,
-      "Data4": 2776277471670448158
+      "Data1": 8297211713690385858,
+      "Data2": 105036567512201717,
+      "Data3": -8495913936093548737,
+      "Data4": -4731152072011410491
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.ValidationMessageTagHelper",
@@ -18897,9 +17984,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-validation-for",
-            "CaseSensitive": false,
-            "DisplayName": "asp-validation-for"
+            "Flags": 0,
+            "Name": "asp-validation-for"
           }
         ]
       }
@@ -18925,10 +18011,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -324297431428773807,
-      "Data2": 9041312678384490421,
-      "Data3": -7983664825210767949,
-      "Data4": 8506289130510871423
+      "Data1": 291705818077823425,
+      "Data2": 8756048039551780657,
+      "Data3": -6497895732771672119,
+      "Data4": -3602474906253647811
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.ValidationSummaryTagHelper",
@@ -18942,9 +18028,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-validation-summary",
-            "CaseSensitive": false,
-            "DisplayName": "asp-validation-summary"
+            "Flags": 0,
+            "Name": "asp-validation-summary"
           }
         ]
       }
@@ -18971,10 +18056,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2383293299956605636,
-      "Data2": 8237308276148878679,
-      "Data3": -2794995612896414953,
-      "Data4": 2560439310821063352
+      "Data1": 4188877008959249826,
+      "Data2": -2272402989854913107,
+      "Data3": -8369454677979694710,
+      "Data4": 7729790438600625422
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.Razor.TagHelpers.UrlResolutionTagHelper",
@@ -18988,11 +18073,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "itemid",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "itemid"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19001,11 +18085,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "href",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "href"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19014,11 +18097,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "archive",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "archive"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19028,11 +18110,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "href",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "href"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19041,11 +18122,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "src",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "src"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19055,11 +18135,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "href",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "href"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19068,11 +18147,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "cite",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "cite"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19081,11 +18159,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "formaction",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "formaction"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19094,11 +18171,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "cite",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "cite"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19108,11 +18184,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "src",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "src"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19121,11 +18196,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "action",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "action"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19134,11 +18208,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "manifest",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "manifest"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19147,11 +18220,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "src",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "src"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19161,11 +18233,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "src",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "src"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19175,11 +18246,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "srcset",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "srcset"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19189,11 +18259,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "src",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "src"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19203,11 +18272,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "formaction",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "formaction"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19216,11 +18284,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "cite",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "cite"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19230,11 +18297,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "href",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "href"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19243,11 +18309,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "icon",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "icon"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19256,11 +18321,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "archive",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "archive"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19269,11 +18333,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "data",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "data"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19282,11 +18345,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "cite",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "cite"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19295,11 +18357,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "src",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "src"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19309,11 +18370,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "src",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "src"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19323,11 +18383,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "srcset",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "srcset"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19337,11 +18396,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "src",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "src"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19350,11 +18408,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "src",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "src"
+            "ValueComparison": 2
           }
         ]
       },
@@ -19363,11 +18420,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "poster",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "poster"
+            "ValueComparison": 2
           }
         ]
       }
@@ -19381,10 +18437,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1073301647227589633,
-      "Data2": 8101759897890733284,
-      "Data3": -6920811933630909984,
-      "Data4": -6290663200272122769
+      "Data1": 7643567100232600412,
+      "Data2": -8619350189066494800,
+      "Data3": -3355225993421399391,
+      "Data4": -7234144764947874940
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -19399,12 +18455,9 @@
         "TagName": "*",
         "Attributes": [
           {
+            "Flags": 3,
             "Name": "@bind-",
-            "NameComparison": 1,
-            "DisplayName": "@bind-...",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "NameComparison": 1
           }
         ]
       }
@@ -19497,10 +18550,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1556004898731902221,
-      "Data2": 7829188875044190705,
-      "Data3": -5991469701502087751,
-      "Data4": -6643408075181463790
+      "Data1": -1208407362033003559,
+      "Data2": 6997977779558301536,
+      "Data3": -1775763830979486606,
+      "Data4": 4581722018174740830
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -19519,11 +18572,8 @@
         "TagName": "input",
         "Attributes": [
           {
-            "Name": "@bind",
-            "DisplayName": "@bind",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind"
           }
         ]
       },
@@ -19531,18 +18581,12 @@
         "TagName": "input",
         "Attributes": [
           {
-            "Name": "@bind:get",
-            "DisplayName": "@bind:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind:get"
           },
           {
-            "Name": "@bind:set",
-            "DisplayName": "@bind:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind:set"
           }
         ]
       }
@@ -19656,10 +18700,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4721804179514870219,
-      "Data2": 7607236171508579391,
-      "Data3": -4587957588803971833,
-      "Data4": -1541458591551164882
+      "Data1": -1748303767561747557,
+      "Data2": 6397579467056846022,
+      "Data3": 2277041626561416222,
+      "Data4": -8459897143433757177
     },
     "Kind": "Components.Bind",
     "Name": "Bind_value",
@@ -19678,11 +18722,8 @@
         "TagName": "input",
         "Attributes": [
           {
-            "Name": "@bind-value",
-            "DisplayName": "@bind-value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-value"
           }
         ]
       },
@@ -19690,18 +18731,12 @@
         "TagName": "input",
         "Attributes": [
           {
-            "Name": "@bind-value:get",
-            "DisplayName": "@bind-value:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-value:get"
           },
           {
-            "Name": "@bind-value:set",
-            "DisplayName": "@bind-value:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-value:set"
           }
         ]
       }
@@ -19815,10 +18850,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -9012130317925565883,
-      "Data2": -8385752469162579727,
-      "Data3": -3360898089607708973,
-      "Data4": 1630998681911142131
+      "Data1": -4853172862298548960,
+      "Data2": 3251296670425394325,
+      "Data3": -8631598445747239468,
+      "Data4": 1113505282078067831
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -19837,17 +18872,14 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "checkbox",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind",
-            "DisplayName": "@bind",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind"
           }
         ]
       },
@@ -19855,24 +18887,18 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "checkbox",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind:get",
-            "DisplayName": "@bind:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind:get"
           },
           {
-            "Name": "@bind:set",
-            "DisplayName": "@bind:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind:set"
           }
         ]
       }
@@ -19987,10 +19013,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1549220529411200477,
-      "Data2": -2761563220845679330,
-      "Data3": -1847807182485603835,
-      "Data4": -3423906826708397841
+      "Data1": -3667894320956382288,
+      "Data2": -3326435738726251720,
+      "Data3": -3458700014341423014,
+      "Data4": 8304636069664478363
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -20009,17 +19035,14 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "text",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind",
-            "DisplayName": "@bind",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind"
           }
         ]
       },
@@ -20027,24 +19050,18 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "text",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind:get",
-            "DisplayName": "@bind:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind:get"
           },
           {
-            "Name": "@bind:set",
-            "DisplayName": "@bind:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind:set"
           }
         ]
       }
@@ -20159,10 +19176,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8735413799192487182,
-      "Data2": 5230765264560867301,
-      "Data3": 5051546020838539200,
-      "Data4": 2018314258591378276
+      "Data1": -3763635225561036793,
+      "Data2": -5727098805425384776,
+      "Data3": -2005692732473116232,
+      "Data4": -4575816668326360785
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -20181,17 +19198,14 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "number",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind",
-            "DisplayName": "@bind",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind"
           }
         ]
       },
@@ -20199,24 +19213,18 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "number",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind:get",
-            "DisplayName": "@bind:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind:get"
           },
           {
-            "Name": "@bind:set",
-            "DisplayName": "@bind:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind:set"
           }
         ]
       }
@@ -20331,10 +19339,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6251259028650079662,
-      "Data2": 7168576928716550522,
-      "Data3": 1403993109432839481,
-      "Data4": 6167908272748344637
+      "Data1": -5335425819645344900,
+      "Data2": -8216205796209995741,
+      "Data3": -2028321660956074774,
+      "Data4": 2149534919632525625
     },
     "Kind": "Components.Bind",
     "Name": "Bind_value",
@@ -20353,17 +19361,14 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "number",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind-value",
-            "DisplayName": "@bind-value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-value"
           }
         ]
       },
@@ -20371,24 +19376,18 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "number",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind-value:get",
-            "DisplayName": "@bind-value:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-value:get"
           },
           {
-            "Name": "@bind-value:set",
-            "DisplayName": "@bind-value:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-value:set"
           }
         ]
       }
@@ -20503,10 +19502,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4394598297581586680,
-      "Data2": 2224518312051877274,
-      "Data3": -2794255316184007845,
-      "Data4": 1833766771664005764
+      "Data1": 3484306485320093352,
+      "Data2": -4223196482323011264,
+      "Data3": -5184051946934014071,
+      "Data4": 813300749114076589
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -20525,17 +19524,14 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "date",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind",
-            "DisplayName": "@bind",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind"
           }
         ]
       },
@@ -20543,24 +19539,18 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "date",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind:get",
-            "DisplayName": "@bind:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind:get"
           },
           {
-            "Name": "@bind:set",
-            "DisplayName": "@bind:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind:set"
           }
         ]
       }
@@ -20675,10 +19665,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7513898485628571921,
-      "Data2": 9204617037395680736,
-      "Data3": 7156667228265874567,
-      "Data4": -1279991360901700991
+      "Data1": -5390216300505944077,
+      "Data2": -2667847587465181838,
+      "Data3": 2976567460569786064,
+      "Data4": 7477790729342057862
     },
     "Kind": "Components.Bind",
     "Name": "Bind_value",
@@ -20697,17 +19687,14 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "date",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind-value",
-            "DisplayName": "@bind-value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-value"
           }
         ]
       },
@@ -20715,24 +19702,18 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "date",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind-value:get",
-            "DisplayName": "@bind-value:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-value:get"
           },
           {
-            "Name": "@bind-value:set",
-            "DisplayName": "@bind-value:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-value:set"
           }
         ]
       }
@@ -20847,10 +19828,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6065669705363870747,
-      "Data2": -1748370172846223305,
-      "Data3": -1034028830525457953,
-      "Data4": 9199791234749301344
+      "Data1": 723510717078503627,
+      "Data2": 3419933591829225030,
+      "Data3": 8323235310091795793,
+      "Data4": -8747858208321034450
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -20869,17 +19850,14 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "datetime-local",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind",
-            "DisplayName": "@bind",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind"
           }
         ]
       },
@@ -20887,24 +19865,18 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "datetime-local",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind:get",
-            "DisplayName": "@bind:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind:get"
           },
           {
-            "Name": "@bind:set",
-            "DisplayName": "@bind:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind:set"
           }
         ]
       }
@@ -21019,10 +19991,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2262595175992799016,
-      "Data2": 1497381156082470256,
-      "Data3": -4152647695859345462,
-      "Data4": -1087305299235597026
+      "Data1": -7297149479398718457,
+      "Data2": -3143372154837633137,
+      "Data3": 1180303772006359496,
+      "Data4": -324814783672622336
     },
     "Kind": "Components.Bind",
     "Name": "Bind_value",
@@ -21041,17 +20013,14 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "datetime-local",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind-value",
-            "DisplayName": "@bind-value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-value"
           }
         ]
       },
@@ -21059,24 +20028,18 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "datetime-local",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind-value:get",
-            "DisplayName": "@bind-value:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-value:get"
           },
           {
-            "Name": "@bind-value:set",
-            "DisplayName": "@bind-value:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-value:set"
           }
         ]
       }
@@ -21191,10 +20154,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3530375003684148846,
-      "Data2": 1678816126431870996,
-      "Data3": -6398414745134880827,
-      "Data4": 8771218935058771279
+      "Data1": 6492552194175959401,
+      "Data2": 2338394509623057187,
+      "Data3": -1497218960006007660,
+      "Data4": 8789987061956251980
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -21213,17 +20176,14 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "month",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind",
-            "DisplayName": "@bind",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind"
           }
         ]
       },
@@ -21231,24 +20191,18 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "month",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind:get",
-            "DisplayName": "@bind:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind:get"
           },
           {
-            "Name": "@bind:set",
-            "DisplayName": "@bind:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind:set"
           }
         ]
       }
@@ -21363,10 +20317,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5193172178106771296,
-      "Data2": 8305085487092208634,
-      "Data3": 5058761880136319390,
-      "Data4": -4185226980644972553
+      "Data1": 4539815835980822257,
+      "Data2": 2060640516905600438,
+      "Data3": -7173020889924630447,
+      "Data4": -3668317204944861906
     },
     "Kind": "Components.Bind",
     "Name": "Bind_value",
@@ -21385,17 +20339,14 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "month",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind-value",
-            "DisplayName": "@bind-value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-value"
           }
         ]
       },
@@ -21403,24 +20354,18 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "month",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind-value:get",
-            "DisplayName": "@bind-value:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-value:get"
           },
           {
-            "Name": "@bind-value:set",
-            "DisplayName": "@bind-value:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-value:set"
           }
         ]
       }
@@ -21535,10 +20480,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2548659463358859266,
-      "Data2": -2352573489261492797,
-      "Data3": 5929663946111134036,
-      "Data4": -3071770098965250483
+      "Data1": 7548124147685699789,
+      "Data2": -6621403271877771531,
+      "Data3": 2422159877348253559,
+      "Data4": -5373789879723104489
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -21557,17 +20502,14 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "time",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind",
-            "DisplayName": "@bind",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind"
           }
         ]
       },
@@ -21575,24 +20517,18 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "time",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind:get",
-            "DisplayName": "@bind:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind:get"
           },
           {
-            "Name": "@bind:set",
-            "DisplayName": "@bind:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind:set"
           }
         ]
       }
@@ -21707,10 +20643,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8845957714180709455,
-      "Data2": -3321753692228733690,
-      "Data3": 4937282102329962251,
-      "Data4": 7486711684880919745
+      "Data1": -7009991608623026781,
+      "Data2": 3980668079249447135,
+      "Data3": -4413945674509080669,
+      "Data4": -462374804533839317
     },
     "Kind": "Components.Bind",
     "Name": "Bind_value",
@@ -21729,17 +20665,14 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "time",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind-value",
-            "DisplayName": "@bind-value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-value"
           }
         ]
       },
@@ -21747,24 +20680,18 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "time",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind-value:get",
-            "DisplayName": "@bind-value:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-value:get"
           },
           {
-            "Name": "@bind-value:set",
-            "DisplayName": "@bind-value:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-value:set"
           }
         ]
       }
@@ -21879,10 +20806,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1480048902184114821,
-      "Data2": -5176199698937666041,
-      "Data3": -5329087519324644459,
-      "Data4": -262845877164119105
+      "Data1": 4883000382447736322,
+      "Data2": 2998270188317509116,
+      "Data3": 4174261864102190989,
+      "Data4": -2842207001591319961
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -21901,11 +20828,8 @@
         "TagName": "select",
         "Attributes": [
           {
-            "Name": "@bind",
-            "DisplayName": "@bind",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind"
           }
         ]
       },
@@ -21913,18 +20837,12 @@
         "TagName": "select",
         "Attributes": [
           {
-            "Name": "@bind:get",
-            "DisplayName": "@bind:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind:get"
           },
           {
-            "Name": "@bind:set",
-            "DisplayName": "@bind:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind:set"
           }
         ]
       }
@@ -22038,10 +20956,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6607248474983469194,
-      "Data2": 7639608389418746979,
-      "Data3": 4800089072749287555,
-      "Data4": -224888138103330670
+      "Data1": 6536064576498516758,
+      "Data2": -4068440606457921854,
+      "Data3": -3359259020734340619,
+      "Data4": 998330027690692505
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -22060,11 +20978,8 @@
         "TagName": "textarea",
         "Attributes": [
           {
-            "Name": "@bind",
-            "DisplayName": "@bind",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind"
           }
         ]
       },
@@ -22072,18 +20987,12 @@
         "TagName": "textarea",
         "Attributes": [
           {
-            "Name": "@bind:get",
-            "DisplayName": "@bind:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind:get"
           },
           {
-            "Name": "@bind:set",
-            "DisplayName": "@bind:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind:set"
           }
         ]
       }
@@ -22197,10 +21106,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3276191800921921802,
-      "Data2": 4513260245355185204,
-      "Data3": -2576952910462202359,
-      "Data4": -937506176843006316
+      "Data1": -670291943803180413,
+      "Data2": -3577246493862423334,
+      "Data3": 7509298745899273828,
+      "Data4": -733412040925858589
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputCheckbox",
@@ -22219,11 +21128,8 @@
         "TagName": "InputCheckbox",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       },
@@ -22231,18 +21137,12 @@
         "TagName": "InputCheckbox",
         "Attributes": [
           {
-            "Name": "@bind-Value:get",
-            "DisplayName": "@bind-Value:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:get"
           },
           {
-            "Name": "@bind-Value:set",
-            "DisplayName": "@bind-Value:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:set"
           }
         ]
       }
@@ -22307,10 +21207,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2088088777708089979,
-      "Data2": 8575525148995798498,
-      "Data3": 158776863372837806,
-      "Data4": 3902257292046130122
+      "Data1": 6851172007389120176,
+      "Data2": 5161888880870543664,
+      "Data3": -3644230967072310923,
+      "Data4": -1271300915867131929
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputCheckbox",
@@ -22329,11 +21229,8 @@
         "TagName": "Microsoft.AspNetCore.Components.Forms.InputCheckbox",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       },
@@ -22341,18 +21238,12 @@
         "TagName": "Microsoft.AspNetCore.Components.Forms.InputCheckbox",
         "Attributes": [
           {
-            "Name": "@bind-Value:get",
-            "DisplayName": "@bind-Value:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:get"
           },
           {
-            "Name": "@bind-Value:set",
-            "DisplayName": "@bind-Value:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:set"
           }
         ]
       }
@@ -22418,10 +21309,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7018675345428767976,
-      "Data2": -1365168072988000591,
-      "Data3": -8784073059659437102,
-      "Data4": 3592457312435978779
+      "Data1": -2434134463900995814,
+      "Data2": -8419666247057005273,
+      "Data3": -6328904659737090595,
+      "Data4": 435062357849248359
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputDate<TValue>",
@@ -22440,11 +21331,8 @@
         "TagName": "InputDate",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       },
@@ -22452,18 +21340,12 @@
         "TagName": "InputDate",
         "Attributes": [
           {
-            "Name": "@bind-Value:get",
-            "DisplayName": "@bind-Value:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:get"
           },
           {
-            "Name": "@bind-Value:set",
-            "DisplayName": "@bind-Value:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:set"
           }
         ]
       }
@@ -22528,10 +21410,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4114637234506317754,
-      "Data2": -6805817000095944842,
-      "Data3": -9022280586090709983,
-      "Data4": 5567039216260504126
+      "Data1": 4610102397039677797,
+      "Data2": 4282623976262008966,
+      "Data3": 4887905859910019940,
+      "Data4": -2942692739276123634
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputDate<TValue>",
@@ -22550,11 +21432,8 @@
         "TagName": "Microsoft.AspNetCore.Components.Forms.InputDate",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       },
@@ -22562,18 +21441,12 @@
         "TagName": "Microsoft.AspNetCore.Components.Forms.InputDate",
         "Attributes": [
           {
-            "Name": "@bind-Value:get",
-            "DisplayName": "@bind-Value:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:get"
           },
           {
-            "Name": "@bind-Value:set",
-            "DisplayName": "@bind-Value:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:set"
           }
         ]
       }
@@ -22639,10 +21512,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8961389199761290019,
-      "Data2": -5821760351464054316,
-      "Data3": -2980198449104638410,
-      "Data4": 2046454222357699386
+      "Data1": 5657170445884353582,
+      "Data2": -6471180931122504959,
+      "Data3": 3120666361369423539,
+      "Data4": 8567669317901437474
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>",
@@ -22661,11 +21534,8 @@
         "TagName": "InputNumber",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       },
@@ -22673,18 +21543,12 @@
         "TagName": "InputNumber",
         "Attributes": [
           {
-            "Name": "@bind-Value:get",
-            "DisplayName": "@bind-Value:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:get"
           },
           {
-            "Name": "@bind-Value:set",
-            "DisplayName": "@bind-Value:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:set"
           }
         ]
       }
@@ -22749,10 +21613,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4690655020524261271,
-      "Data2": -8275349966617060297,
-      "Data3": 3961478111746509057,
-      "Data4": 6888637949762861865
+      "Data1": 2025972573451119712,
+      "Data2": 7347296852843538731,
+      "Data3": -222521662685752314,
+      "Data4": -5966298651064155717
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>",
@@ -22771,11 +21635,8 @@
         "TagName": "Microsoft.AspNetCore.Components.Forms.InputNumber",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       },
@@ -22783,18 +21644,12 @@
         "TagName": "Microsoft.AspNetCore.Components.Forms.InputNumber",
         "Attributes": [
           {
-            "Name": "@bind-Value:get",
-            "DisplayName": "@bind-Value:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:get"
           },
           {
-            "Name": "@bind-Value:set",
-            "DisplayName": "@bind-Value:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:set"
           }
         ]
       }
@@ -22860,10 +21715,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5717882134386465073,
-      "Data2": 8034896147222961196,
-      "Data3": -2837159614071967350,
-      "Data4": 5210987620701611409
+      "Data1": 6183465097341830127,
+      "Data2": 9039372920940046976,
+      "Data3": -9001373462484882533,
+      "Data4": 8426392165964768059
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>",
@@ -22882,11 +21737,8 @@
         "TagName": "InputRadioGroup",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       },
@@ -22894,18 +21746,12 @@
         "TagName": "InputRadioGroup",
         "Attributes": [
           {
-            "Name": "@bind-Value:get",
-            "DisplayName": "@bind-Value:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:get"
           },
           {
-            "Name": "@bind-Value:set",
-            "DisplayName": "@bind-Value:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:set"
           }
         ]
       }
@@ -22970,10 +21816,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5984347378442387488,
-      "Data2": 188862352023201556,
-      "Data3": 6521783132572974966,
-      "Data4": -905545728348648981
+      "Data1": 7405446399240504473,
+      "Data2": 105232129500840473,
+      "Data3": 3118862556043375449,
+      "Data4": 386393736450773542
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>",
@@ -22992,11 +21838,8 @@
         "TagName": "Microsoft.AspNetCore.Components.Forms.InputRadioGroup",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       },
@@ -23004,18 +21847,12 @@
         "TagName": "Microsoft.AspNetCore.Components.Forms.InputRadioGroup",
         "Attributes": [
           {
-            "Name": "@bind-Value:get",
-            "DisplayName": "@bind-Value:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:get"
           },
           {
-            "Name": "@bind-Value:set",
-            "DisplayName": "@bind-Value:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:set"
           }
         ]
       }
@@ -23081,10 +21918,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3264438285090029890,
-      "Data2": 1801940021254323519,
-      "Data3": -3020105652873365421,
-      "Data4": -7839071809104232476
+      "Data1": -3693141219311339236,
+      "Data2": 8410159910381503390,
+      "Data3": 5484097674249207208,
+      "Data4": -126909098070266478
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>",
@@ -23103,11 +21940,8 @@
         "TagName": "InputSelect",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       },
@@ -23115,18 +21949,12 @@
         "TagName": "InputSelect",
         "Attributes": [
           {
-            "Name": "@bind-Value:get",
-            "DisplayName": "@bind-Value:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:get"
           },
           {
-            "Name": "@bind-Value:set",
-            "DisplayName": "@bind-Value:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:set"
           }
         ]
       }
@@ -23191,10 +22019,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6842202156290866491,
-      "Data2": -3914392770148398935,
-      "Data3": -4192744942988181366,
-      "Data4": -2347925610916699686
+      "Data1": 3528299229099318765,
+      "Data2": 8223919418513807305,
+      "Data3": 8879996746598943632,
+      "Data4": -4735139797393080971
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>",
@@ -23213,11 +22041,8 @@
         "TagName": "Microsoft.AspNetCore.Components.Forms.InputSelect",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       },
@@ -23225,18 +22050,12 @@
         "TagName": "Microsoft.AspNetCore.Components.Forms.InputSelect",
         "Attributes": [
           {
-            "Name": "@bind-Value:get",
-            "DisplayName": "@bind-Value:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:get"
           },
           {
-            "Name": "@bind-Value:set",
-            "DisplayName": "@bind-Value:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:set"
           }
         ]
       }
@@ -23302,10 +22121,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 9090280802210564846,
-      "Data2": -6266284878899832283,
-      "Data3": 6989333063678890185,
-      "Data4": 2920980918393632342
+      "Data1": -6146091860497507523,
+      "Data2": 6556785666822826664,
+      "Data3": 8879319399505184078,
+      "Data4": 6902620913755275283
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputText",
@@ -23324,11 +22143,8 @@
         "TagName": "InputText",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       },
@@ -23336,18 +22152,12 @@
         "TagName": "InputText",
         "Attributes": [
           {
-            "Name": "@bind-Value:get",
-            "DisplayName": "@bind-Value:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:get"
           },
           {
-            "Name": "@bind-Value:set",
-            "DisplayName": "@bind-Value:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:set"
           }
         ]
       }
@@ -23412,10 +22222,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6590276302536833864,
-      "Data2": -5394958843841354575,
-      "Data3": 4288607606627449254,
-      "Data4": -9051709823621622449
+      "Data1": 6545074320035395792,
+      "Data2": -3355799273207522427,
+      "Data3": 5213073429438553555,
+      "Data4": -5791609774180348736
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputText",
@@ -23434,11 +22244,8 @@
         "TagName": "Microsoft.AspNetCore.Components.Forms.InputText",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       },
@@ -23446,18 +22253,12 @@
         "TagName": "Microsoft.AspNetCore.Components.Forms.InputText",
         "Attributes": [
           {
-            "Name": "@bind-Value:get",
-            "DisplayName": "@bind-Value:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:get"
           },
           {
-            "Name": "@bind-Value:set",
-            "DisplayName": "@bind-Value:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:set"
           }
         ]
       }
@@ -23523,10 +22324,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -429484931486236910,
-      "Data2": -7734931497761470796,
-      "Data3": -1015320485118632528,
-      "Data4": 3157981366101583363
+      "Data1": -8021011910432232630,
+      "Data2": -2786956617752370706,
+      "Data3": 1970831242442724648,
+      "Data4": -9178434859511662112
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputTextArea",
@@ -23545,11 +22346,8 @@
         "TagName": "InputTextArea",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       },
@@ -23557,18 +22355,12 @@
         "TagName": "InputTextArea",
         "Attributes": [
           {
-            "Name": "@bind-Value:get",
-            "DisplayName": "@bind-Value:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:get"
           },
           {
-            "Name": "@bind-Value:set",
-            "DisplayName": "@bind-Value:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:set"
           }
         ]
       }
@@ -23633,10 +22425,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2407412623707583861,
-      "Data2": -1616016677399057252,
-      "Data3": -724398860504216064,
-      "Data4": -2552689729345681718
+      "Data1": -6752161774456575714,
+      "Data2": -6755933093086924356,
+      "Data3": -5380920644661108568,
+      "Data4": -189171832529954035
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputTextArea",
@@ -23655,11 +22447,8 @@
         "TagName": "Microsoft.AspNetCore.Components.Forms.InputTextArea",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       },
@@ -23667,18 +22456,12 @@
         "TagName": "Microsoft.AspNetCore.Components.Forms.InputTextArea",
         "Attributes": [
           {
-            "Name": "@bind-Value:get",
-            "DisplayName": "@bind-Value:get",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:get"
           },
           {
-            "Name": "@bind-Value:set",
-            "DisplayName": "@bind-Value:set",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value:set"
           }
         ]
       }
@@ -23744,10 +22527,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8471053076684220184,
-      "Data2": 733975027910313587,
-      "Data3": 2670013795459003691,
-      "Data4": 7517720934849557693
+      "Data1": 8241577802313068336,
+      "Data2": -662247667978802400,
+      "Data3": 6678707511331583811,
+      "Data4": 7492898768020661457
     },
     "Kind": "Components.Ref",
     "Name": "Ref",
@@ -23762,11 +22545,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ref",
-            "DisplayName": "@ref",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ref"
           }
         ]
       }
@@ -23794,10 +22574,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1799122480488717236,
-      "Data2": -3037038074828170693,
-      "Data3": -6772261430420861497,
-      "Data4": -1932036478778670876
+      "Data1": -1068131698866358198,
+      "Data2": 62691019737764014,
+      "Data3": -7304881588193315808,
+      "Data4": -4146157435121999505
     },
     "Kind": "Components.Key",
     "Name": "Key",
@@ -23812,11 +22592,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@key",
-            "DisplayName": "@key",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@key"
           }
         ]
       }

--- a/src/Shared/files/Tooling/project.razor.json
+++ b/src/Shared/files/Tooling/project.razor.json
@@ -1,5 +1,5 @@
 {
-  "__Version": 10,
+  "__Version": 11,
   "ProjectKey": "C:/Users/admin/location/blazorserver/obj/Debug/net7.0/",
   "FilePath": "C:\\Users\\admin\\location\\blazorserver\\blazorserver.csproj",
   "Configuration": {
@@ -3797,10 +3797,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -7185869318604740139,
-          "Data2": 1266744045890869363,
-          "Data3": 7352259449973114746,
-          "Data4": 7043152225972481361
+          "Data1": -6149468512978995535,
+          "Data2": 758187971046944338,
+          "Data3": -8197916759391359447,
+          "Data4": 1672432993493435004
         },
         "Kind": "Components.EventHandler",
         "Name": "onabort",
@@ -3813,11 +3813,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onabort",
-                "DisplayName": "@onabort",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onabort"
               }
             ]
           },
@@ -3825,11 +3822,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onabort:preventDefault",
-                "DisplayName": "@onabort:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onabort:preventDefault"
               }
             ]
           },
@@ -3837,11 +3831,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onabort:stopPropagation",
-                "DisplayName": "@onabort:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onabort:stopPropagation"
               }
             ]
           }
@@ -3885,10 +3876,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -8300532361499004606,
-          "Data2": 854999057381832682,
-          "Data3": -902755126215940511,
-          "Data4": -6947721768026850105
+          "Data1": -1805208970925494509,
+          "Data2": -594869155216608152,
+          "Data3": -4625283657019804013,
+          "Data4": 7414194748224084394
         },
         "Kind": "Components.EventHandler",
         "Name": "onactivate",
@@ -3901,11 +3892,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onactivate",
-                "DisplayName": "@onactivate",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onactivate"
               }
             ]
           },
@@ -3913,11 +3901,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onactivate:preventDefault",
-                "DisplayName": "@onactivate:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onactivate:preventDefault"
               }
             ]
           },
@@ -3925,11 +3910,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onactivate:stopPropagation",
-                "DisplayName": "@onactivate:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onactivate:stopPropagation"
               }
             ]
           }
@@ -3973,10 +3955,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -3681368087013449715,
-          "Data2": 1706754919948434469,
-          "Data3": -5309422892307001556,
-          "Data4": 4120388465437424843
+          "Data1": 8094032824031635409,
+          "Data2": 7586561138673037798,
+          "Data3": -5744924611213459814,
+          "Data4": -8228314915692489805
         },
         "Kind": "Components.EventHandler",
         "Name": "onbeforeactivate",
@@ -3989,11 +3971,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onbeforeactivate",
-                "DisplayName": "@onbeforeactivate",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onbeforeactivate"
               }
             ]
           },
@@ -4001,11 +3980,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onbeforeactivate:preventDefault",
-                "DisplayName": "@onbeforeactivate:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onbeforeactivate:preventDefault"
               }
             ]
           },
@@ -4013,11 +3989,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onbeforeactivate:stopPropagation",
-                "DisplayName": "@onbeforeactivate:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onbeforeactivate:stopPropagation"
               }
             ]
           }
@@ -4061,10 +4034,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 5005358520951546475,
-          "Data2": -1863520435212253126,
-          "Data3": 7979764898830936391,
-          "Data4": 3977545847797089733
+          "Data1": 4843069744865351846,
+          "Data2": 2702503929940794901,
+          "Data3": -7491090305215837720,
+          "Data4": -4564897703255750231
         },
         "Kind": "Components.EventHandler",
         "Name": "onbeforecopy",
@@ -4077,11 +4050,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onbeforecopy",
-                "DisplayName": "@onbeforecopy",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onbeforecopy"
               }
             ]
           },
@@ -4089,11 +4059,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onbeforecopy:preventDefault",
-                "DisplayName": "@onbeforecopy:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onbeforecopy:preventDefault"
               }
             ]
           },
@@ -4101,11 +4068,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onbeforecopy:stopPropagation",
-                "DisplayName": "@onbeforecopy:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onbeforecopy:stopPropagation"
               }
             ]
           }
@@ -4149,10 +4113,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 254953506678173427,
-          "Data2": 656497337734799826,
-          "Data3": -5721114991822481504,
-          "Data4": -5659572082348998454
+          "Data1": -700558949241862568,
+          "Data2": 3749782703394152268,
+          "Data3": 4623428340057478536,
+          "Data4": 7338634138575681037
         },
         "Kind": "Components.EventHandler",
         "Name": "onbeforecut",
@@ -4165,11 +4129,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onbeforecut",
-                "DisplayName": "@onbeforecut",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onbeforecut"
               }
             ]
           },
@@ -4177,11 +4138,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onbeforecut:preventDefault",
-                "DisplayName": "@onbeforecut:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onbeforecut:preventDefault"
               }
             ]
           },
@@ -4189,11 +4147,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onbeforecut:stopPropagation",
-                "DisplayName": "@onbeforecut:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onbeforecut:stopPropagation"
               }
             ]
           }
@@ -4237,10 +4192,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 5998236281554342689,
-          "Data2": -1420832079730483711,
-          "Data3": -6962432517941287245,
-          "Data4": -302283119740540702
+          "Data1": -1913109564896506053,
+          "Data2": 4406052743976412923,
+          "Data3": 7902814546313246496,
+          "Data4": -3812159401577979893
         },
         "Kind": "Components.EventHandler",
         "Name": "onbeforedeactivate",
@@ -4253,11 +4208,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onbeforedeactivate",
-                "DisplayName": "@onbeforedeactivate",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onbeforedeactivate"
               }
             ]
           },
@@ -4265,11 +4217,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onbeforedeactivate:preventDefault",
-                "DisplayName": "@onbeforedeactivate:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onbeforedeactivate:preventDefault"
               }
             ]
           },
@@ -4277,11 +4226,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onbeforedeactivate:stopPropagation",
-                "DisplayName": "@onbeforedeactivate:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onbeforedeactivate:stopPropagation"
               }
             ]
           }
@@ -4325,10 +4271,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 8858228293029966369,
-          "Data2": -5207907779052301717,
-          "Data3": 4320986515400584397,
-          "Data4": 60653984184612181
+          "Data1": 246227753572677039,
+          "Data2": 7310137314303675084,
+          "Data3": -8130073642956667623,
+          "Data4": 4543044551753766551
         },
         "Kind": "Components.EventHandler",
         "Name": "onbeforepaste",
@@ -4341,11 +4287,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onbeforepaste",
-                "DisplayName": "@onbeforepaste",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onbeforepaste"
               }
             ]
           },
@@ -4353,11 +4296,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onbeforepaste:preventDefault",
-                "DisplayName": "@onbeforepaste:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onbeforepaste:preventDefault"
               }
             ]
           },
@@ -4365,11 +4305,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onbeforepaste:stopPropagation",
-                "DisplayName": "@onbeforepaste:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onbeforepaste:stopPropagation"
               }
             ]
           }
@@ -4413,10 +4350,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -4528298221161968077,
-          "Data2": -5949511076020729716,
-          "Data3": -1678589538090319120,
-          "Data4": 1435113847205400560
+          "Data1": 2602744706177386271,
+          "Data2": -6407889349391162132,
+          "Data3": 9066527711613360726,
+          "Data4": -2031931930791909026
         },
         "Kind": "Components.EventHandler",
         "Name": "onblur",
@@ -4429,11 +4366,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onblur",
-                "DisplayName": "@onblur",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onblur"
               }
             ]
           },
@@ -4441,11 +4375,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onblur:preventDefault",
-                "DisplayName": "@onblur:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onblur:preventDefault"
               }
             ]
           },
@@ -4453,11 +4384,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onblur:stopPropagation",
-                "DisplayName": "@onblur:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onblur:stopPropagation"
               }
             ]
           }
@@ -4501,10 +4429,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 1892125199373762621,
-          "Data2": 380988957736880981,
-          "Data3": -5577440301498642388,
-          "Data4": 3854944777952895040
+          "Data1": 5957844510830803544,
+          "Data2": 4254220876008683505,
+          "Data3": -7895128175585019563,
+          "Data4": 7566686124866061521
         },
         "Kind": "Components.EventHandler",
         "Name": "oncanplay",
@@ -4517,11 +4445,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@oncanplay",
-                "DisplayName": "@oncanplay",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@oncanplay"
               }
             ]
           },
@@ -4529,11 +4454,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@oncanplay:preventDefault",
-                "DisplayName": "@oncanplay:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@oncanplay:preventDefault"
               }
             ]
           },
@@ -4541,11 +4463,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@oncanplay:stopPropagation",
-                "DisplayName": "@oncanplay:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@oncanplay:stopPropagation"
               }
             ]
           }
@@ -4589,10 +4508,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -6417109148879373144,
-          "Data2": -5216029134280523214,
-          "Data3": 663072832703797255,
-          "Data4": 7607191632481161555
+          "Data1": 6656340910552291425,
+          "Data2": 8220550027642629643,
+          "Data3": -3524984334834265659,
+          "Data4": 5346171168776002337
         },
         "Kind": "Components.EventHandler",
         "Name": "oncanplaythrough",
@@ -4605,11 +4524,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@oncanplaythrough",
-                "DisplayName": "@oncanplaythrough",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@oncanplaythrough"
               }
             ]
           },
@@ -4617,11 +4533,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@oncanplaythrough:preventDefault",
-                "DisplayName": "@oncanplaythrough:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@oncanplaythrough:preventDefault"
               }
             ]
           },
@@ -4629,11 +4542,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@oncanplaythrough:stopPropagation",
-                "DisplayName": "@oncanplaythrough:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@oncanplaythrough:stopPropagation"
               }
             ]
           }
@@ -4677,10 +4587,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 6780348617368014301,
-          "Data2": 8525139024005634855,
-          "Data3": -2352843958001868051,
-          "Data4": -4789685502587947193
+          "Data1": -3857163207008466599,
+          "Data2": 2113681961243785822,
+          "Data3": -3671294372143802891,
+          "Data4": 36145750722787107
         },
         "Kind": "Components.EventHandler",
         "Name": "onchange",
@@ -4693,11 +4603,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onchange",
-                "DisplayName": "@onchange",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onchange"
               }
             ]
           },
@@ -4705,11 +4612,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onchange:preventDefault",
-                "DisplayName": "@onchange:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onchange:preventDefault"
               }
             ]
           },
@@ -4717,11 +4621,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onchange:stopPropagation",
-                "DisplayName": "@onchange:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onchange:stopPropagation"
               }
             ]
           }
@@ -4765,10 +4666,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -8103443168700733929,
-          "Data2": -6911235250501572401,
-          "Data3": -5412405907229474075,
-          "Data4": -3488741747911843477
+          "Data1": -1560726501750249937,
+          "Data2": 148261790923257051,
+          "Data3": 5015158278997361118,
+          "Data4": -1607293725219147553
         },
         "Kind": "Components.EventHandler",
         "Name": "onclick",
@@ -4781,11 +4682,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onclick",
-                "DisplayName": "@onclick",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onclick"
               }
             ]
           },
@@ -4793,11 +4691,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onclick:preventDefault",
-                "DisplayName": "@onclick:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onclick:preventDefault"
               }
             ]
           },
@@ -4805,11 +4700,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onclick:stopPropagation",
-                "DisplayName": "@onclick:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onclick:stopPropagation"
               }
             ]
           }
@@ -4853,10 +4745,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -3646788032127206908,
-          "Data2": -6974094337749969146,
-          "Data3": -9154077109796387926,
-          "Data4": 6631452549439957642
+          "Data1": -1116389842734098588,
+          "Data2": -4808782172849818348,
+          "Data3": -2483540699034589803,
+          "Data4": -3658085948308120185
         },
         "Kind": "Components.EventHandler",
         "Name": "oncontextmenu",
@@ -4869,11 +4761,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@oncontextmenu",
-                "DisplayName": "@oncontextmenu",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@oncontextmenu"
               }
             ]
           },
@@ -4881,11 +4770,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@oncontextmenu:preventDefault",
-                "DisplayName": "@oncontextmenu:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@oncontextmenu:preventDefault"
               }
             ]
           },
@@ -4893,11 +4779,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@oncontextmenu:stopPropagation",
-                "DisplayName": "@oncontextmenu:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@oncontextmenu:stopPropagation"
               }
             ]
           }
@@ -4941,10 +4824,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -1801345638014640380,
-          "Data2": -5776314023726260384,
-          "Data3": -3557943133529042211,
-          "Data4": -7700866317228252321
+          "Data1": -1204762064173830262,
+          "Data2": -4510278277136537850,
+          "Data3": 4785640090503862560,
+          "Data4": -2479682132258022778
         },
         "Kind": "Components.EventHandler",
         "Name": "oncopy",
@@ -4957,11 +4840,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@oncopy",
-                "DisplayName": "@oncopy",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@oncopy"
               }
             ]
           },
@@ -4969,11 +4849,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@oncopy:preventDefault",
-                "DisplayName": "@oncopy:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@oncopy:preventDefault"
               }
             ]
           },
@@ -4981,11 +4858,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@oncopy:stopPropagation",
-                "DisplayName": "@oncopy:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@oncopy:stopPropagation"
               }
             ]
           }
@@ -5029,10 +4903,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -8553962487927456731,
-          "Data2": -4140973295189806341,
-          "Data3": 2359164150377993109,
-          "Data4": -6263867169461712955
+          "Data1": -3321501028344939106,
+          "Data2": -7530559755662774181,
+          "Data3": -8887845401249477808,
+          "Data4": 2709284071515456371
         },
         "Kind": "Components.EventHandler",
         "Name": "oncuechange",
@@ -5045,11 +4919,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@oncuechange",
-                "DisplayName": "@oncuechange",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@oncuechange"
               }
             ]
           },
@@ -5057,11 +4928,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@oncuechange:preventDefault",
-                "DisplayName": "@oncuechange:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@oncuechange:preventDefault"
               }
             ]
           },
@@ -5069,11 +4937,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@oncuechange:stopPropagation",
-                "DisplayName": "@oncuechange:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@oncuechange:stopPropagation"
               }
             ]
           }
@@ -5117,10 +4982,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -5798522915240585359,
-          "Data2": 4007661949163750611,
-          "Data3": 3840586293082212082,
-          "Data4": -3698329017368706813
+          "Data1": 1144030553355467506,
+          "Data2": -2219402751672377507,
+          "Data3": -8881516716299622272,
+          "Data4": -8411447246749474016
         },
         "Kind": "Components.EventHandler",
         "Name": "oncut",
@@ -5133,11 +4998,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@oncut",
-                "DisplayName": "@oncut",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@oncut"
               }
             ]
           },
@@ -5145,11 +5007,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@oncut:preventDefault",
-                "DisplayName": "@oncut:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@oncut:preventDefault"
               }
             ]
           },
@@ -5157,11 +5016,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@oncut:stopPropagation",
-                "DisplayName": "@oncut:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@oncut:stopPropagation"
               }
             ]
           }
@@ -5205,10 +5061,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 1141247401040638157,
-          "Data2": 2277194456865445772,
-          "Data3": 7709499647001075365,
-          "Data4": 3263240579429817108
+          "Data1": -8806718804999159239,
+          "Data2": -6417390545437270011,
+          "Data3": 3485051680942832790,
+          "Data4": -4694922216581030817
         },
         "Kind": "Components.EventHandler",
         "Name": "ondblclick",
@@ -5221,11 +5077,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondblclick",
-                "DisplayName": "@ondblclick",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondblclick"
               }
             ]
           },
@@ -5233,11 +5086,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondblclick:preventDefault",
-                "DisplayName": "@ondblclick:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondblclick:preventDefault"
               }
             ]
           },
@@ -5245,11 +5095,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondblclick:stopPropagation",
-                "DisplayName": "@ondblclick:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondblclick:stopPropagation"
               }
             ]
           }
@@ -5293,10 +5140,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 3307789522207218683,
-          "Data2": -5166754862892962557,
-          "Data3": 2133498849378304817,
-          "Data4": 8511945813689698568
+          "Data1": 4147813645654259325,
+          "Data2": -5907551368269296591,
+          "Data3": -1921074556631247225,
+          "Data4": -422127882600145512
         },
         "Kind": "Components.EventHandler",
         "Name": "ondeactivate",
@@ -5309,11 +5156,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondeactivate",
-                "DisplayName": "@ondeactivate",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondeactivate"
               }
             ]
           },
@@ -5321,11 +5165,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondeactivate:preventDefault",
-                "DisplayName": "@ondeactivate:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondeactivate:preventDefault"
               }
             ]
           },
@@ -5333,11 +5174,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondeactivate:stopPropagation",
-                "DisplayName": "@ondeactivate:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondeactivate:stopPropagation"
               }
             ]
           }
@@ -5381,10 +5219,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -3971027640034613206,
-          "Data2": 5042178227829604736,
-          "Data3": -121111243416218833,
-          "Data4": 8367313766383784857
+          "Data1": -3294252354818037101,
+          "Data2": -2445030416538313283,
+          "Data3": 8360606178794600453,
+          "Data4": -3377104740670194665
         },
         "Kind": "Components.EventHandler",
         "Name": "ondrag",
@@ -5397,11 +5235,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondrag",
-                "DisplayName": "@ondrag",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondrag"
               }
             ]
           },
@@ -5409,11 +5244,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondrag:preventDefault",
-                "DisplayName": "@ondrag:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondrag:preventDefault"
               }
             ]
           },
@@ -5421,11 +5253,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondrag:stopPropagation",
-                "DisplayName": "@ondrag:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondrag:stopPropagation"
               }
             ]
           }
@@ -5469,10 +5298,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 4601150040565282116,
-          "Data2": 8175906426495218935,
-          "Data3": 8655249903144333231,
-          "Data4": -2338133232019961329
+          "Data1": -2510295031227324583,
+          "Data2": -9184054799171823071,
+          "Data3": 3165420459075734320,
+          "Data4": 3256169798171445371
         },
         "Kind": "Components.EventHandler",
         "Name": "ondragend",
@@ -5485,11 +5314,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondragend",
-                "DisplayName": "@ondragend",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondragend"
               }
             ]
           },
@@ -5497,11 +5323,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondragend:preventDefault",
-                "DisplayName": "@ondragend:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondragend:preventDefault"
               }
             ]
           },
@@ -5509,11 +5332,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondragend:stopPropagation",
-                "DisplayName": "@ondragend:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondragend:stopPropagation"
               }
             ]
           }
@@ -5557,10 +5377,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -2544703068246711798,
-          "Data2": -3844339009414526648,
-          "Data3": 599480062940613391,
-          "Data4": 8963675232117641429
+          "Data1": -7829524007668587137,
+          "Data2": -4723569884359440332,
+          "Data3": -875770198924811702,
+          "Data4": -9072562598084508154
         },
         "Kind": "Components.EventHandler",
         "Name": "ondragenter",
@@ -5573,11 +5393,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondragenter",
-                "DisplayName": "@ondragenter",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondragenter"
               }
             ]
           },
@@ -5585,11 +5402,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondragenter:preventDefault",
-                "DisplayName": "@ondragenter:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondragenter:preventDefault"
               }
             ]
           },
@@ -5597,11 +5411,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondragenter:stopPropagation",
-                "DisplayName": "@ondragenter:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondragenter:stopPropagation"
               }
             ]
           }
@@ -5645,10 +5456,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -603820631122538782,
-          "Data2": 6117031101746764137,
-          "Data3": -1807964945543940673,
-          "Data4": -378984891486118370
+          "Data1": -206579956413000992,
+          "Data2": 7185029009635258615,
+          "Data3": -5707883960702365242,
+          "Data4": 5018391140069950598
         },
         "Kind": "Components.EventHandler",
         "Name": "ondragleave",
@@ -5661,11 +5472,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondragleave",
-                "DisplayName": "@ondragleave",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondragleave"
               }
             ]
           },
@@ -5673,11 +5481,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondragleave:preventDefault",
-                "DisplayName": "@ondragleave:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondragleave:preventDefault"
               }
             ]
           },
@@ -5685,11 +5490,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondragleave:stopPropagation",
-                "DisplayName": "@ondragleave:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondragleave:stopPropagation"
               }
             ]
           }
@@ -5733,10 +5535,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -9154575738318105975,
-          "Data2": -2435068396200159572,
-          "Data3": 5023923861701015648,
-          "Data4": 4303306424838097015
+          "Data1": -4224030625650002780,
+          "Data2": -5995153366885795108,
+          "Data3": -4441255700661130688,
+          "Data4": 8944699288004045172
         },
         "Kind": "Components.EventHandler",
         "Name": "ondragover",
@@ -5749,11 +5551,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondragover",
-                "DisplayName": "@ondragover",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondragover"
               }
             ]
           },
@@ -5761,11 +5560,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondragover:preventDefault",
-                "DisplayName": "@ondragover:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondragover:preventDefault"
               }
             ]
           },
@@ -5773,11 +5569,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondragover:stopPropagation",
-                "DisplayName": "@ondragover:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondragover:stopPropagation"
               }
             ]
           }
@@ -5821,10 +5614,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 3083299950790812217,
-          "Data2": -4968702566915380517,
-          "Data3": -4472887354064608249,
-          "Data4": 3810560918520983291
+          "Data1": 4794452213461418007,
+          "Data2": -9039684359258260320,
+          "Data3": -3017139799976738827,
+          "Data4": 9106932971497603704
         },
         "Kind": "Components.EventHandler",
         "Name": "ondragstart",
@@ -5837,11 +5630,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondragstart",
-                "DisplayName": "@ondragstart",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondragstart"
               }
             ]
           },
@@ -5849,11 +5639,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondragstart:preventDefault",
-                "DisplayName": "@ondragstart:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondragstart:preventDefault"
               }
             ]
           },
@@ -5861,11 +5648,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondragstart:stopPropagation",
-                "DisplayName": "@ondragstart:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondragstart:stopPropagation"
               }
             ]
           }
@@ -5909,10 +5693,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 935830456054590141,
-          "Data2": 6443916597130182316,
-          "Data3": 8844323502459125925,
-          "Data4": -7457467704015705562
+          "Data1": -5423674691388779458,
+          "Data2": -2722522976864819143,
+          "Data3": 19216789288993075,
+          "Data4": 7327836565907216735
         },
         "Kind": "Components.EventHandler",
         "Name": "ondrop",
@@ -5925,11 +5709,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondrop",
-                "DisplayName": "@ondrop",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondrop"
               }
             ]
           },
@@ -5937,11 +5718,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondrop:preventDefault",
-                "DisplayName": "@ondrop:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondrop:preventDefault"
               }
             ]
           },
@@ -5949,11 +5727,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondrop:stopPropagation",
-                "DisplayName": "@ondrop:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondrop:stopPropagation"
               }
             ]
           }
@@ -5997,10 +5772,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 6432534032227519227,
-          "Data2": -2924799898615421785,
-          "Data3": 6209592232426818343,
-          "Data4": 3447830059337752498
+          "Data1": 214019447438315997,
+          "Data2": -3281927221722086239,
+          "Data3": 5358300335297953406,
+          "Data4": 1752982294655578099
         },
         "Kind": "Components.EventHandler",
         "Name": "ondurationchange",
@@ -6013,11 +5788,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondurationchange",
-                "DisplayName": "@ondurationchange",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondurationchange"
               }
             ]
           },
@@ -6025,11 +5797,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondurationchange:preventDefault",
-                "DisplayName": "@ondurationchange:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondurationchange:preventDefault"
               }
             ]
           },
@@ -6037,11 +5806,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ondurationchange:stopPropagation",
-                "DisplayName": "@ondurationchange:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ondurationchange:stopPropagation"
               }
             ]
           }
@@ -6085,10 +5851,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 7176251681502761364,
-          "Data2": 793105031127567863,
-          "Data3": 1642741129950405811,
-          "Data4": -5797995583437017070
+          "Data1": -8708422208986495080,
+          "Data2": -2762714952693247751,
+          "Data3": -6875369797188153336,
+          "Data4": 524918462036041825
         },
         "Kind": "Components.EventHandler",
         "Name": "onemptied",
@@ -6101,11 +5867,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onemptied",
-                "DisplayName": "@onemptied",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onemptied"
               }
             ]
           },
@@ -6113,11 +5876,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onemptied:preventDefault",
-                "DisplayName": "@onemptied:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onemptied:preventDefault"
               }
             ]
           },
@@ -6125,11 +5885,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onemptied:stopPropagation",
-                "DisplayName": "@onemptied:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onemptied:stopPropagation"
               }
             ]
           }
@@ -6173,10 +5930,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -7317323689869026524,
-          "Data2": 3798310874467210894,
-          "Data3": 1216027367430773556,
-          "Data4": 2575865312152985327
+          "Data1": -4554416900238852353,
+          "Data2": 5238658343516163038,
+          "Data3": -182436746325260686,
+          "Data4": 2664282900204696076
         },
         "Kind": "Components.EventHandler",
         "Name": "onended",
@@ -6189,11 +5946,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onended",
-                "DisplayName": "@onended",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onended"
               }
             ]
           },
@@ -6201,11 +5955,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onended:preventDefault",
-                "DisplayName": "@onended:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onended:preventDefault"
               }
             ]
           },
@@ -6213,11 +5964,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onended:stopPropagation",
-                "DisplayName": "@onended:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onended:stopPropagation"
               }
             ]
           }
@@ -6261,10 +6009,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 4218487070720220381,
-          "Data2": -5578517268464598094,
-          "Data3": -9015511342552368416,
-          "Data4": 1026379393625161924
+          "Data1": 2809875565666366167,
+          "Data2": -9188463250865273443,
+          "Data3": -1196263309607459172,
+          "Data4": 7846197091763169895
         },
         "Kind": "Components.EventHandler",
         "Name": "onerror",
@@ -6277,11 +6025,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onerror",
-                "DisplayName": "@onerror",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onerror"
               }
             ]
           },
@@ -6289,11 +6034,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onerror:preventDefault",
-                "DisplayName": "@onerror:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onerror:preventDefault"
               }
             ]
           },
@@ -6301,11 +6043,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onerror:stopPropagation",
-                "DisplayName": "@onerror:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onerror:stopPropagation"
               }
             ]
           }
@@ -6349,10 +6088,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 5952537330027437152,
-          "Data2": -2364310788504605699,
-          "Data3": -5143931978055261402,
-          "Data4": -7338955179103254898
+          "Data1": -7397293074606110482,
+          "Data2": -1530717216879986499,
+          "Data3": -7490600609509723687,
+          "Data4": 9168180149504697034
         },
         "Kind": "Components.EventHandler",
         "Name": "onfocus",
@@ -6365,11 +6104,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onfocus",
-                "DisplayName": "@onfocus",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onfocus"
               }
             ]
           },
@@ -6377,11 +6113,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onfocus:preventDefault",
-                "DisplayName": "@onfocus:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onfocus:preventDefault"
               }
             ]
           },
@@ -6389,11 +6122,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onfocus:stopPropagation",
-                "DisplayName": "@onfocus:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onfocus:stopPropagation"
               }
             ]
           }
@@ -6437,10 +6167,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 1963785329310803167,
-          "Data2": 4062222865568090195,
-          "Data3": -8613580747884273239,
-          "Data4": 5771109156451271566
+          "Data1": 5026440531955946295,
+          "Data2": 562847148800056550,
+          "Data3": -2607921947714439444,
+          "Data4": -2579332674445229939
         },
         "Kind": "Components.EventHandler",
         "Name": "onfocusin",
@@ -6453,11 +6183,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onfocusin",
-                "DisplayName": "@onfocusin",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onfocusin"
               }
             ]
           },
@@ -6465,11 +6192,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onfocusin:preventDefault",
-                "DisplayName": "@onfocusin:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onfocusin:preventDefault"
               }
             ]
           },
@@ -6477,11 +6201,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onfocusin:stopPropagation",
-                "DisplayName": "@onfocusin:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onfocusin:stopPropagation"
               }
             ]
           }
@@ -6525,10 +6246,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -5152788383053143318,
-          "Data2": 6122717765153124112,
-          "Data3": -97135714486118605,
-          "Data4": -8514905249756934125
+          "Data1": -2680942304667449139,
+          "Data2": 2477756332688778335,
+          "Data3": -1217409248355910645,
+          "Data4": 9155688076473166849
         },
         "Kind": "Components.EventHandler",
         "Name": "onfocusout",
@@ -6541,11 +6262,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onfocusout",
-                "DisplayName": "@onfocusout",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onfocusout"
               }
             ]
           },
@@ -6553,11 +6271,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onfocusout:preventDefault",
-                "DisplayName": "@onfocusout:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onfocusout:preventDefault"
               }
             ]
           },
@@ -6565,11 +6280,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onfocusout:stopPropagation",
-                "DisplayName": "@onfocusout:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onfocusout:stopPropagation"
               }
             ]
           }
@@ -6613,10 +6325,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -4540934740724939268,
-          "Data2": -5361594406278152334,
-          "Data3": 6540418271600002087,
-          "Data4": 4593000682503910564
+          "Data1": 2151094400620944168,
+          "Data2": 6727243794449941786,
+          "Data3": 7038534020465911792,
+          "Data4": -1383499837654537315
         },
         "Kind": "Components.EventHandler",
         "Name": "onfullscreenchange",
@@ -6629,11 +6341,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onfullscreenchange",
-                "DisplayName": "@onfullscreenchange",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onfullscreenchange"
               }
             ]
           },
@@ -6641,11 +6350,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onfullscreenchange:preventDefault",
-                "DisplayName": "@onfullscreenchange:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onfullscreenchange:preventDefault"
               }
             ]
           },
@@ -6653,11 +6359,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onfullscreenchange:stopPropagation",
-                "DisplayName": "@onfullscreenchange:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onfullscreenchange:stopPropagation"
               }
             ]
           }
@@ -6701,10 +6404,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -80512023763574386,
-          "Data2": -1205366447683213333,
-          "Data3": 8707755760609381741,
-          "Data4": -2890727083912684227
+          "Data1": -522175510408569136,
+          "Data2": -3886206302592461716,
+          "Data3": -4109034068234513776,
+          "Data4": -8788615370973760086
         },
         "Kind": "Components.EventHandler",
         "Name": "onfullscreenerror",
@@ -6717,11 +6420,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onfullscreenerror",
-                "DisplayName": "@onfullscreenerror",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onfullscreenerror"
               }
             ]
           },
@@ -6729,11 +6429,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onfullscreenerror:preventDefault",
-                "DisplayName": "@onfullscreenerror:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onfullscreenerror:preventDefault"
               }
             ]
           },
@@ -6741,11 +6438,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onfullscreenerror:stopPropagation",
-                "DisplayName": "@onfullscreenerror:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onfullscreenerror:stopPropagation"
               }
             ]
           }
@@ -6789,10 +6483,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -323475231051038962,
-          "Data2": -7491078729319372522,
-          "Data3": 5267872635142330093,
-          "Data4": -4694185516221206718
+          "Data1": -1780445450501630633,
+          "Data2": 1848905132315268166,
+          "Data3": -4757805793303995299,
+          "Data4": 2582261302568284728
         },
         "Kind": "Components.EventHandler",
         "Name": "ongotpointercapture",
@@ -6805,11 +6499,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ongotpointercapture",
-                "DisplayName": "@ongotpointercapture",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ongotpointercapture"
               }
             ]
           },
@@ -6817,11 +6508,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ongotpointercapture:preventDefault",
-                "DisplayName": "@ongotpointercapture:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ongotpointercapture:preventDefault"
               }
             ]
           },
@@ -6829,11 +6517,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ongotpointercapture:stopPropagation",
-                "DisplayName": "@ongotpointercapture:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ongotpointercapture:stopPropagation"
               }
             ]
           }
@@ -6877,10 +6562,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 7012990235676648942,
-          "Data2": -242970938381580547,
-          "Data3": -9152498249791379481,
-          "Data4": 6807485459192046558
+          "Data1": -6231210906612962927,
+          "Data2": -2711610619601498257,
+          "Data3": -5703913484947778576,
+          "Data4": -8811605075170227185
         },
         "Kind": "Components.EventHandler",
         "Name": "oninput",
@@ -6893,11 +6578,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@oninput",
-                "DisplayName": "@oninput",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@oninput"
               }
             ]
           },
@@ -6905,11 +6587,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@oninput:preventDefault",
-                "DisplayName": "@oninput:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@oninput:preventDefault"
               }
             ]
           },
@@ -6917,11 +6596,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@oninput:stopPropagation",
-                "DisplayName": "@oninput:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@oninput:stopPropagation"
               }
             ]
           }
@@ -6965,10 +6641,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 4140131986068099268,
-          "Data2": 5778188919659894930,
-          "Data3": -8984740439060137997,
-          "Data4": 6093345290385440595
+          "Data1": 5519768072458355089,
+          "Data2": -2064444543166626877,
+          "Data3": -5782514036834914019,
+          "Data4": -3476339069579196393
         },
         "Kind": "Components.EventHandler",
         "Name": "oninvalid",
@@ -6981,11 +6657,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@oninvalid",
-                "DisplayName": "@oninvalid",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@oninvalid"
               }
             ]
           },
@@ -6993,11 +6666,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@oninvalid:preventDefault",
-                "DisplayName": "@oninvalid:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@oninvalid:preventDefault"
               }
             ]
           },
@@ -7005,11 +6675,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@oninvalid:stopPropagation",
-                "DisplayName": "@oninvalid:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@oninvalid:stopPropagation"
               }
             ]
           }
@@ -7053,10 +6720,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 7388829674657333435,
-          "Data2": 7004998130754596244,
-          "Data3": -1579151717965161512,
-          "Data4": -6194561806369711246
+          "Data1": 8852026219208113898,
+          "Data2": -7699951046774629316,
+          "Data3": -704320462105300342,
+          "Data4": -7258644519679581739
         },
         "Kind": "Components.EventHandler",
         "Name": "onkeydown",
@@ -7069,11 +6736,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onkeydown",
-                "DisplayName": "@onkeydown",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onkeydown"
               }
             ]
           },
@@ -7081,11 +6745,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onkeydown:preventDefault",
-                "DisplayName": "@onkeydown:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onkeydown:preventDefault"
               }
             ]
           },
@@ -7093,11 +6754,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onkeydown:stopPropagation",
-                "DisplayName": "@onkeydown:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onkeydown:stopPropagation"
               }
             ]
           }
@@ -7141,10 +6799,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -8809473822173676466,
-          "Data2": 4114145171708624415,
-          "Data3": -587994465041241124,
-          "Data4": 1718318931641151579
+          "Data1": -3970630358786875293,
+          "Data2": -5582451072542807118,
+          "Data3": -5362938517790123649,
+          "Data4": -5365447188590268254
         },
         "Kind": "Components.EventHandler",
         "Name": "onkeypress",
@@ -7157,11 +6815,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onkeypress",
-                "DisplayName": "@onkeypress",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onkeypress"
               }
             ]
           },
@@ -7169,11 +6824,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onkeypress:preventDefault",
-                "DisplayName": "@onkeypress:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onkeypress:preventDefault"
               }
             ]
           },
@@ -7181,11 +6833,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onkeypress:stopPropagation",
-                "DisplayName": "@onkeypress:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onkeypress:stopPropagation"
               }
             ]
           }
@@ -7229,10 +6878,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -1050830011451391982,
-          "Data2": 146129200320685063,
-          "Data3": -2752290423156559593,
-          "Data4": -982313209953280895
+          "Data1": -2467422439488932910,
+          "Data2": -5236447598450906068,
+          "Data3": 4412842774154973903,
+          "Data4": -6900106573732297262
         },
         "Kind": "Components.EventHandler",
         "Name": "onkeyup",
@@ -7245,11 +6894,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onkeyup",
-                "DisplayName": "@onkeyup",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onkeyup"
               }
             ]
           },
@@ -7257,11 +6903,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onkeyup:preventDefault",
-                "DisplayName": "@onkeyup:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onkeyup:preventDefault"
               }
             ]
           },
@@ -7269,11 +6912,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onkeyup:stopPropagation",
-                "DisplayName": "@onkeyup:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onkeyup:stopPropagation"
               }
             ]
           }
@@ -7317,10 +6957,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -4895298995921209103,
-          "Data2": -4398235020243634804,
-          "Data3": -9203117683559151385,
-          "Data4": -2807978460185291108
+          "Data1": 6503004461232236068,
+          "Data2": -1869727307106235779,
+          "Data3": -9161417249868370005,
+          "Data4": -1118439130888785889
         },
         "Kind": "Components.EventHandler",
         "Name": "onload",
@@ -7333,11 +6973,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onload",
-                "DisplayName": "@onload",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onload"
               }
             ]
           },
@@ -7345,11 +6982,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onload:preventDefault",
-                "DisplayName": "@onload:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onload:preventDefault"
               }
             ]
           },
@@ -7357,11 +6991,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onload:stopPropagation",
-                "DisplayName": "@onload:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onload:stopPropagation"
               }
             ]
           }
@@ -7405,10 +7036,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 7578014425924351235,
-          "Data2": -4955574261112010754,
-          "Data3": -8317743918882351619,
-          "Data4": 1140902661960732738
+          "Data1": -8496068036364201354,
+          "Data2": -2885257568015304759,
+          "Data3": 723552628833709086,
+          "Data4": 2708700083939132305
         },
         "Kind": "Components.EventHandler",
         "Name": "onloadeddata",
@@ -7421,11 +7052,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onloadeddata",
-                "DisplayName": "@onloadeddata",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onloadeddata"
               }
             ]
           },
@@ -7433,11 +7061,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onloadeddata:preventDefault",
-                "DisplayName": "@onloadeddata:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onloadeddata:preventDefault"
               }
             ]
           },
@@ -7445,11 +7070,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onloadeddata:stopPropagation",
-                "DisplayName": "@onloadeddata:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onloadeddata:stopPropagation"
               }
             ]
           }
@@ -7493,10 +7115,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 4611079111657132786,
-          "Data2": -643654385775602938,
-          "Data3": 3485405907981295335,
-          "Data4": -1286127212698286851
+          "Data1": 41149717577884286,
+          "Data2": 7999802658308335121,
+          "Data3": -6198340322159682477,
+          "Data4": 6854686569293198949
         },
         "Kind": "Components.EventHandler",
         "Name": "onloadedmetadata",
@@ -7509,11 +7131,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onloadedmetadata",
-                "DisplayName": "@onloadedmetadata",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onloadedmetadata"
               }
             ]
           },
@@ -7521,11 +7140,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onloadedmetadata:preventDefault",
-                "DisplayName": "@onloadedmetadata:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onloadedmetadata:preventDefault"
               }
             ]
           },
@@ -7533,11 +7149,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onloadedmetadata:stopPropagation",
-                "DisplayName": "@onloadedmetadata:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onloadedmetadata:stopPropagation"
               }
             ]
           }
@@ -7581,10 +7194,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -3916582289612656701,
-          "Data2": -6901651429604899888,
-          "Data3": 5991811088085112636,
-          "Data4": -7865461190550542044
+          "Data1": 3029981543005024951,
+          "Data2": -5982525017462156459,
+          "Data3": 2368224722642161964,
+          "Data4": -4455341827417771401
         },
         "Kind": "Components.EventHandler",
         "Name": "onloadend",
@@ -7597,11 +7210,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onloadend",
-                "DisplayName": "@onloadend",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onloadend"
               }
             ]
           },
@@ -7609,11 +7219,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onloadend:preventDefault",
-                "DisplayName": "@onloadend:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onloadend:preventDefault"
               }
             ]
           },
@@ -7621,11 +7228,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onloadend:stopPropagation",
-                "DisplayName": "@onloadend:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onloadend:stopPropagation"
               }
             ]
           }
@@ -7669,10 +7273,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -6620870422699118137,
-          "Data2": -742727370848380124,
-          "Data3": -8165102667604339678,
-          "Data4": -2582130758413984269
+          "Data1": -1782993236971788013,
+          "Data2": -5742016432606248459,
+          "Data3": 8132668648271189348,
+          "Data4": 2820629088217899745
         },
         "Kind": "Components.EventHandler",
         "Name": "onloadstart",
@@ -7685,11 +7289,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onloadstart",
-                "DisplayName": "@onloadstart",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onloadstart"
               }
             ]
           },
@@ -7697,11 +7298,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onloadstart:preventDefault",
-                "DisplayName": "@onloadstart:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onloadstart:preventDefault"
               }
             ]
           },
@@ -7709,11 +7307,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onloadstart:stopPropagation",
-                "DisplayName": "@onloadstart:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onloadstart:stopPropagation"
               }
             ]
           }
@@ -7757,10 +7352,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 8376339645682673586,
-          "Data2": -5431962627570531157,
-          "Data3": -7223577022614846299,
-          "Data4": 3350849269904885251
+          "Data1": -6637136007499409842,
+          "Data2": -6303289742423501247,
+          "Data3": -4893953849687985941,
+          "Data4": 3472164489231474667
         },
         "Kind": "Components.EventHandler",
         "Name": "onlostpointercapture",
@@ -7773,11 +7368,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onlostpointercapture",
-                "DisplayName": "@onlostpointercapture",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onlostpointercapture"
               }
             ]
           },
@@ -7785,11 +7377,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onlostpointercapture:preventDefault",
-                "DisplayName": "@onlostpointercapture:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onlostpointercapture:preventDefault"
               }
             ]
           },
@@ -7797,11 +7386,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onlostpointercapture:stopPropagation",
-                "DisplayName": "@onlostpointercapture:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onlostpointercapture:stopPropagation"
               }
             ]
           }
@@ -7845,10 +7431,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 85490524366915387,
-          "Data2": -7672361594115455654,
-          "Data3": 930006045806036201,
-          "Data4": 6481220027802324338
+          "Data1": 4744552595599607474,
+          "Data2": -2902962455970868150,
+          "Data3": -3670286617599794367,
+          "Data4": -424133635556548551
         },
         "Kind": "Components.EventHandler",
         "Name": "onmousedown",
@@ -7861,11 +7447,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onmousedown",
-                "DisplayName": "@onmousedown",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onmousedown"
               }
             ]
           },
@@ -7873,11 +7456,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onmousedown:preventDefault",
-                "DisplayName": "@onmousedown:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onmousedown:preventDefault"
               }
             ]
           },
@@ -7885,11 +7465,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onmousedown:stopPropagation",
-                "DisplayName": "@onmousedown:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onmousedown:stopPropagation"
               }
             ]
           }
@@ -7933,10 +7510,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -7100107938822728515,
-          "Data2": -2916780864129095540,
-          "Data3": -6498625848404956595,
-          "Data4": 8575665302158667421
+          "Data1": -2584306115477626898,
+          "Data2": -6271733338078080848,
+          "Data3": 4528697605942295999,
+          "Data4": 7143989706903346111
         },
         "Kind": "Components.EventHandler",
         "Name": "onmousemove",
@@ -7949,11 +7526,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onmousemove",
-                "DisplayName": "@onmousemove",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onmousemove"
               }
             ]
           },
@@ -7961,11 +7535,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onmousemove:preventDefault",
-                "DisplayName": "@onmousemove:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onmousemove:preventDefault"
               }
             ]
           },
@@ -7973,11 +7544,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onmousemove:stopPropagation",
-                "DisplayName": "@onmousemove:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onmousemove:stopPropagation"
               }
             ]
           }
@@ -8021,10 +7589,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 4338058125008432386,
-          "Data2": -2412516069099269055,
-          "Data3": 4537199837414391339,
-          "Data4": -6940566173904013284
+          "Data1": 5313452197034756453,
+          "Data2": 2450429532652760740,
+          "Data3": -6157680293267059987,
+          "Data4": 4870396587161081734
         },
         "Kind": "Components.EventHandler",
         "Name": "onmouseout",
@@ -8037,11 +7605,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onmouseout",
-                "DisplayName": "@onmouseout",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onmouseout"
               }
             ]
           },
@@ -8049,11 +7614,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onmouseout:preventDefault",
-                "DisplayName": "@onmouseout:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onmouseout:preventDefault"
               }
             ]
           },
@@ -8061,11 +7623,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onmouseout:stopPropagation",
-                "DisplayName": "@onmouseout:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onmouseout:stopPropagation"
               }
             ]
           }
@@ -8109,10 +7668,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -6991340220244018570,
-          "Data2": 2684265868884871799,
-          "Data3": 7035889216883200605,
-          "Data4": 2423404781952235603
+          "Data1": 5059710732031474892,
+          "Data2": 4671433110070084200,
+          "Data3": 1522974613585570320,
+          "Data4": 5338178310363460568
         },
         "Kind": "Components.EventHandler",
         "Name": "onmouseover",
@@ -8125,11 +7684,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onmouseover",
-                "DisplayName": "@onmouseover",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onmouseover"
               }
             ]
           },
@@ -8137,11 +7693,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onmouseover:preventDefault",
-                "DisplayName": "@onmouseover:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onmouseover:preventDefault"
               }
             ]
           },
@@ -8149,11 +7702,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onmouseover:stopPropagation",
-                "DisplayName": "@onmouseover:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onmouseover:stopPropagation"
               }
             ]
           }
@@ -8197,10 +7747,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -3240934355022450766,
-          "Data2": 6617560377088607469,
-          "Data3": -3260815483546683390,
-          "Data4": 4043379036710452099
+          "Data1": 764211647199564396,
+          "Data2": 8418899782907168716,
+          "Data3": -7833318875486082439,
+          "Data4": 7408322286860270555
         },
         "Kind": "Components.EventHandler",
         "Name": "onmouseup",
@@ -8213,11 +7763,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onmouseup",
-                "DisplayName": "@onmouseup",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onmouseup"
               }
             ]
           },
@@ -8225,11 +7772,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onmouseup:preventDefault",
-                "DisplayName": "@onmouseup:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onmouseup:preventDefault"
               }
             ]
           },
@@ -8237,11 +7781,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onmouseup:stopPropagation",
-                "DisplayName": "@onmouseup:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onmouseup:stopPropagation"
               }
             ]
           }
@@ -8285,10 +7826,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 28708832908640841,
-          "Data2": 4637111640987001692,
-          "Data3": 659937512556419651,
-          "Data4": 2960656789339959525
+          "Data1": -4191985466399433658,
+          "Data2": 8783361737552525967,
+          "Data3": 6476935164305980389,
+          "Data4": 7656437873064728488
         },
         "Kind": "Components.EventHandler",
         "Name": "onmousewheel",
@@ -8301,11 +7842,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onmousewheel",
-                "DisplayName": "@onmousewheel",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onmousewheel"
               }
             ]
           },
@@ -8313,11 +7851,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onmousewheel:preventDefault",
-                "DisplayName": "@onmousewheel:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onmousewheel:preventDefault"
               }
             ]
           },
@@ -8325,11 +7860,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onmousewheel:stopPropagation",
-                "DisplayName": "@onmousewheel:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onmousewheel:stopPropagation"
               }
             ]
           }
@@ -8373,10 +7905,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -7320546096527219427,
-          "Data2": -5652096307083058252,
-          "Data3": -424066266533036725,
-          "Data4": -4882621223666078251
+          "Data1": 7768900762341921318,
+          "Data2": 5615711718542435317,
+          "Data3": 5668815454522945251,
+          "Data4": -3762560715682529289
         },
         "Kind": "Components.EventHandler",
         "Name": "onpaste",
@@ -8389,11 +7921,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpaste",
-                "DisplayName": "@onpaste",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpaste"
               }
             ]
           },
@@ -8401,11 +7930,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpaste:preventDefault",
-                "DisplayName": "@onpaste:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpaste:preventDefault"
               }
             ]
           },
@@ -8413,11 +7939,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpaste:stopPropagation",
-                "DisplayName": "@onpaste:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpaste:stopPropagation"
               }
             ]
           }
@@ -8461,10 +7984,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 6925683031597902808,
-          "Data2": -8193858560874879844,
-          "Data3": 3009403209639563434,
-          "Data4": -5873878936090806
+          "Data1": -5200235359389050039,
+          "Data2": 1619793879918305222,
+          "Data3": -4982273366626455589,
+          "Data4": 6774872805338104513
         },
         "Kind": "Components.EventHandler",
         "Name": "onpause",
@@ -8477,11 +8000,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpause",
-                "DisplayName": "@onpause",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpause"
               }
             ]
           },
@@ -8489,11 +8009,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpause:preventDefault",
-                "DisplayName": "@onpause:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpause:preventDefault"
               }
             ]
           },
@@ -8501,11 +8018,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpause:stopPropagation",
-                "DisplayName": "@onpause:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpause:stopPropagation"
               }
             ]
           }
@@ -8549,10 +8063,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 7316575855584128364,
-          "Data2": 1136041920911461526,
-          "Data3": 185278435014702853,
-          "Data4": -8482359216563013969
+          "Data1": 6378451033611079652,
+          "Data2": -3675551171836981886,
+          "Data3": -4829355028070074525,
+          "Data4": -7494399875753837718
         },
         "Kind": "Components.EventHandler",
         "Name": "onplay",
@@ -8565,11 +8079,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onplay",
-                "DisplayName": "@onplay",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onplay"
               }
             ]
           },
@@ -8577,11 +8088,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onplay:preventDefault",
-                "DisplayName": "@onplay:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onplay:preventDefault"
               }
             ]
           },
@@ -8589,11 +8097,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onplay:stopPropagation",
-                "DisplayName": "@onplay:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onplay:stopPropagation"
               }
             ]
           }
@@ -8637,10 +8142,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -9145055928073374728,
-          "Data2": -5565933669786037571,
-          "Data3": -6601509529724848786,
-          "Data4": -6625522752830695027
+          "Data1": -106247947188182745,
+          "Data2": -180986689862186269,
+          "Data3": -596431007312074781,
+          "Data4": 5242711495979842766
         },
         "Kind": "Components.EventHandler",
         "Name": "onplaying",
@@ -8653,11 +8158,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onplaying",
-                "DisplayName": "@onplaying",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onplaying"
               }
             ]
           },
@@ -8665,11 +8167,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onplaying:preventDefault",
-                "DisplayName": "@onplaying:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onplaying:preventDefault"
               }
             ]
           },
@@ -8677,11 +8176,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onplaying:stopPropagation",
-                "DisplayName": "@onplaying:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onplaying:stopPropagation"
               }
             ]
           }
@@ -8725,10 +8221,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 7397328215603430353,
-          "Data2": 2551951551227428823,
-          "Data3": -4827177530417202644,
-          "Data4": -8873729829902051552
+          "Data1": 6987715690296857855,
+          "Data2": 2160310109086742499,
+          "Data3": -1315411940393705524,
+          "Data4": 148043464125965601
         },
         "Kind": "Components.EventHandler",
         "Name": "onpointercancel",
@@ -8741,11 +8237,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointercancel",
-                "DisplayName": "@onpointercancel",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointercancel"
               }
             ]
           },
@@ -8753,11 +8246,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointercancel:preventDefault",
-                "DisplayName": "@onpointercancel:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointercancel:preventDefault"
               }
             ]
           },
@@ -8765,11 +8255,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointercancel:stopPropagation",
-                "DisplayName": "@onpointercancel:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointercancel:stopPropagation"
               }
             ]
           }
@@ -8813,10 +8300,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 5531789134773406438,
-          "Data2": 7900188402148951667,
-          "Data3": -2633580919224608338,
-          "Data4": 4059275599916629843
+          "Data1": 4180694709008887748,
+          "Data2": -168516699050744951,
+          "Data3": -8207657916446142013,
+          "Data4": -2478050778389329341
         },
         "Kind": "Components.EventHandler",
         "Name": "onpointerdown",
@@ -8829,11 +8316,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointerdown",
-                "DisplayName": "@onpointerdown",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointerdown"
               }
             ]
           },
@@ -8841,11 +8325,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointerdown:preventDefault",
-                "DisplayName": "@onpointerdown:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointerdown:preventDefault"
               }
             ]
           },
@@ -8853,11 +8334,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointerdown:stopPropagation",
-                "DisplayName": "@onpointerdown:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointerdown:stopPropagation"
               }
             ]
           }
@@ -8901,10 +8379,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -3394523682458429064,
-          "Data2": 7219114259961966861,
-          "Data3": 612786561963848094,
-          "Data4": 5272092732060072440
+          "Data1": -7006113035456745837,
+          "Data2": 5315787959195315422,
+          "Data3": -3514523871746462662,
+          "Data4": -4712460163508028305
         },
         "Kind": "Components.EventHandler",
         "Name": "onpointerenter",
@@ -8917,11 +8395,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointerenter",
-                "DisplayName": "@onpointerenter",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointerenter"
               }
             ]
           },
@@ -8929,11 +8404,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointerenter:preventDefault",
-                "DisplayName": "@onpointerenter:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointerenter:preventDefault"
               }
             ]
           },
@@ -8941,11 +8413,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointerenter:stopPropagation",
-                "DisplayName": "@onpointerenter:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointerenter:stopPropagation"
               }
             ]
           }
@@ -8989,10 +8458,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 2829293836043812326,
-          "Data2": -1260604900553246092,
-          "Data3": 9113273088391495345,
-          "Data4": -4654675625642582510
+          "Data1": -909531757197365778,
+          "Data2": 15975412292832218,
+          "Data3": -8890069829515663249,
+          "Data4": -981670869667276131
         },
         "Kind": "Components.EventHandler",
         "Name": "onpointerleave",
@@ -9005,11 +8474,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointerleave",
-                "DisplayName": "@onpointerleave",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointerleave"
               }
             ]
           },
@@ -9017,11 +8483,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointerleave:preventDefault",
-                "DisplayName": "@onpointerleave:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointerleave:preventDefault"
               }
             ]
           },
@@ -9029,11 +8492,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointerleave:stopPropagation",
-                "DisplayName": "@onpointerleave:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointerleave:stopPropagation"
               }
             ]
           }
@@ -9077,10 +8537,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 6375921679450568672,
-          "Data2": -3269108332157207636,
-          "Data3": 4628894935344228480,
-          "Data4": -856220540572064425
+          "Data1": 6840186188303753666,
+          "Data2": 2565945039695678509,
+          "Data3": -9092483272445117559,
+          "Data4": 4779379574378913285
         },
         "Kind": "Components.EventHandler",
         "Name": "onpointerlockchange",
@@ -9093,11 +8553,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointerlockchange",
-                "DisplayName": "@onpointerlockchange",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointerlockchange"
               }
             ]
           },
@@ -9105,11 +8562,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointerlockchange:preventDefault",
-                "DisplayName": "@onpointerlockchange:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointerlockchange:preventDefault"
               }
             ]
           },
@@ -9117,11 +8571,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointerlockchange:stopPropagation",
-                "DisplayName": "@onpointerlockchange:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointerlockchange:stopPropagation"
               }
             ]
           }
@@ -9165,10 +8616,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 7887239623514062704,
-          "Data2": -5436090644757708037,
-          "Data3": 7549354325751636281,
-          "Data4": 8066751189638259098
+          "Data1": -116444232607248628,
+          "Data2": 3083705371692773526,
+          "Data3": 3893921551062578485,
+          "Data4": 7351705281182446940
         },
         "Kind": "Components.EventHandler",
         "Name": "onpointerlockerror",
@@ -9181,11 +8632,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointerlockerror",
-                "DisplayName": "@onpointerlockerror",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointerlockerror"
               }
             ]
           },
@@ -9193,11 +8641,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointerlockerror:preventDefault",
-                "DisplayName": "@onpointerlockerror:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointerlockerror:preventDefault"
               }
             ]
           },
@@ -9205,11 +8650,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointerlockerror:stopPropagation",
-                "DisplayName": "@onpointerlockerror:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointerlockerror:stopPropagation"
               }
             ]
           }
@@ -9253,10 +8695,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 4832439747655564991,
-          "Data2": -4512879615785887514,
-          "Data3": -7133993899680201306,
-          "Data4": -6891247532307498545
+          "Data1": 7901232504570993313,
+          "Data2": -471244497602939549,
+          "Data3": 5948144395928766032,
+          "Data4": 5973104939491564056
         },
         "Kind": "Components.EventHandler",
         "Name": "onpointermove",
@@ -9269,11 +8711,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointermove",
-                "DisplayName": "@onpointermove",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointermove"
               }
             ]
           },
@@ -9281,11 +8720,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointermove:preventDefault",
-                "DisplayName": "@onpointermove:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointermove:preventDefault"
               }
             ]
           },
@@ -9293,11 +8729,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointermove:stopPropagation",
-                "DisplayName": "@onpointermove:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointermove:stopPropagation"
               }
             ]
           }
@@ -9341,10 +8774,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -7473029431622188229,
-          "Data2": 1862511663468593325,
-          "Data3": 4055023952708697663,
-          "Data4": -4133895208001499675
+          "Data1": 6444381276508903201,
+          "Data2": 6803115970972526893,
+          "Data3": 2566313385091378943,
+          "Data4": -8475414617275197945
         },
         "Kind": "Components.EventHandler",
         "Name": "onpointerout",
@@ -9357,11 +8790,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointerout",
-                "DisplayName": "@onpointerout",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointerout"
               }
             ]
           },
@@ -9369,11 +8799,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointerout:preventDefault",
-                "DisplayName": "@onpointerout:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointerout:preventDefault"
               }
             ]
           },
@@ -9381,11 +8808,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointerout:stopPropagation",
-                "DisplayName": "@onpointerout:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointerout:stopPropagation"
               }
             ]
           }
@@ -9429,10 +8853,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 7317353743738043694,
-          "Data2": -5739996462267796877,
-          "Data3": -2888130792210317441,
-          "Data4": 231589467525074146
+          "Data1": -4528745887110444423,
+          "Data2": -1766370550095932973,
+          "Data3": -7158050748314265987,
+          "Data4": -8566231929190831416
         },
         "Kind": "Components.EventHandler",
         "Name": "onpointerover",
@@ -9445,11 +8869,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointerover",
-                "DisplayName": "@onpointerover",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointerover"
               }
             ]
           },
@@ -9457,11 +8878,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointerover:preventDefault",
-                "DisplayName": "@onpointerover:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointerover:preventDefault"
               }
             ]
           },
@@ -9469,11 +8887,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointerover:stopPropagation",
-                "DisplayName": "@onpointerover:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointerover:stopPropagation"
               }
             ]
           }
@@ -9517,10 +8932,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -5366786791349307980,
-          "Data2": -9066722678336691475,
-          "Data3": -444911357641092109,
-          "Data4": -4191957969607723941
+          "Data1": 2786598247335912998,
+          "Data2": -7160535197118535966,
+          "Data3": 4665531076966556819,
+          "Data4": 6453693007012846053
         },
         "Kind": "Components.EventHandler",
         "Name": "onpointerup",
@@ -9533,11 +8948,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointerup",
-                "DisplayName": "@onpointerup",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointerup"
               }
             ]
           },
@@ -9545,11 +8957,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointerup:preventDefault",
-                "DisplayName": "@onpointerup:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointerup:preventDefault"
               }
             ]
           },
@@ -9557,11 +8966,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onpointerup:stopPropagation",
-                "DisplayName": "@onpointerup:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onpointerup:stopPropagation"
               }
             ]
           }
@@ -9605,10 +9011,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 3406400838604803747,
-          "Data2": -2098749030409528133,
-          "Data3": -6414629464348170303,
-          "Data4": -5243582165770392498
+          "Data1": 9106838743662096750,
+          "Data2": 1853912210846062097,
+          "Data3": 4323769959829418218,
+          "Data4": 5457094017358266820
         },
         "Kind": "Components.EventHandler",
         "Name": "onprogress",
@@ -9621,11 +9027,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onprogress",
-                "DisplayName": "@onprogress",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onprogress"
               }
             ]
           },
@@ -9633,11 +9036,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onprogress:preventDefault",
-                "DisplayName": "@onprogress:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onprogress:preventDefault"
               }
             ]
           },
@@ -9645,11 +9045,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onprogress:stopPropagation",
-                "DisplayName": "@onprogress:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onprogress:stopPropagation"
               }
             ]
           }
@@ -9693,10 +9090,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 494567630702822934,
-          "Data2": -1018097234928779685,
-          "Data3": -393951081920276844,
-          "Data4": 4581155809097731917
+          "Data1": -6321636853498416219,
+          "Data2": -3722090091616380544,
+          "Data3": -3197186809783996999,
+          "Data4": 4207917375985470974
         },
         "Kind": "Components.EventHandler",
         "Name": "onratechange",
@@ -9709,11 +9106,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onratechange",
-                "DisplayName": "@onratechange",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onratechange"
               }
             ]
           },
@@ -9721,11 +9115,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onratechange:preventDefault",
-                "DisplayName": "@onratechange:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onratechange:preventDefault"
               }
             ]
           },
@@ -9733,11 +9124,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onratechange:stopPropagation",
-                "DisplayName": "@onratechange:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onratechange:stopPropagation"
               }
             ]
           }
@@ -9781,10 +9169,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -7688023218366364410,
-          "Data2": -2829820205990183412,
-          "Data3": 7637016241948523981,
-          "Data4": 4548677191200725293
+          "Data1": 5950566851430619926,
+          "Data2": -6650914754310694628,
+          "Data3": -2345130887281270697,
+          "Data4": -2698990448426154019
         },
         "Kind": "Components.EventHandler",
         "Name": "onreadystatechange",
@@ -9797,11 +9185,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onreadystatechange",
-                "DisplayName": "@onreadystatechange",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onreadystatechange"
               }
             ]
           },
@@ -9809,11 +9194,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onreadystatechange:preventDefault",
-                "DisplayName": "@onreadystatechange:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onreadystatechange:preventDefault"
               }
             ]
           },
@@ -9821,11 +9203,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onreadystatechange:stopPropagation",
-                "DisplayName": "@onreadystatechange:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onreadystatechange:stopPropagation"
               }
             ]
           }
@@ -9869,10 +9248,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 224717445316874759,
-          "Data2": 5347660932654165673,
-          "Data3": 5181719928833362039,
-          "Data4": -4387464771602446362
+          "Data1": -5342892640395119362,
+          "Data2": 6394986243877743307,
+          "Data3": -139779456945022743,
+          "Data4": 155465471657207495
         },
         "Kind": "Components.EventHandler",
         "Name": "onreset",
@@ -9885,11 +9264,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onreset",
-                "DisplayName": "@onreset",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onreset"
               }
             ]
           },
@@ -9897,11 +9273,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onreset:preventDefault",
-                "DisplayName": "@onreset:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onreset:preventDefault"
               }
             ]
           },
@@ -9909,11 +9282,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onreset:stopPropagation",
-                "DisplayName": "@onreset:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onreset:stopPropagation"
               }
             ]
           }
@@ -9957,10 +9327,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 6826453195202586983,
-          "Data2": 7683457740343697410,
-          "Data3": -8768293978917309078,
-          "Data4": -1699932148962838449
+          "Data1": 5029902404704121304,
+          "Data2": -390492781122521802,
+          "Data3": 8576990586523992981,
+          "Data4": -4499605108372347984
         },
         "Kind": "Components.EventHandler",
         "Name": "onscroll",
@@ -9973,11 +9343,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onscroll",
-                "DisplayName": "@onscroll",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onscroll"
               }
             ]
           },
@@ -9985,11 +9352,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onscroll:preventDefault",
-                "DisplayName": "@onscroll:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onscroll:preventDefault"
               }
             ]
           },
@@ -9997,11 +9361,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onscroll:stopPropagation",
-                "DisplayName": "@onscroll:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onscroll:stopPropagation"
               }
             ]
           }
@@ -10045,10 +9406,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 8445864660291885180,
-          "Data2": 510040691898294539,
-          "Data3": 6480558170492764918,
-          "Data4": -5418274989094225347
+          "Data1": 1321169214746586356,
+          "Data2": -7894685192787653769,
+          "Data3": 6793740820433130563,
+          "Data4": -657480808649644355
         },
         "Kind": "Components.EventHandler",
         "Name": "onseeked",
@@ -10061,11 +9422,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onseeked",
-                "DisplayName": "@onseeked",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onseeked"
               }
             ]
           },
@@ -10073,11 +9431,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onseeked:preventDefault",
-                "DisplayName": "@onseeked:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onseeked:preventDefault"
               }
             ]
           },
@@ -10085,11 +9440,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onseeked:stopPropagation",
-                "DisplayName": "@onseeked:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onseeked:stopPropagation"
               }
             ]
           }
@@ -10133,10 +9485,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -2192183166053862912,
-          "Data2": -7744244642283049125,
-          "Data3": -2809229131799001521,
-          "Data4": -8886585934832241989
+          "Data1": 6305649079732851537,
+          "Data2": -4038854325843304265,
+          "Data3": 8078232878785635094,
+          "Data4": 219912366895870387
         },
         "Kind": "Components.EventHandler",
         "Name": "onseeking",
@@ -10149,11 +9501,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onseeking",
-                "DisplayName": "@onseeking",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onseeking"
               }
             ]
           },
@@ -10161,11 +9510,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onseeking:preventDefault",
-                "DisplayName": "@onseeking:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onseeking:preventDefault"
               }
             ]
           },
@@ -10173,11 +9519,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onseeking:stopPropagation",
-                "DisplayName": "@onseeking:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onseeking:stopPropagation"
               }
             ]
           }
@@ -10221,10 +9564,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 8740321036435910222,
-          "Data2": 5891384443450844093,
-          "Data3": -2967303923433362985,
-          "Data4": 1612163178029608108
+          "Data1": -4462025492518591692,
+          "Data2": -5594144927576957297,
+          "Data3": 7931743049730008730,
+          "Data4": 5357059209995722837
         },
         "Kind": "Components.EventHandler",
         "Name": "onselect",
@@ -10237,11 +9580,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onselect",
-                "DisplayName": "@onselect",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onselect"
               }
             ]
           },
@@ -10249,11 +9589,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onselect:preventDefault",
-                "DisplayName": "@onselect:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onselect:preventDefault"
               }
             ]
           },
@@ -10261,11 +9598,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onselect:stopPropagation",
-                "DisplayName": "@onselect:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onselect:stopPropagation"
               }
             ]
           }
@@ -10309,10 +9643,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -4064073072735914895,
-          "Data2": -31601092673190627,
-          "Data3": 8734947246065897115,
-          "Data4": 6185886125014021072
+          "Data1": -9122827468633671012,
+          "Data2": 5814484778640554119,
+          "Data3": 7159130364460705929,
+          "Data4": 5597774853748213498
         },
         "Kind": "Components.EventHandler",
         "Name": "onselectionchange",
@@ -10325,11 +9659,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onselectionchange",
-                "DisplayName": "@onselectionchange",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onselectionchange"
               }
             ]
           },
@@ -10337,11 +9668,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onselectionchange:preventDefault",
-                "DisplayName": "@onselectionchange:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onselectionchange:preventDefault"
               }
             ]
           },
@@ -10349,11 +9677,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onselectionchange:stopPropagation",
-                "DisplayName": "@onselectionchange:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onselectionchange:stopPropagation"
               }
             ]
           }
@@ -10397,10 +9722,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -1138046083590599608,
-          "Data2": 4687463443162695208,
-          "Data3": 9053096327392442231,
-          "Data4": -6965323229588981034
+          "Data1": -8333461437087992322,
+          "Data2": 4122258132761912273,
+          "Data3": 3984778566282703246,
+          "Data4": 8908002323329523231
         },
         "Kind": "Components.EventHandler",
         "Name": "onselectstart",
@@ -10413,11 +9738,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onselectstart",
-                "DisplayName": "@onselectstart",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onselectstart"
               }
             ]
           },
@@ -10425,11 +9747,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onselectstart:preventDefault",
-                "DisplayName": "@onselectstart:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onselectstart:preventDefault"
               }
             ]
           },
@@ -10437,11 +9756,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onselectstart:stopPropagation",
-                "DisplayName": "@onselectstart:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onselectstart:stopPropagation"
               }
             ]
           }
@@ -10485,10 +9801,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 318596306897676962,
-          "Data2": -840774377398621388,
-          "Data3": -1462482679929495584,
-          "Data4": 5294382030114106666
+          "Data1": -4719244791733854423,
+          "Data2": -4385197274526762793,
+          "Data3": 6965508848743563882,
+          "Data4": -8149943593995976756
         },
         "Kind": "Components.EventHandler",
         "Name": "onstalled",
@@ -10501,11 +9817,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onstalled",
-                "DisplayName": "@onstalled",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onstalled"
               }
             ]
           },
@@ -10513,11 +9826,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onstalled:preventDefault",
-                "DisplayName": "@onstalled:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onstalled:preventDefault"
               }
             ]
           },
@@ -10525,11 +9835,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onstalled:stopPropagation",
-                "DisplayName": "@onstalled:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onstalled:stopPropagation"
               }
             ]
           }
@@ -10573,10 +9880,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 682335393944696285,
-          "Data2": -8143509266863874208,
-          "Data3": -2282273855033062024,
-          "Data4": -5179552279762309277
+          "Data1": 2242369434484631425,
+          "Data2": 6889718217386680446,
+          "Data3": 8182432235645098567,
+          "Data4": -5223207934459407920
         },
         "Kind": "Components.EventHandler",
         "Name": "onstop",
@@ -10589,11 +9896,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onstop",
-                "DisplayName": "@onstop",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onstop"
               }
             ]
           },
@@ -10601,11 +9905,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onstop:preventDefault",
-                "DisplayName": "@onstop:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onstop:preventDefault"
               }
             ]
           },
@@ -10613,11 +9914,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onstop:stopPropagation",
-                "DisplayName": "@onstop:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onstop:stopPropagation"
               }
             ]
           }
@@ -10661,10 +9959,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 375207229838560256,
-          "Data2": -18760777078759482,
-          "Data3": 3985625336333601867,
-          "Data4": 2953121569794424637
+          "Data1": -1015983375478685235,
+          "Data2": 1134044599145699539,
+          "Data3": 7193027339167603445,
+          "Data4": 3925138182756097161
         },
         "Kind": "Components.EventHandler",
         "Name": "onsubmit",
@@ -10677,11 +9975,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onsubmit",
-                "DisplayName": "@onsubmit",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onsubmit"
               }
             ]
           },
@@ -10689,11 +9984,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onsubmit:preventDefault",
-                "DisplayName": "@onsubmit:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onsubmit:preventDefault"
               }
             ]
           },
@@ -10701,11 +9993,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onsubmit:stopPropagation",
-                "DisplayName": "@onsubmit:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onsubmit:stopPropagation"
               }
             ]
           }
@@ -10749,10 +10038,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -5445321366961653967,
-          "Data2": 4124806904531967893,
-          "Data3": 1933661076932727502,
-          "Data4": 8854206439306489824
+          "Data1": 44109589224560879,
+          "Data2": 316920930045571212,
+          "Data3": 4167180397861804650,
+          "Data4": -3754961615361174755
         },
         "Kind": "Components.EventHandler",
         "Name": "onsuspend",
@@ -10765,11 +10054,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onsuspend",
-                "DisplayName": "@onsuspend",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onsuspend"
               }
             ]
           },
@@ -10777,11 +10063,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onsuspend:preventDefault",
-                "DisplayName": "@onsuspend:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onsuspend:preventDefault"
               }
             ]
           },
@@ -10789,11 +10072,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onsuspend:stopPropagation",
-                "DisplayName": "@onsuspend:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onsuspend:stopPropagation"
               }
             ]
           }
@@ -10837,10 +10117,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -6260758442662658747,
-          "Data2": -4956140924178912324,
-          "Data3": -7339672672011689316,
-          "Data4": 2413686638602994464
+          "Data1": -2643127332938728889,
+          "Data2": 6425772254464447077,
+          "Data3": 7317140988311795538,
+          "Data4": -1585026134919286593
         },
         "Kind": "Components.EventHandler",
         "Name": "ontimeout",
@@ -10853,11 +10133,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ontimeout",
-                "DisplayName": "@ontimeout",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ontimeout"
               }
             ]
           },
@@ -10865,11 +10142,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ontimeout:preventDefault",
-                "DisplayName": "@ontimeout:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ontimeout:preventDefault"
               }
             ]
           },
@@ -10877,11 +10151,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ontimeout:stopPropagation",
-                "DisplayName": "@ontimeout:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ontimeout:stopPropagation"
               }
             ]
           }
@@ -10925,10 +10196,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 7222802425613234723,
-          "Data2": -7277154280083511902,
-          "Data3": 2966982761299943195,
-          "Data4": -1162499262911127340
+          "Data1": -238507167698301444,
+          "Data2": 9173448480606936059,
+          "Data3": -4150774773488915715,
+          "Data4": -458704340998488283
         },
         "Kind": "Components.EventHandler",
         "Name": "ontimeupdate",
@@ -10941,11 +10212,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ontimeupdate",
-                "DisplayName": "@ontimeupdate",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ontimeupdate"
               }
             ]
           },
@@ -10953,11 +10221,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ontimeupdate:preventDefault",
-                "DisplayName": "@ontimeupdate:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ontimeupdate:preventDefault"
               }
             ]
           },
@@ -10965,11 +10230,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ontimeupdate:stopPropagation",
-                "DisplayName": "@ontimeupdate:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ontimeupdate:stopPropagation"
               }
             ]
           }
@@ -11013,10 +10275,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -2933110866959855969,
-          "Data2": 4776123269696502483,
-          "Data3": -7215451003448242449,
-          "Data4": -4731990563456866962
+          "Data1": -6956224922083775162,
+          "Data2": 5731551277113824748,
+          "Data3": 1588927753839617119,
+          "Data4": 1947176667586024890
         },
         "Kind": "Components.EventHandler",
         "Name": "ontouchcancel",
@@ -11029,11 +10291,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ontouchcancel",
-                "DisplayName": "@ontouchcancel",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ontouchcancel"
               }
             ]
           },
@@ -11041,11 +10300,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ontouchcancel:preventDefault",
-                "DisplayName": "@ontouchcancel:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ontouchcancel:preventDefault"
               }
             ]
           },
@@ -11053,11 +10309,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ontouchcancel:stopPropagation",
-                "DisplayName": "@ontouchcancel:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ontouchcancel:stopPropagation"
               }
             ]
           }
@@ -11101,10 +10354,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -6989557799974096154,
-          "Data2": -8781554843878572521,
-          "Data3": -7050593770855838515,
-          "Data4": 4846614854330578457
+          "Data1": -5744622818009150461,
+          "Data2": -6601095825222649489,
+          "Data3": 3361646574580135318,
+          "Data4": 1360324519264414068
         },
         "Kind": "Components.EventHandler",
         "Name": "ontouchend",
@@ -11117,11 +10370,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ontouchend",
-                "DisplayName": "@ontouchend",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ontouchend"
               }
             ]
           },
@@ -11129,11 +10379,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ontouchend:preventDefault",
-                "DisplayName": "@ontouchend:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ontouchend:preventDefault"
               }
             ]
           },
@@ -11141,11 +10388,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ontouchend:stopPropagation",
-                "DisplayName": "@ontouchend:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ontouchend:stopPropagation"
               }
             ]
           }
@@ -11189,10 +10433,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -6046162252574913814,
-          "Data2": 1996982228263436704,
-          "Data3": 162079317515365391,
-          "Data4": -8030054928814096267
+          "Data1": -3846047859350255792,
+          "Data2": -6460450546633631324,
+          "Data3": -2917929016495444548,
+          "Data4": 2600033528561086714
         },
         "Kind": "Components.EventHandler",
         "Name": "ontouchenter",
@@ -11205,11 +10449,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ontouchenter",
-                "DisplayName": "@ontouchenter",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ontouchenter"
               }
             ]
           },
@@ -11217,11 +10458,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ontouchenter:preventDefault",
-                "DisplayName": "@ontouchenter:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ontouchenter:preventDefault"
               }
             ]
           },
@@ -11229,11 +10467,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ontouchenter:stopPropagation",
-                "DisplayName": "@ontouchenter:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ontouchenter:stopPropagation"
               }
             ]
           }
@@ -11277,10 +10512,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -2557764745591168310,
-          "Data2": -482904289065305496,
-          "Data3": -8882497789396432323,
-          "Data4": 3149874420673659964
+          "Data1": 7682630061975012541,
+          "Data2": 8932709732425301993,
+          "Data3": -47256705057531277,
+          "Data4": -4979193845823220801
         },
         "Kind": "Components.EventHandler",
         "Name": "ontouchleave",
@@ -11293,11 +10528,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ontouchleave",
-                "DisplayName": "@ontouchleave",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ontouchleave"
               }
             ]
           },
@@ -11305,11 +10537,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ontouchleave:preventDefault",
-                "DisplayName": "@ontouchleave:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ontouchleave:preventDefault"
               }
             ]
           },
@@ -11317,11 +10546,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ontouchleave:stopPropagation",
-                "DisplayName": "@ontouchleave:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ontouchleave:stopPropagation"
               }
             ]
           }
@@ -11365,10 +10591,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 7570418477598409072,
-          "Data2": -2012819158168851695,
-          "Data3": 5833721410694397516,
-          "Data4": 4052898797121392415
+          "Data1": -7880092992649242315,
+          "Data2": -7891931341216695734,
+          "Data3": 4053625628827445194,
+          "Data4": -6006647902952321398
         },
         "Kind": "Components.EventHandler",
         "Name": "ontouchmove",
@@ -11381,11 +10607,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ontouchmove",
-                "DisplayName": "@ontouchmove",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ontouchmove"
               }
             ]
           },
@@ -11393,11 +10616,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ontouchmove:preventDefault",
-                "DisplayName": "@ontouchmove:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ontouchmove:preventDefault"
               }
             ]
           },
@@ -11405,11 +10625,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ontouchmove:stopPropagation",
-                "DisplayName": "@ontouchmove:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ontouchmove:stopPropagation"
               }
             ]
           }
@@ -11453,10 +10670,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -6276453969501756829,
-          "Data2": -8277767549315702204,
-          "Data3": 8082463828934951326,
-          "Data4": 6384139276086053334
+          "Data1": -2126075021269604018,
+          "Data2": 3428208583121267476,
+          "Data3": -5162555442003096810,
+          "Data4": 3917091426778544157
         },
         "Kind": "Components.EventHandler",
         "Name": "ontouchstart",
@@ -11469,11 +10686,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ontouchstart",
-                "DisplayName": "@ontouchstart",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ontouchstart"
               }
             ]
           },
@@ -11481,11 +10695,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ontouchstart:preventDefault",
-                "DisplayName": "@ontouchstart:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ontouchstart:preventDefault"
               }
             ]
           },
@@ -11493,11 +10704,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ontouchstart:stopPropagation",
-                "DisplayName": "@ontouchstart:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ontouchstart:stopPropagation"
               }
             ]
           }
@@ -11541,10 +10749,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 9085283702070882756,
-          "Data2": 4853304623921408194,
-          "Data3": 4840371610510195757,
-          "Data4": 2679967318257509693
+          "Data1": -475886422414293048,
+          "Data2": 6295031481353040591,
+          "Data3": 7041298141548308396,
+          "Data4": 8262191507356487060
         },
         "Kind": "Components.EventHandler",
         "Name": "onvolumechange",
@@ -11557,11 +10765,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onvolumechange",
-                "DisplayName": "@onvolumechange",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onvolumechange"
               }
             ]
           },
@@ -11569,11 +10774,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onvolumechange:preventDefault",
-                "DisplayName": "@onvolumechange:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onvolumechange:preventDefault"
               }
             ]
           },
@@ -11581,11 +10783,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onvolumechange:stopPropagation",
-                "DisplayName": "@onvolumechange:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onvolumechange:stopPropagation"
               }
             ]
           }
@@ -11629,10 +10828,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 4763739743440912051,
-          "Data2": -5805890290527098950,
-          "Data3": 4415708932505262221,
-          "Data4": -4761431241838105867
+          "Data1": -962752337359484196,
+          "Data2": 3554863927796419840,
+          "Data3": -544666066629377866,
+          "Data4": 9070517958718402128
         },
         "Kind": "Components.EventHandler",
         "Name": "onwaiting",
@@ -11645,11 +10844,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onwaiting",
-                "DisplayName": "@onwaiting",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onwaiting"
               }
             ]
           },
@@ -11657,11 +10853,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onwaiting:preventDefault",
-                "DisplayName": "@onwaiting:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onwaiting:preventDefault"
               }
             ]
           },
@@ -11669,11 +10862,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onwaiting:stopPropagation",
-                "DisplayName": "@onwaiting:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onwaiting:stopPropagation"
               }
             ]
           }
@@ -11717,10 +10907,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -2435732156176880840,
-          "Data2": 7236098437422307162,
-          "Data3": -9030750916488917926,
-          "Data4": 1709821249770257085
+          "Data1": -1949066097490187511,
+          "Data2": 5999241979040486074,
+          "Data3": 8907390653326872307,
+          "Data4": -240072234951696921
         },
         "Kind": "Components.EventHandler",
         "Name": "onwheel",
@@ -11733,11 +10923,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onwheel",
-                "DisplayName": "@onwheel",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onwheel"
               }
             ]
           },
@@ -11745,11 +10932,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onwheel:preventDefault",
-                "DisplayName": "@onwheel:preventDefault",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onwheel:preventDefault"
               }
             ]
           },
@@ -11757,11 +10941,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@onwheel:stopPropagation",
-                "DisplayName": "@onwheel:stopPropagation",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@onwheel:stopPropagation"
               }
             ]
           }
@@ -11805,10 +10986,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -4729156663012653819,
-          "Data2": 7887674614229876202,
-          "Data3": 1368514906265025673,
-          "Data4": -1263323792859939829
+          "Data1": 2861763021405833325,
+          "Data2": 1431576662276731303,
+          "Data3": 6607767468708348185,
+          "Data4": 283921649352743508
         },
         "Kind": "Components.Splat",
         "Name": "Attributes",
@@ -11821,11 +11002,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@attributes",
-                "DisplayName": "@attributes",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@attributes"
               }
             ]
           }
@@ -11851,10 +11029,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -6794739141767603240,
-          "Data2": -5156856437996489133,
-          "Data3": -3600799249922803548,
-          "Data4": 41373604104144405
+          "Data1": -8232557690012894739,
+          "Data2": -9066787556766015502,
+          "Data3": 7565656151679393505,
+          "Data4": 6231695327871273453
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper",
@@ -11868,9 +11046,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-action",
-                "CaseSensitive": false,
-                "DisplayName": "asp-action"
+                "Flags": 0,
+                "Name": "asp-action"
               }
             ]
           },
@@ -11879,9 +11056,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-all-route-data",
-                "CaseSensitive": false,
-                "DisplayName": "asp-all-route-data"
+                "Flags": 0,
+                "Name": "asp-all-route-data"
               }
             ]
           },
@@ -11890,9 +11066,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-area",
-                "CaseSensitive": false,
-                "DisplayName": "asp-area"
+                "Flags": 0,
+                "Name": "asp-area"
               }
             ]
           },
@@ -11901,9 +11076,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-controller",
-                "CaseSensitive": false,
-                "DisplayName": "asp-controller"
+                "Flags": 0,
+                "Name": "asp-controller"
               }
             ]
           },
@@ -11912,9 +11086,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-fragment",
-                "CaseSensitive": false,
-                "DisplayName": "asp-fragment"
+                "Flags": 0,
+                "Name": "asp-fragment"
               }
             ]
           },
@@ -11923,9 +11096,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-host",
-                "CaseSensitive": false,
-                "DisplayName": "asp-host"
+                "Flags": 0,
+                "Name": "asp-host"
               }
             ]
           },
@@ -11934,9 +11106,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-page",
-                "CaseSensitive": false,
-                "DisplayName": "asp-page"
+                "Flags": 0,
+                "Name": "asp-page"
               }
             ]
           },
@@ -11945,9 +11116,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-page-handler",
-                "CaseSensitive": false,
-                "DisplayName": "asp-page-handler"
+                "Flags": 0,
+                "Name": "asp-page-handler"
               }
             ]
           },
@@ -11956,9 +11126,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-protocol",
-                "CaseSensitive": false,
-                "DisplayName": "asp-protocol"
+                "Flags": 0,
+                "Name": "asp-protocol"
               }
             ]
           },
@@ -11967,9 +11136,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-route",
-                "CaseSensitive": false,
-                "DisplayName": "asp-route"
+                "Flags": 0,
+                "Name": "asp-route"
               }
             ]
           },
@@ -11978,10 +11146,9 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "asp-route-",
-                "NameComparison": 1,
-                "CaseSensitive": false,
-                "DisplayName": "asp-route-..."
+                "NameComparison": 1
               }
             ]
           }
@@ -12244,10 +11411,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 4581920250563710317,
-          "Data2": -8880893329172663176,
-          "Data3": 8668544002643465490,
-          "Data4": -3449420563159090491
+          "Data1": -3923939772086150127,
+          "Data2": 8904737766230501760,
+          "Data3": 1088747519176060824,
+          "Data4": -4105039943699030457
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.ComponentTagHelper",
@@ -12262,9 +11429,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "type",
-                "CaseSensitive": false,
-                "DisplayName": "type"
+                "Flags": 0,
+                "Name": "type"
               }
             ]
           }
@@ -12312,10 +11478,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -4504640625100609167,
-          "Data2": 286858932747717958,
-          "Data3": 420905696124787708,
-          "Data4": 2962274153101561248
+          "Data1": -9178821197460058153,
+          "Data2": 7613500767027087526,
+          "Data3": -1424859735013367359,
+          "Data4": -706011234296891639
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper",
@@ -12329,9 +11495,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "name",
-                "CaseSensitive": false,
-                "DisplayName": "name"
+                "Flags": 0,
+                "Name": "name"
               }
             ]
           }
@@ -12521,10 +11686,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -3726615085879205137,
-          "Data2": -2749921508980930552,
-          "Data3": -4428035603497049265,
-          "Data4": 8539145911212404645
+          "Data1": 1635860868682128912,
+          "Data2": 6830307419053562288,
+          "Data3": 1605499379899060436,
+          "Data4": -7658647497552762100
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.FormActionTagHelper",
@@ -12538,9 +11703,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-action",
-                "CaseSensitive": false,
-                "DisplayName": "asp-action"
+                "Flags": 0,
+                "Name": "asp-action"
               }
             ]
           },
@@ -12549,9 +11713,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-all-route-data",
-                "CaseSensitive": false,
-                "DisplayName": "asp-all-route-data"
+                "Flags": 0,
+                "Name": "asp-all-route-data"
               }
             ]
           },
@@ -12560,9 +11723,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-area",
-                "CaseSensitive": false,
-                "DisplayName": "asp-area"
+                "Flags": 0,
+                "Name": "asp-area"
               }
             ]
           },
@@ -12571,9 +11733,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-controller",
-                "CaseSensitive": false,
-                "DisplayName": "asp-controller"
+                "Flags": 0,
+                "Name": "asp-controller"
               }
             ]
           },
@@ -12582,9 +11743,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-fragment",
-                "CaseSensitive": false,
-                "DisplayName": "asp-fragment"
+                "Flags": 0,
+                "Name": "asp-fragment"
               }
             ]
           },
@@ -12593,9 +11753,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-page",
-                "CaseSensitive": false,
-                "DisplayName": "asp-page"
+                "Flags": 0,
+                "Name": "asp-page"
               }
             ]
           },
@@ -12604,9 +11763,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-page-handler",
-                "CaseSensitive": false,
-                "DisplayName": "asp-page-handler"
+                "Flags": 0,
+                "Name": "asp-page-handler"
               }
             ]
           },
@@ -12615,9 +11773,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-route",
-                "CaseSensitive": false,
-                "DisplayName": "asp-route"
+                "Flags": 0,
+                "Name": "asp-route"
               }
             ]
           },
@@ -12626,10 +11783,9 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "asp-route-",
-                "NameComparison": 1,
-                "CaseSensitive": false,
-                "DisplayName": "asp-route-..."
+                "NameComparison": 1
               }
             ]
           },
@@ -12639,16 +11795,14 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "type",
-                "CaseSensitive": false,
                 "Value": "image",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "asp-action",
-                "CaseSensitive": false,
-                "DisplayName": "asp-action"
+                "Flags": 0,
+                "Name": "asp-action"
               }
             ]
           },
@@ -12658,16 +11812,14 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "type",
-                "CaseSensitive": false,
                 "Value": "image",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "asp-all-route-data",
-                "CaseSensitive": false,
-                "DisplayName": "asp-all-route-data"
+                "Flags": 0,
+                "Name": "asp-all-route-data"
               }
             ]
           },
@@ -12677,16 +11829,14 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "type",
-                "CaseSensitive": false,
                 "Value": "image",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "asp-area",
-                "CaseSensitive": false,
-                "DisplayName": "asp-area"
+                "Flags": 0,
+                "Name": "asp-area"
               }
             ]
           },
@@ -12696,16 +11846,14 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "type",
-                "CaseSensitive": false,
                 "Value": "image",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "asp-controller",
-                "CaseSensitive": false,
-                "DisplayName": "asp-controller"
+                "Flags": 0,
+                "Name": "asp-controller"
               }
             ]
           },
@@ -12715,16 +11863,14 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "type",
-                "CaseSensitive": false,
                 "Value": "image",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "asp-fragment",
-                "CaseSensitive": false,
-                "DisplayName": "asp-fragment"
+                "Flags": 0,
+                "Name": "asp-fragment"
               }
             ]
           },
@@ -12734,16 +11880,14 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "type",
-                "CaseSensitive": false,
                 "Value": "image",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "asp-page",
-                "CaseSensitive": false,
-                "DisplayName": "asp-page"
+                "Flags": 0,
+                "Name": "asp-page"
               }
             ]
           },
@@ -12753,16 +11897,14 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "type",
-                "CaseSensitive": false,
                 "Value": "image",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "asp-page-handler",
-                "CaseSensitive": false,
-                "DisplayName": "asp-page-handler"
+                "Flags": 0,
+                "Name": "asp-page-handler"
               }
             ]
           },
@@ -12772,16 +11914,14 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "type",
-                "CaseSensitive": false,
                 "Value": "image",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "asp-route",
-                "CaseSensitive": false,
-                "DisplayName": "asp-route"
+                "Flags": 0,
+                "Name": "asp-route"
               }
             ]
           },
@@ -12791,17 +11931,15 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "type",
-                "CaseSensitive": false,
                 "Value": "image",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
+                "Flags": 0,
                 "Name": "asp-route-",
-                "NameComparison": 1,
-                "CaseSensitive": false,
-                "DisplayName": "asp-route-..."
+                "NameComparison": 1
               }
             ]
           },
@@ -12811,16 +11949,14 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "type",
-                "CaseSensitive": false,
                 "Value": "submit",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "asp-action",
-                "CaseSensitive": false,
-                "DisplayName": "asp-action"
+                "Flags": 0,
+                "Name": "asp-action"
               }
             ]
           },
@@ -12830,16 +11966,14 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "type",
-                "CaseSensitive": false,
                 "Value": "submit",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "asp-all-route-data",
-                "CaseSensitive": false,
-                "DisplayName": "asp-all-route-data"
+                "Flags": 0,
+                "Name": "asp-all-route-data"
               }
             ]
           },
@@ -12849,16 +11983,14 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "type",
-                "CaseSensitive": false,
                 "Value": "submit",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "asp-area",
-                "CaseSensitive": false,
-                "DisplayName": "asp-area"
+                "Flags": 0,
+                "Name": "asp-area"
               }
             ]
           },
@@ -12868,16 +12000,14 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "type",
-                "CaseSensitive": false,
                 "Value": "submit",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "asp-controller",
-                "CaseSensitive": false,
-                "DisplayName": "asp-controller"
+                "Flags": 0,
+                "Name": "asp-controller"
               }
             ]
           },
@@ -12887,16 +12017,14 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "type",
-                "CaseSensitive": false,
                 "Value": "submit",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "asp-fragment",
-                "CaseSensitive": false,
-                "DisplayName": "asp-fragment"
+                "Flags": 0,
+                "Name": "asp-fragment"
               }
             ]
           },
@@ -12906,16 +12034,14 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "type",
-                "CaseSensitive": false,
                 "Value": "submit",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "asp-page",
-                "CaseSensitive": false,
-                "DisplayName": "asp-page"
+                "Flags": 0,
+                "Name": "asp-page"
               }
             ]
           },
@@ -12925,16 +12051,14 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "type",
-                "CaseSensitive": false,
                 "Value": "submit",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "asp-page-handler",
-                "CaseSensitive": false,
-                "DisplayName": "asp-page-handler"
+                "Flags": 0,
+                "Name": "asp-page-handler"
               }
             ]
           },
@@ -12944,16 +12068,14 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "type",
-                "CaseSensitive": false,
                 "Value": "submit",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "asp-route",
-                "CaseSensitive": false,
-                "DisplayName": "asp-route"
+                "Flags": 0,
+                "Name": "asp-route"
               }
             ]
           },
@@ -12963,17 +12085,15 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "type",
-                "CaseSensitive": false,
                 "Value": "submit",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
+                "Flags": 0,
                 "Name": "asp-route-",
-                "NameComparison": 1,
-                "CaseSensitive": false,
-                "DisplayName": "asp-route-..."
+                "NameComparison": 1
               }
             ]
           }
@@ -13189,10 +12309,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -8870279712415447174,
-          "Data2": 6078425903863187833,
-          "Data3": -5415246709170453110,
-          "Data4": -8470988199746932398
+          "Data1": 5806778673051985790,
+          "Data2": -7376835900172042420,
+          "Data3": -2092347591282441194,
+          "Data4": 8152909573886010910
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.ImageTagHelper",
@@ -13207,14 +12327,12 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-append-version",
-                "CaseSensitive": false,
-                "DisplayName": "asp-append-version"
+                "Flags": 0,
+                "Name": "asp-append-version"
               },
               {
-                "Name": "src",
-                "CaseSensitive": false,
-                "DisplayName": "src"
+                "Flags": 0,
+                "Name": "src"
               }
             ]
           }
@@ -13248,10 +12366,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 5705355647857304997,
-          "Data2": -5072557624117743047,
-          "Data3": 1296426584042257144,
-          "Data4": 2848941384404325948
+          "Data1": -4469704460570534052,
+          "Data2": 7283775881506722565,
+          "Data3": 6164086144235116128,
+          "Data4": 2711155776810976322
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.InputTagHelper",
@@ -13266,9 +12384,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-for",
-                "CaseSensitive": false,
-                "DisplayName": "asp-for"
+                "Flags": 0,
+                "Name": "asp-for"
               }
             ]
           }
@@ -13332,10 +12449,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 3554574752981167574,
-          "Data2": 6265055283691595622,
-          "Data3": 8745424011729455050,
-          "Data4": -5733662445732106688
+          "Data1": -7501206882444642790,
+          "Data2": -8327674516516294318,
+          "Data3": 4321719721397934322,
+          "Data4": 7810127103710142111
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.LabelTagHelper",
@@ -13349,9 +12466,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-for",
-                "CaseSensitive": false,
-                "DisplayName": "asp-for"
+                "Flags": 0,
+                "Name": "asp-for"
               }
             ]
           }
@@ -13375,10 +12491,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 6156553920825600034,
-          "Data2": -3313600398067191160,
-          "Data3": 2922438975368121157,
-          "Data4": -5729865764986130647
+          "Data1": 718527919516570557,
+          "Data2": -9137720598255409680,
+          "Data3": -3806205841115481130,
+          "Data4": 4124050461564254334
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper",
@@ -13393,9 +12509,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-append-version",
-                "CaseSensitive": false,
-                "DisplayName": "asp-append-version"
+                "Flags": 0,
+                "Name": "asp-append-version"
               }
             ]
           },
@@ -13405,9 +12520,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-fallback-href",
-                "CaseSensitive": false,
-                "DisplayName": "asp-fallback-href"
+                "Flags": 0,
+                "Name": "asp-fallback-href"
               }
             ]
           },
@@ -13417,9 +12531,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-fallback-href-exclude",
-                "CaseSensitive": false,
-                "DisplayName": "asp-fallback-href-exclude"
+                "Flags": 0,
+                "Name": "asp-fallback-href-exclude"
               }
             ]
           },
@@ -13429,9 +12542,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-fallback-href-include",
-                "CaseSensitive": false,
-                "DisplayName": "asp-fallback-href-include"
+                "Flags": 0,
+                "Name": "asp-fallback-href-include"
               }
             ]
           },
@@ -13441,9 +12553,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-fallback-test-class",
-                "CaseSensitive": false,
-                "DisplayName": "asp-fallback-test-class"
+                "Flags": 0,
+                "Name": "asp-fallback-test-class"
               }
             ]
           },
@@ -13453,9 +12564,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-fallback-test-property",
-                "CaseSensitive": false,
-                "DisplayName": "asp-fallback-test-property"
+                "Flags": 0,
+                "Name": "asp-fallback-test-property"
               }
             ]
           },
@@ -13465,9 +12575,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-fallback-test-value",
-                "CaseSensitive": false,
-                "DisplayName": "asp-fallback-test-value"
+                "Flags": 0,
+                "Name": "asp-fallback-test-value"
               }
             ]
           },
@@ -13477,9 +12586,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-href-exclude",
-                "CaseSensitive": false,
-                "DisplayName": "asp-href-exclude"
+                "Flags": 0,
+                "Name": "asp-href-exclude"
               }
             ]
           },
@@ -13489,9 +12597,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-href-include",
-                "CaseSensitive": false,
-                "DisplayName": "asp-href-include"
+                "Flags": 0,
+                "Name": "asp-href-include"
               }
             ]
           }
@@ -13651,10 +12758,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 5466786547207860338,
-          "Data2": 493634687525400824,
-          "Data3": 2314588454713957300,
-          "Data4": 3719630365100569977
+          "Data1": -2814188570841913487,
+          "Data2": -1072890839187882048,
+          "Data3": 3569850693652472095,
+          "Data4": 3911548285072196538
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.PartialTagHelper",
@@ -13669,9 +12776,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "name",
-                "CaseSensitive": false,
-                "DisplayName": "name"
+                "Flags": 0,
+                "Name": "name"
               }
             ]
           }
@@ -13748,10 +12854,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 2895383444354329644,
-          "Data2": -6194998671113114949,
-          "Data3": -8565886842565356770,
-          "Data4": -674350993269314830
+          "Data1": 7563647525992746539,
+          "Data2": 3773888571414571191,
+          "Data3": -9206008905967448535,
+          "Data4": -1033221561068612151
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.ScriptTagHelper",
@@ -13765,9 +12871,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-append-version",
-                "CaseSensitive": false,
-                "DisplayName": "asp-append-version"
+                "Flags": 0,
+                "Name": "asp-append-version"
               }
             ]
           },
@@ -13776,9 +12881,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-fallback-src",
-                "CaseSensitive": false,
-                "DisplayName": "asp-fallback-src"
+                "Flags": 0,
+                "Name": "asp-fallback-src"
               }
             ]
           },
@@ -13787,9 +12891,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-fallback-src-exclude",
-                "CaseSensitive": false,
-                "DisplayName": "asp-fallback-src-exclude"
+                "Flags": 0,
+                "Name": "asp-fallback-src-exclude"
               }
             ]
           },
@@ -13798,9 +12901,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-fallback-src-include",
-                "CaseSensitive": false,
-                "DisplayName": "asp-fallback-src-include"
+                "Flags": 0,
+                "Name": "asp-fallback-src-include"
               }
             ]
           },
@@ -13809,9 +12911,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-fallback-test",
-                "CaseSensitive": false,
-                "DisplayName": "asp-fallback-test"
+                "Flags": 0,
+                "Name": "asp-fallback-test"
               }
             ]
           },
@@ -13820,9 +12921,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-src-exclude",
-                "CaseSensitive": false,
-                "DisplayName": "asp-src-exclude"
+                "Flags": 0,
+                "Name": "asp-src-exclude"
               }
             ]
           },
@@ -13831,9 +12931,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-src-include",
-                "CaseSensitive": false,
-                "DisplayName": "asp-src-include"
+                "Flags": 0,
+                "Name": "asp-src-include"
               }
             ]
           }
@@ -13937,10 +13036,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 6579479996482823186,
-          "Data2": -520876175589740566,
-          "Data3": 1806748383989227039,
-          "Data4": -458203092849747883
+          "Data1": -5046440106069012246,
+          "Data2": 5047098817398963561,
+          "Data3": 7010397551355614148,
+          "Data4": -1498614178483073306
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.SelectTagHelper",
@@ -13954,9 +13053,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-for",
-                "CaseSensitive": false,
-                "DisplayName": "asp-for"
+                "Flags": 0,
+                "Name": "asp-for"
               }
             ]
           },
@@ -13965,9 +13063,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-items",
-                "CaseSensitive": false,
-                "DisplayName": "asp-items"
+                "Flags": 0,
+                "Name": "asp-items"
               }
             ]
           }
@@ -14011,10 +13108,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 6980159081445591201,
-          "Data2": -6480588413843073081,
-          "Data3": -3074849698123011725,
-          "Data4": 5108887778510629743
+          "Data1": 1039783404033332749,
+          "Data2": -6999374993664527604,
+          "Data3": -6397029846348731705,
+          "Data4": -2917357541342977300
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.TextAreaTagHelper",
@@ -14028,9 +13125,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-for",
-                "CaseSensitive": false,
-                "DisplayName": "asp-for"
+                "Flags": 0,
+                "Name": "asp-for"
               }
             ]
           }
@@ -14064,10 +13160,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -5339600428732863986,
-          "Data2": 6065060134186830106,
-          "Data3": 2231597810216291074,
-          "Data4": -387028852536953028
+          "Data1": -7176956603040704753,
+          "Data2": -190942329591018817,
+          "Data3": 1337760413431011518,
+          "Data4": 8195658529292841343
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.ValidationMessageTagHelper",
@@ -14081,9 +13177,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-validation-for",
-                "CaseSensitive": false,
-                "DisplayName": "asp-validation-for"
+                "Flags": 0,
+                "Name": "asp-validation-for"
               }
             ]
           }
@@ -14107,10 +13202,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -5925740776405247863,
-          "Data2": 4485792911133715007,
-          "Data3": 2572514906731951580,
-          "Data4": 3422618998698535538
+          "Data1": -3561358720762965503,
+          "Data2": -13325856521585852,
+          "Data3": -4317853643337726375,
+          "Data4": -8178613388397682429
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.ValidationSummaryTagHelper",
@@ -14124,9 +13219,8 @@
             "CaseSensitive": false,
             "Attributes": [
               {
-                "Name": "asp-validation-summary",
-                "CaseSensitive": false,
-                "DisplayName": "asp-validation-summary"
+                "Flags": 0,
+                "Name": "asp-validation-summary"
               }
             ]
           }
@@ -14151,10 +13245,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 2703787133070718142,
-          "Data2": -6989096503033917865,
-          "Data3": -7691382971945125776,
-          "Data4": -3367102540293617851
+          "Data1": -1971386796320537680,
+          "Data2": -2829455033961105896,
+          "Data3": 2279090164954144924,
+          "Data4": 6800045277150886655
         },
         "Kind": "ITagHelper",
         "Name": "Microsoft.AspNetCore.Mvc.Razor.TagHelpers.UrlResolutionTagHelper",
@@ -14168,11 +13262,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "itemid",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "itemid"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14181,11 +13274,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "href",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "href"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14194,11 +13286,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "archive",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "archive"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14208,11 +13299,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "href",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "href"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14221,11 +13311,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "src",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "src"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14235,11 +13324,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "href",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "href"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14248,11 +13336,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "cite",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "cite"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14261,11 +13348,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "formaction",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "formaction"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14274,11 +13360,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "cite",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "cite"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14288,11 +13373,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "src",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "src"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14301,11 +13385,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "action",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "action"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14314,11 +13397,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "manifest",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "manifest"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14327,11 +13409,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "src",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "src"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14341,11 +13422,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "src",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "src"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14355,11 +13435,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "srcset",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "srcset"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14369,11 +13448,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "formaction",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "formaction"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14383,11 +13461,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "src",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "src"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14396,11 +13473,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "cite",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "cite"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14410,11 +13486,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "href",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "href"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14423,11 +13498,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "icon",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "icon"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14436,11 +13510,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "archive",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "archive"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14449,11 +13522,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "data",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "data"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14462,11 +13534,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "cite",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "cite"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14475,11 +13546,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "src",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "src"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14489,11 +13559,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "src",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "src"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14503,11 +13572,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "srcset",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "srcset"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14517,11 +13585,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "src",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "src"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14530,11 +13597,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "poster",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "poster"
+                "ValueComparison": 2
               }
             ]
           },
@@ -14543,11 +13609,10 @@
             "CaseSensitive": false,
             "Attributes": [
               {
+                "Flags": 0,
                 "Name": "src",
-                "CaseSensitive": false,
                 "Value": "~/",
-                "ValueComparison": 2,
-                "DisplayName": "src"
+                "ValueComparison": 2
               }
             ]
           }
@@ -14559,10 +13624,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -3685292186040504276,
-          "Data2": 8536781606371643524,
-          "Data3": 4274372468402335766,
-          "Data4": 1468910848180810761
+          "Data1": 2804772334835929651,
+          "Data2": -4071457583106880409,
+          "Data3": -7552671308884001213,
+          "Data4": -3911738881672381844
         },
         "Kind": "Components.Bind",
         "Name": "Bind",
@@ -14575,12 +13640,9 @@
             "TagName": "*",
             "Attributes": [
               {
+                "Flags": 3,
                 "Name": "@bind-",
-                "NameComparison": 1,
-                "DisplayName": "@bind-...",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "NameComparison": 1
               }
             ]
           }
@@ -14633,10 +13695,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 2985670379829105576,
-          "Data2": 8274301716369992601,
-          "Data3": 2880453571866082091,
-          "Data4": -3575772219232359282
+          "Data1": 2381831365340684755,
+          "Data2": -3500743983131782613,
+          "Data3": 8615030207128129701,
+          "Data4": 110864337719284804
         },
         "Kind": "Components.Bind",
         "Name": "Bind",
@@ -14649,11 +13711,8 @@
             "TagName": "select",
             "Attributes": [
               {
-                "Name": "@bind",
-                "DisplayName": "@bind",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind"
               }
             ]
           }
@@ -14715,10 +13774,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 2817812258952236956,
-          "Data2": 5253073933658094894,
-          "Data3": 6740588000506545263,
-          "Data4": 7862719811371506707
+          "Data1": 5620146109763150971,
+          "Data2": -515773383298902286,
+          "Data3": -5647196385990364781,
+          "Data4": 3131838451983383767
         },
         "Kind": "Components.Bind",
         "Name": "Bind",
@@ -14731,11 +13790,8 @@
             "TagName": "textarea",
             "Attributes": [
               {
-                "Name": "@bind",
-                "DisplayName": "@bind",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind"
               }
             ]
           }
@@ -14797,10 +13853,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -7809547790453801279,
-          "Data2": -5757433330597755039,
-          "Data3": 623067456977970697,
-          "Data4": 4689900097438501027
+          "Data1": 7458264567237911786,
+          "Data2": 6755863600676652634,
+          "Data3": -3010345942743721819,
+          "Data4": -150762814647803201
         },
         "Kind": "Components.Bind",
         "Name": "Bind",
@@ -14813,17 +13869,14 @@
             "TagName": "input",
             "Attributes": [
               {
+                "Flags": 1,
                 "Name": "type",
                 "Value": "checkbox",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "@bind",
-                "DisplayName": "@bind",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind"
               }
             ]
           }
@@ -14886,10 +13939,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -4785482484865695785,
-          "Data2": 3314045726500131272,
-          "Data3": -7713856404844623095,
-          "Data4": -6715489049262522563
+          "Data1": -2910624359999412392,
+          "Data2": -5150390336822816208,
+          "Data3": 6186364345083519540,
+          "Data4": -6846765070324959704
         },
         "Kind": "Components.Bind",
         "Name": "Bind_value",
@@ -14902,17 +13955,14 @@
             "TagName": "input",
             "Attributes": [
               {
+                "Flags": 1,
                 "Name": "type",
                 "Value": "date",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "@bind-value",
-                "DisplayName": "@bind-value",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind-value"
               }
             ]
           }
@@ -14975,10 +14025,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 890662114278379898,
-          "Data2": 3971470295267907455,
-          "Data3": 49589090793957989,
-          "Data4": -8367456935790439680
+          "Data1": 7146248459324564583,
+          "Data2": 8515868674577677430,
+          "Data3": -6547357366767465279,
+          "Data4": 1609452384247464939
         },
         "Kind": "Components.Bind",
         "Name": "Bind",
@@ -14991,17 +14041,14 @@
             "TagName": "input",
             "Attributes": [
               {
+                "Flags": 1,
                 "Name": "type",
                 "Value": "date",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "@bind",
-                "DisplayName": "@bind",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind"
               }
             ]
           }
@@ -15064,10 +14111,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 2902268118371366552,
-          "Data2": -5291299079245225802,
-          "Data3": -863434885957592293,
-          "Data4": -7062582030546450024
+          "Data1": 1038749346976908677,
+          "Data2": 778082851521077154,
+          "Data3": -2968373470771382921,
+          "Data4": 2582624751300289179
         },
         "Kind": "Components.Bind",
         "Name": "Bind_value",
@@ -15080,17 +14127,14 @@
             "TagName": "input",
             "Attributes": [
               {
+                "Flags": 1,
                 "Name": "type",
                 "Value": "datetime-local",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "@bind-value",
-                "DisplayName": "@bind-value",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind-value"
               }
             ]
           }
@@ -15153,10 +14197,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 8323077042696068576,
-          "Data2": -7679787121196400457,
-          "Data3": 2237142770718645983,
-          "Data4": 1897522602057373425
+          "Data1": -5188222517003340227,
+          "Data2": -5067749519619062123,
+          "Data3": 4152377210985356021,
+          "Data4": 4683380244481999080
         },
         "Kind": "Components.Bind",
         "Name": "Bind",
@@ -15169,17 +14213,14 @@
             "TagName": "input",
             "Attributes": [
               {
+                "Flags": 1,
                 "Name": "type",
                 "Value": "datetime-local",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "@bind",
-                "DisplayName": "@bind",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind"
               }
             ]
           }
@@ -15242,10 +14283,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -6320533541342552612,
-          "Data2": -4323539625282631642,
-          "Data3": 2195120552717965085,
-          "Data4": 4106216466811421772
+          "Data1": -3621852157860299565,
+          "Data2": 1028886125704664799,
+          "Data3": 979507895702947760,
+          "Data4": -2294102797086233507
         },
         "Kind": "Components.Bind",
         "Name": "Bind_value",
@@ -15258,17 +14299,14 @@
             "TagName": "input",
             "Attributes": [
               {
+                "Flags": 1,
                 "Name": "type",
                 "Value": "month",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "@bind-value",
-                "DisplayName": "@bind-value",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind-value"
               }
             ]
           }
@@ -15331,10 +14369,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 2539118183301452226,
-          "Data2": -5921674867011910942,
-          "Data3": -5440624088004299023,
-          "Data4": 7688493597734439022
+          "Data1": -5662336750199339130,
+          "Data2": -2776614948189466889,
+          "Data3": 8682067512095888895,
+          "Data4": 2516071458753287825
         },
         "Kind": "Components.Bind",
         "Name": "Bind",
@@ -15347,17 +14385,14 @@
             "TagName": "input",
             "Attributes": [
               {
+                "Flags": 1,
                 "Name": "type",
                 "Value": "month",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "@bind",
-                "DisplayName": "@bind",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind"
               }
             ]
           }
@@ -15420,10 +14455,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 4880179657431543240,
-          "Data2": -423513603172884336,
-          "Data3": 2206583150977906855,
-          "Data4": -5906331554161240979
+          "Data1": -5343011444579369888,
+          "Data2": 7250245566596724201,
+          "Data3": 7396674355917313069,
+          "Data4": -7553986846281427037
         },
         "Kind": "Components.Bind",
         "Name": "Bind_value",
@@ -15436,17 +14471,14 @@
             "TagName": "input",
             "Attributes": [
               {
+                "Flags": 1,
                 "Name": "type",
                 "Value": "number",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "@bind-value",
-                "DisplayName": "@bind-value",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind-value"
               }
             ]
           }
@@ -15509,10 +14541,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 625677145327438669,
-          "Data2": -874903887778963408,
-          "Data3": 7956982106780899970,
-          "Data4": 4320036332833234398
+          "Data1": -5989822042861799638,
+          "Data2": 5045066735856221062,
+          "Data3": -299540289955689373,
+          "Data4": 7613331302251228254
         },
         "Kind": "Components.Bind",
         "Name": "Bind",
@@ -15525,17 +14557,14 @@
             "TagName": "input",
             "Attributes": [
               {
+                "Flags": 1,
                 "Name": "type",
                 "Value": "number",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "@bind",
-                "DisplayName": "@bind",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind"
               }
             ]
           }
@@ -15598,10 +14627,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 4747274241146740015,
-          "Data2": 8761114011558415887,
-          "Data3": -6881949634175154265,
-          "Data4": 4082854514770647392
+          "Data1": 5912408316621125630,
+          "Data2": 4151096116074659019,
+          "Data3": 493445837153395982,
+          "Data4": 3936840078485951403
         },
         "Kind": "Components.Bind",
         "Name": "Bind",
@@ -15614,17 +14643,14 @@
             "TagName": "input",
             "Attributes": [
               {
+                "Flags": 1,
                 "Name": "type",
                 "Value": "text",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "@bind",
-                "DisplayName": "@bind",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind"
               }
             ]
           }
@@ -15687,10 +14713,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -4350784122265236843,
-          "Data2": 2700830642728689475,
-          "Data3": 7664509657514465206,
-          "Data4": 8896253258108937877
+          "Data1": -1159795519944325857,
+          "Data2": 5218612147715096891,
+          "Data3": 7439000300129034381,
+          "Data4": 5501330739930627319
         },
         "Kind": "Components.Bind",
         "Name": "Bind_value",
@@ -15703,17 +14729,14 @@
             "TagName": "input",
             "Attributes": [
               {
+                "Flags": 1,
                 "Name": "type",
                 "Value": "time",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "@bind-value",
-                "DisplayName": "@bind-value",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind-value"
               }
             ]
           }
@@ -15776,10 +14799,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 2910981472147216679,
-          "Data2": 1688254039565410991,
-          "Data3": -5900639657447504829,
-          "Data4": -3920063457595131644
+          "Data1": -7528010983589696380,
+          "Data2": 449215042021313901,
+          "Data3": 7707172625713499608,
+          "Data4": -3688221223718961466
         },
         "Kind": "Components.Bind",
         "Name": "Bind",
@@ -15792,17 +14815,14 @@
             "TagName": "input",
             "Attributes": [
               {
+                "Flags": 1,
                 "Name": "type",
                 "Value": "time",
-                "ValueComparison": 1,
-                "DisplayName": "type"
+                "ValueComparison": 1
               },
               {
-                "Name": "@bind",
-                "DisplayName": "@bind",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind"
               }
             ]
           }
@@ -15865,10 +14885,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -7022367332598984804,
-          "Data2": -6246828379507765753,
-          "Data3": 4707808536421549178,
-          "Data4": -5278616444778478773
+          "Data1": -2263363294789195755,
+          "Data2": 4233873893882973798,
+          "Data3": 8976932368813185160,
+          "Data4": 8149596999588536841
         },
         "Kind": "Components.Bind",
         "Name": "Bind_value",
@@ -15881,11 +14901,8 @@
             "TagName": "input",
             "Attributes": [
               {
-                "Name": "@bind-value",
-                "DisplayName": "@bind-value",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind-value"
               }
             ]
           }
@@ -15947,10 +14964,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -8344498090806234141,
-          "Data2": 3783416190601196617,
-          "Data3": 8412050911796659813,
-          "Data4": -4863640647035698696
+          "Data1": -4481990614977928469,
+          "Data2": -3489938844178137081,
+          "Data3": -7270224432600862056,
+          "Data4": -2689442964714280153
         },
         "Kind": "Components.Bind",
         "Name": "Bind",
@@ -15963,11 +14980,8 @@
             "TagName": "input",
             "Attributes": [
               {
-                "Name": "@bind",
-                "DisplayName": "@bind",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind"
               }
             ]
           }
@@ -16029,10 +15043,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -5080415232478509494,
-          "Data2": 4819699287119748366,
-          "Data3": -8209674754516177236,
-          "Data4": 2684243872072977176
+          "Data1": 8833822444078191826,
+          "Data2": -1117136902533086126,
+          "Data3": 1109771947580984304,
+          "Data4": 5055196165280018404
         },
         "Kind": "Components.Bind",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputCheckbox",
@@ -16045,11 +15059,8 @@
             "TagName": "InputCheckbox",
             "Attributes": [
               {
-                "Name": "@bind-Value",
-                "DisplayName": "@bind-Value",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind-Value"
               }
             ]
           }
@@ -16077,10 +15088,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 6345236687639076384,
-          "Data2": -3487871092147233171,
-          "Data3": -8551282643494994133,
-          "Data4": 8444671501195184205
+          "Data1": -8745052376647985522,
+          "Data2": -7558593515612905488,
+          "Data3": 2010195863487376246,
+          "Data4": 8603758389994355544
         },
         "Kind": "Components.Bind",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputCheckbox",
@@ -16093,11 +15104,8 @@
             "TagName": "Microsoft.AspNetCore.Components.Forms.InputCheckbox",
             "Attributes": [
               {
-                "Name": "@bind-Value",
-                "DisplayName": "@bind-Value",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind-Value"
               }
             ]
           }
@@ -16126,10 +15134,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -4314029047945001303,
-          "Data2": -1630859374079543980,
-          "Data3": -285602460916989842,
-          "Data4": -1956441111676836875
+          "Data1": -3339170499089431606,
+          "Data2": -1468829925373350858,
+          "Data3": 6452684532984905742,
+          "Data4": -8017785937308263278
         },
         "Kind": "Components.Bind",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputDate<TValue>",
@@ -16142,11 +15150,8 @@
             "TagName": "InputDate",
             "Attributes": [
               {
-                "Name": "@bind-Value",
-                "DisplayName": "@bind-Value",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind-Value"
               }
             ]
           }
@@ -16174,10 +15179,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -8606467388077565933,
-          "Data2": 6026805045330357622,
-          "Data3": 2947170347199897399,
-          "Data4": 8283420710909573260
+          "Data1": 6623132442028878991,
+          "Data2": -6151043454419574227,
+          "Data3": 3859145110192387674,
+          "Data4": -6237858142522541826
         },
         "Kind": "Components.Bind",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputDate<TValue>",
@@ -16190,11 +15195,8 @@
             "TagName": "Microsoft.AspNetCore.Components.Forms.InputDate",
             "Attributes": [
               {
-                "Name": "@bind-Value",
-                "DisplayName": "@bind-Value",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind-Value"
               }
             ]
           }
@@ -16223,10 +15225,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 770310171565119570,
-          "Data2": 1346830284163346421,
-          "Data3": -5116255847226173193,
-          "Data4": -3179112254135771168
+          "Data1": -5895604482621277320,
+          "Data2": 7722523754533772318,
+          "Data3": 7169894091923728970,
+          "Data4": -5515708919820606488
         },
         "Kind": "Components.Bind",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>",
@@ -16239,11 +15241,8 @@
             "TagName": "InputNumber",
             "Attributes": [
               {
-                "Name": "@bind-Value",
-                "DisplayName": "@bind-Value",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind-Value"
               }
             ]
           }
@@ -16271,10 +15270,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 5318434596194194593,
-          "Data2": 562838146021960775,
-          "Data3": 1007413628672408739,
-          "Data4": -2099831474612322626
+          "Data1": 215512487702315609,
+          "Data2": -6668078386142117924,
+          "Data3": -2901767046733361437,
+          "Data4": -5919779103139160883
         },
         "Kind": "Components.Bind",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>",
@@ -16287,11 +15286,8 @@
             "TagName": "Microsoft.AspNetCore.Components.Forms.InputNumber",
             "Attributes": [
               {
-                "Name": "@bind-Value",
-                "DisplayName": "@bind-Value",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind-Value"
               }
             ]
           }
@@ -16320,10 +15316,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 2980009989284336402,
-          "Data2": 3262046464264859668,
-          "Data3": 8225890023716967200,
-          "Data4": -5916661811237023621
+          "Data1": 8052947956344820095,
+          "Data2": 4684765108769099838,
+          "Data3": 8883334803662915749,
+          "Data4": 1781737171988585359
         },
         "Kind": "Components.Bind",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>",
@@ -16336,11 +15332,8 @@
             "TagName": "InputSelect",
             "Attributes": [
               {
-                "Name": "@bind-Value",
-                "DisplayName": "@bind-Value",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind-Value"
               }
             ]
           }
@@ -16368,10 +15361,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -4739879909583326270,
-          "Data2": -4331164756340733023,
-          "Data3": -695035121757217838,
-          "Data4": -7303457385444870737
+          "Data1": -6850034648584414383,
+          "Data2": -6363083754800546833,
+          "Data3": -6432064771405142607,
+          "Data4": 6307166297046574106
         },
         "Kind": "Components.Bind",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>",
@@ -16384,11 +15377,8 @@
             "TagName": "Microsoft.AspNetCore.Components.Forms.InputSelect",
             "Attributes": [
               {
-                "Name": "@bind-Value",
-                "DisplayName": "@bind-Value",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind-Value"
               }
             ]
           }
@@ -16417,10 +15407,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 7355656378855522805,
-          "Data2": 3662902899766694902,
-          "Data3": 2413703173523070260,
-          "Data4": -6738163032111662636
+          "Data1": 2772643131899611355,
+          "Data2": 161230923266143376,
+          "Data3": -6417247422822014078,
+          "Data4": -3073161447026675681
         },
         "Kind": "Components.Bind",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputText",
@@ -16433,11 +15423,8 @@
             "TagName": "InputText",
             "Attributes": [
               {
-                "Name": "@bind-Value",
-                "DisplayName": "@bind-Value",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind-Value"
               }
             ]
           }
@@ -16465,10 +15452,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 2476657285447884112,
-          "Data2": 2888031809996437989,
-          "Data3": 6322966919060727303,
-          "Data4": -5883539387910982967
+          "Data1": -3816996189101937828,
+          "Data2": 8142691235552438996,
+          "Data3": -386264467503246253,
+          "Data4": -9057864446646040750
         },
         "Kind": "Components.Bind",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputText",
@@ -16481,11 +15468,8 @@
             "TagName": "Microsoft.AspNetCore.Components.Forms.InputText",
             "Attributes": [
               {
-                "Name": "@bind-Value",
-                "DisplayName": "@bind-Value",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind-Value"
               }
             ]
           }
@@ -16514,10 +15498,10 @@
       },
       {
         "__Checksum": {
-          "Data1": -5771655227374795541,
-          "Data2": -3839372673098512560,
-          "Data3": -3515657784015293388,
-          "Data4": 7730937333667464506
+          "Data1": 8489912928017896798,
+          "Data2": -19393457681018577,
+          "Data3": 3138030808152772388,
+          "Data4": -5751162210066935151
         },
         "Kind": "Components.Bind",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputTextArea",
@@ -16530,11 +15514,8 @@
             "TagName": "InputTextArea",
             "Attributes": [
               {
-                "Name": "@bind-Value",
-                "DisplayName": "@bind-Value",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind-Value"
               }
             ]
           }
@@ -16562,10 +15543,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 4108805942338143318,
-          "Data2": -1959355447728106029,
-          "Data3": 6859453115345515934,
-          "Data4": -5985838738746024879
+          "Data1": -675003618323021070,
+          "Data2": -2059731121279843109,
+          "Data3": 197622197621679671,
+          "Data4": 7667259632515529736
         },
         "Kind": "Components.Bind",
         "Name": "Microsoft.AspNetCore.Components.Forms.InputTextArea",
@@ -16578,11 +15559,8 @@
             "TagName": "Microsoft.AspNetCore.Components.Forms.InputTextArea",
             "Attributes": [
               {
-                "Name": "@bind-Value",
-                "DisplayName": "@bind-Value",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@bind-Value"
               }
             ]
           }
@@ -16611,10 +15589,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 1347304352155116622,
-          "Data2": -7243151059964407181,
-          "Data3": -5597255805512913270,
-          "Data4": 1929205353189293387
+          "Data1": 259137181660549947,
+          "Data2": -8831846084524296709,
+          "Data3": -466609509331154823,
+          "Data4": -537230876773147632
         },
         "Kind": "Components.Ref",
         "Name": "Ref",
@@ -16627,11 +15605,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@ref",
-                "DisplayName": "@ref",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@ref"
               }
             ]
           }
@@ -16657,10 +15632,10 @@
       },
       {
         "__Checksum": {
-          "Data1": 3173142411512989623,
-          "Data2": 6084693246750490904,
-          "Data3": 1162821467855587449,
-          "Data4": -1742661707188792840
+          "Data1": -5468280135945511307,
+          "Data2": -4733080031900872941,
+          "Data3": 3577791141724655338,
+          "Data4": -2142966127068421661
         },
         "Kind": "Components.Key",
         "Name": "Key",
@@ -16673,11 +15648,8 @@
             "TagName": "*",
             "Attributes": [
               {
-                "Name": "@key",
-                "DisplayName": "@key",
-                "Metadata": {
-                  "Common.DirectiveAttribute": "True"
-                }
+                "Flags": 3,
+                "Name": "@key"
               }
             ]
           }

--- a/src/Shared/files/Tooling/taghelpers.json
+++ b/src/Shared/files/Tooling/taghelpers.json
@@ -86574,10 +86574,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 776561726507942884,
-      "Data2": 5557630740736201865,
-      "Data3": 7355842519808458354,
-      "Data4": -3964587568195868151
+      "Data1": -2806707935077827727,
+      "Data2": 6415107801635374698,
+      "Data3": 6215170250707143238,
+      "Data4": 6075380084954728241
     },
     "Kind": "Components.EventHandler",
     "Name": "onfocus",
@@ -86590,11 +86590,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfocus",
-            "DisplayName": "@onfocus",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfocus"
           }
         ]
       },
@@ -86602,11 +86599,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfocus:preventDefault",
-            "DisplayName": "@onfocus:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfocus:preventDefault"
           }
         ]
       },
@@ -86614,11 +86608,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfocus:stopPropagation",
-            "DisplayName": "@onfocus:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfocus:stopPropagation"
           }
         ]
       }
@@ -86662,10 +86653,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7950054930748702975,
-      "Data2": 6465363889119136392,
-      "Data3": -4143786467884568428,
-      "Data4": -7359791184330635656
+      "Data1": 824751730599287744,
+      "Data2": -42213401304457652,
+      "Data3": 2725691573206123723,
+      "Data4": 7780232472071648075
     },
     "Kind": "Components.EventHandler",
     "Name": "onblur",
@@ -86678,11 +86669,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onblur",
-            "DisplayName": "@onblur",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onblur"
           }
         ]
       },
@@ -86690,11 +86678,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onblur:preventDefault",
-            "DisplayName": "@onblur:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onblur:preventDefault"
           }
         ]
       },
@@ -86702,11 +86687,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onblur:stopPropagation",
-            "DisplayName": "@onblur:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onblur:stopPropagation"
           }
         ]
       }
@@ -86750,10 +86732,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4699592739833148788,
-      "Data2": -8331610815184386671,
-      "Data3": 4173905434627084587,
-      "Data4": -328988478052119607
+      "Data1": -5818192813319111004,
+      "Data2": 5085531177117623840,
+      "Data3": -4484106822643441038,
+      "Data4": -1679210546199914372
     },
     "Kind": "Components.EventHandler",
     "Name": "onfocusin",
@@ -86766,11 +86748,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfocusin",
-            "DisplayName": "@onfocusin",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfocusin"
           }
         ]
       },
@@ -86778,11 +86757,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfocusin:preventDefault",
-            "DisplayName": "@onfocusin:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfocusin:preventDefault"
           }
         ]
       },
@@ -86790,11 +86766,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfocusin:stopPropagation",
-            "DisplayName": "@onfocusin:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfocusin:stopPropagation"
           }
         ]
       }
@@ -86838,10 +86811,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4832732406522545188,
-      "Data2": 6876575770989611033,
-      "Data3": 3801586134737525481,
-      "Data4": 5803459775368156402
+      "Data1": 6934465511782769131,
+      "Data2": -5517164131169765394,
+      "Data3": 5546638896181097513,
+      "Data4": -9094264430498391810
     },
     "Kind": "Components.EventHandler",
     "Name": "onfocusout",
@@ -86854,11 +86827,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfocusout",
-            "DisplayName": "@onfocusout",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfocusout"
           }
         ]
       },
@@ -86866,11 +86836,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfocusout:preventDefault",
-            "DisplayName": "@onfocusout:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfocusout:preventDefault"
           }
         ]
       },
@@ -86878,11 +86845,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfocusout:stopPropagation",
-            "DisplayName": "@onfocusout:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfocusout:stopPropagation"
           }
         ]
       }
@@ -86926,10 +86890,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2456623862534754194,
-      "Data2": 4897916296463155188,
-      "Data3": 641005691947285359,
-      "Data4": -8838201390559360680
+      "Data1": 2785170637431761670,
+      "Data2": 1175465762616700831,
+      "Data3": -2165898375219221231,
+      "Data4": -8534162041979924076
     },
     "Kind": "Components.EventHandler",
     "Name": "onmouseover",
@@ -86942,11 +86906,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmouseover",
-            "DisplayName": "@onmouseover",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmouseover"
           }
         ]
       },
@@ -86954,11 +86915,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmouseover:preventDefault",
-            "DisplayName": "@onmouseover:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmouseover:preventDefault"
           }
         ]
       },
@@ -86966,11 +86924,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmouseover:stopPropagation",
-            "DisplayName": "@onmouseover:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmouseover:stopPropagation"
           }
         ]
       }
@@ -87014,10 +86969,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6049076316800264400,
-      "Data2": -8058562634396256426,
-      "Data3": -2668176197574968240,
-      "Data4": -5490107775533555661
+      "Data1": 9151459009653472844,
+      "Data2": 1177966038064466060,
+      "Data3": 3907842854120762625,
+      "Data4": 5459724499559682031
     },
     "Kind": "Components.EventHandler",
     "Name": "onmouseout",
@@ -87030,11 +86985,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmouseout",
-            "DisplayName": "@onmouseout",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmouseout"
           }
         ]
       },
@@ -87042,11 +86994,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmouseout:preventDefault",
-            "DisplayName": "@onmouseout:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmouseout:preventDefault"
           }
         ]
       },
@@ -87054,11 +87003,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmouseout:stopPropagation",
-            "DisplayName": "@onmouseout:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmouseout:stopPropagation"
           }
         ]
       }
@@ -87102,10 +87048,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 745056966200040031,
-      "Data2": -8118750236149352757,
-      "Data3": -2143126753721766364,
-      "Data4": 3180479463644345544
+      "Data1": 8499031587342469625,
+      "Data2": -1578719258540975467,
+      "Data3": -6321896220134494535,
+      "Data4": -2638931091945177816
     },
     "Kind": "Components.EventHandler",
     "Name": "onmousemove",
@@ -87118,11 +87064,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmousemove",
-            "DisplayName": "@onmousemove",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmousemove"
           }
         ]
       },
@@ -87130,11 +87073,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmousemove:preventDefault",
-            "DisplayName": "@onmousemove:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmousemove:preventDefault"
           }
         ]
       },
@@ -87142,11 +87082,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmousemove:stopPropagation",
-            "DisplayName": "@onmousemove:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmousemove:stopPropagation"
           }
         ]
       }
@@ -87190,10 +87127,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7813760438582330405,
-      "Data2": 3191338601767660698,
-      "Data3": 1598423061245711969,
-      "Data4": 3538887710525514946
+      "Data1": 6319626064263734005,
+      "Data2": -6817840555217389995,
+      "Data3": -8847327528516667437,
+      "Data4": -7631336618150995831
     },
     "Kind": "Components.EventHandler",
     "Name": "onmousedown",
@@ -87206,11 +87143,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmousedown",
-            "DisplayName": "@onmousedown",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmousedown"
           }
         ]
       },
@@ -87218,11 +87152,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmousedown:preventDefault",
-            "DisplayName": "@onmousedown:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmousedown:preventDefault"
           }
         ]
       },
@@ -87230,11 +87161,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmousedown:stopPropagation",
-            "DisplayName": "@onmousedown:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmousedown:stopPropagation"
           }
         ]
       }
@@ -87278,10 +87206,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8568747407739400930,
-      "Data2": -2739194467979803088,
-      "Data3": -494792239438407205,
-      "Data4": 4069383184054621234
+      "Data1": 6260371015158154665,
+      "Data2": 483178568384276213,
+      "Data3": 6133005821654693151,
+      "Data4": -4025040320785507336
     },
     "Kind": "Components.EventHandler",
     "Name": "onmouseup",
@@ -87294,11 +87222,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmouseup",
-            "DisplayName": "@onmouseup",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmouseup"
           }
         ]
       },
@@ -87306,11 +87231,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmouseup:preventDefault",
-            "DisplayName": "@onmouseup:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmouseup:preventDefault"
           }
         ]
       },
@@ -87318,11 +87240,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmouseup:stopPropagation",
-            "DisplayName": "@onmouseup:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmouseup:stopPropagation"
           }
         ]
       }
@@ -87366,10 +87285,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2691366312267196551,
-      "Data2": 945764990463275536,
-      "Data3": -6633382773603334787,
-      "Data4": 9056029558432764453
+      "Data1": 3328069064315024030,
+      "Data2": -8350708226304690653,
+      "Data3": 3120971516740919470,
+      "Data4": 2706598109973872892
     },
     "Kind": "Components.EventHandler",
     "Name": "onclick",
@@ -87382,11 +87301,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onclick",
-            "DisplayName": "@onclick",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onclick"
           }
         ]
       },
@@ -87394,11 +87310,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onclick:preventDefault",
-            "DisplayName": "@onclick:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onclick:preventDefault"
           }
         ]
       },
@@ -87406,11 +87319,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onclick:stopPropagation",
-            "DisplayName": "@onclick:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onclick:stopPropagation"
           }
         ]
       }
@@ -87454,10 +87364,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5746034800709908768,
-      "Data2": 1384114053049548018,
-      "Data3": -762745928578686125,
-      "Data4": 3310133740194521339
+      "Data1": -7002829992097446641,
+      "Data2": -6565614873396982712,
+      "Data3": -2708508866793076893,
+      "Data4": -8722302105890322993
     },
     "Kind": "Components.EventHandler",
     "Name": "ondblclick",
@@ -87470,11 +87380,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondblclick",
-            "DisplayName": "@ondblclick",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondblclick"
           }
         ]
       },
@@ -87482,11 +87389,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondblclick:preventDefault",
-            "DisplayName": "@ondblclick:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondblclick:preventDefault"
           }
         ]
       },
@@ -87494,11 +87398,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondblclick:stopPropagation",
-            "DisplayName": "@ondblclick:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondblclick:stopPropagation"
           }
         ]
       }
@@ -87542,10 +87443,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6571673966820787306,
-      "Data2": -356722867657918075,
-      "Data3": -4323490984558370885,
-      "Data4": -2327808082380185750
+      "Data1": 4854518818470381938,
+      "Data2": 6749642084960956172,
+      "Data3": 7087328032748468620,
+      "Data4": -8663330378580485573
     },
     "Kind": "Components.EventHandler",
     "Name": "onwheel",
@@ -87558,11 +87459,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onwheel",
-            "DisplayName": "@onwheel",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onwheel"
           }
         ]
       },
@@ -87570,11 +87468,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onwheel:preventDefault",
-            "DisplayName": "@onwheel:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onwheel:preventDefault"
           }
         ]
       },
@@ -87582,11 +87477,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onwheel:stopPropagation",
-            "DisplayName": "@onwheel:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onwheel:stopPropagation"
           }
         ]
       }
@@ -87630,10 +87522,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7009791439294874418,
-      "Data2": -5518190968471865242,
-      "Data3": 996180290626419525,
-      "Data4": 4724612514121241554
+      "Data1": -4121560565808091206,
+      "Data2": 1537297420629449179,
+      "Data3": 9047104739121015435,
+      "Data4": -2466498699364320227
     },
     "Kind": "Components.EventHandler",
     "Name": "onmousewheel",
@@ -87646,11 +87538,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmousewheel",
-            "DisplayName": "@onmousewheel",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmousewheel"
           }
         ]
       },
@@ -87658,11 +87547,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmousewheel:preventDefault",
-            "DisplayName": "@onmousewheel:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmousewheel:preventDefault"
           }
         ]
       },
@@ -87670,11 +87556,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmousewheel:stopPropagation",
-            "DisplayName": "@onmousewheel:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmousewheel:stopPropagation"
           }
         ]
       }
@@ -87718,10 +87601,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8684766088183726974,
-      "Data2": -4179632678952881697,
-      "Data3": -1835629594978760273,
-      "Data4": 6806337382292419095
+      "Data1": -734859657916130803,
+      "Data2": -1599004492719338175,
+      "Data3": -1243473379538151840,
+      "Data4": -7332987339347123911
     },
     "Kind": "Components.EventHandler",
     "Name": "oncontextmenu",
@@ -87734,11 +87617,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncontextmenu",
-            "DisplayName": "@oncontextmenu",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncontextmenu"
           }
         ]
       },
@@ -87746,11 +87626,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncontextmenu:preventDefault",
-            "DisplayName": "@oncontextmenu:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncontextmenu:preventDefault"
           }
         ]
       },
@@ -87758,11 +87635,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncontextmenu:stopPropagation",
-            "DisplayName": "@oncontextmenu:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncontextmenu:stopPropagation"
           }
         ]
       }
@@ -87806,10 +87680,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3936034570909442512,
-      "Data2": 8185574875338810261,
-      "Data3": -7294789916148375604,
-      "Data4": -7988381909870867183
+      "Data1": -4077780472112033312,
+      "Data2": -1226196748455167572,
+      "Data3": 7850929576869548389,
+      "Data4": 7320474539365212469
     },
     "Kind": "Components.EventHandler",
     "Name": "ondrag",
@@ -87822,11 +87696,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondrag",
-            "DisplayName": "@ondrag",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondrag"
           }
         ]
       },
@@ -87834,11 +87705,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondrag:preventDefault",
-            "DisplayName": "@ondrag:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondrag:preventDefault"
           }
         ]
       },
@@ -87846,11 +87714,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondrag:stopPropagation",
-            "DisplayName": "@ondrag:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondrag:stopPropagation"
           }
         ]
       }
@@ -87894,10 +87759,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6612364046286108891,
-      "Data2": 7938084268625906938,
-      "Data3": -5496393027756177394,
-      "Data4": -8842852218074003515
+      "Data1": 43648727579695502,
+      "Data2": 2183586787322421050,
+      "Data3": -2492988724065465235,
+      "Data4": -3426810353075645433
     },
     "Kind": "Components.EventHandler",
     "Name": "ondragend",
@@ -87910,11 +87775,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragend",
-            "DisplayName": "@ondragend",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragend"
           }
         ]
       },
@@ -87922,11 +87784,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragend:preventDefault",
-            "DisplayName": "@ondragend:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragend:preventDefault"
           }
         ]
       },
@@ -87934,11 +87793,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragend:stopPropagation",
-            "DisplayName": "@ondragend:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragend:stopPropagation"
           }
         ]
       }
@@ -87982,10 +87838,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7157106690163754092,
-      "Data2": 2959549450549697234,
-      "Data3": -3573606193669284279,
-      "Data4": -4412809196265448223
+      "Data1": 6724843067153610846,
+      "Data2": 1392407115265109337,
+      "Data3": -8300530331807383485,
+      "Data4": -210067135487700046
     },
     "Kind": "Components.EventHandler",
     "Name": "ondragenter",
@@ -87998,11 +87854,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragenter",
-            "DisplayName": "@ondragenter",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragenter"
           }
         ]
       },
@@ -88010,11 +87863,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragenter:preventDefault",
-            "DisplayName": "@ondragenter:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragenter:preventDefault"
           }
         ]
       },
@@ -88022,11 +87872,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragenter:stopPropagation",
-            "DisplayName": "@ondragenter:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragenter:stopPropagation"
           }
         ]
       }
@@ -88070,10 +87917,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3469870177517462699,
-      "Data2": 6312380037254605637,
-      "Data3": -3094073707890115628,
-      "Data4": 461245180926347400
+      "Data1": -6850037096017173468,
+      "Data2": 6706959201688396614,
+      "Data3": 685700038119232604,
+      "Data4": -3916288527381659077
     },
     "Kind": "Components.EventHandler",
     "Name": "ondragleave",
@@ -88086,11 +87933,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragleave",
-            "DisplayName": "@ondragleave",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragleave"
           }
         ]
       },
@@ -88098,11 +87942,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragleave:preventDefault",
-            "DisplayName": "@ondragleave:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragleave:preventDefault"
           }
         ]
       },
@@ -88110,11 +87951,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragleave:stopPropagation",
-            "DisplayName": "@ondragleave:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragleave:stopPropagation"
           }
         ]
       }
@@ -88158,10 +87996,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1198582670071088953,
-      "Data2": 3739268369360527671,
-      "Data3": 2931243054922686622,
-      "Data4": 1587176538678499991
+      "Data1": 4495662173416045820,
+      "Data2": 2722829120274002581,
+      "Data3": 7791791919175356367,
+      "Data4": -4158390811852637041
     },
     "Kind": "Components.EventHandler",
     "Name": "ondragover",
@@ -88174,11 +88012,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragover",
-            "DisplayName": "@ondragover",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragover"
           }
         ]
       },
@@ -88186,11 +88021,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragover:preventDefault",
-            "DisplayName": "@ondragover:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragover:preventDefault"
           }
         ]
       },
@@ -88198,11 +88030,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragover:stopPropagation",
-            "DisplayName": "@ondragover:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragover:stopPropagation"
           }
         ]
       }
@@ -88246,10 +88075,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5924328765303398517,
-      "Data2": -4895237971080167607,
-      "Data3": -1210778275634014654,
-      "Data4": -3517362703801785521
+      "Data1": 4389496981340227186,
+      "Data2": 7120638920260579588,
+      "Data3": 6333713214429050068,
+      "Data4": -1862982825446439910
     },
     "Kind": "Components.EventHandler",
     "Name": "ondragstart",
@@ -88262,11 +88091,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragstart",
-            "DisplayName": "@ondragstart",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragstart"
           }
         ]
       },
@@ -88274,11 +88100,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragstart:preventDefault",
-            "DisplayName": "@ondragstart:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragstart:preventDefault"
           }
         ]
       },
@@ -88286,11 +88109,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondragstart:stopPropagation",
-            "DisplayName": "@ondragstart:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondragstart:stopPropagation"
           }
         ]
       }
@@ -88334,10 +88154,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3351120994073836432,
-      "Data2": -8078898051877844987,
-      "Data3": 9134138371014904605,
-      "Data4": -2854312192401876534
+      "Data1": -2355687517541602418,
+      "Data2": -1735587079450517717,
+      "Data3": -5441801070067985253,
+      "Data4": 7435168180727956948
     },
     "Kind": "Components.EventHandler",
     "Name": "ondrop",
@@ -88350,11 +88170,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondrop",
-            "DisplayName": "@ondrop",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondrop"
           }
         ]
       },
@@ -88362,11 +88179,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondrop:preventDefault",
-            "DisplayName": "@ondrop:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondrop:preventDefault"
           }
         ]
       },
@@ -88374,11 +88188,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondrop:stopPropagation",
-            "DisplayName": "@ondrop:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondrop:stopPropagation"
           }
         ]
       }
@@ -88422,10 +88233,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5077285199962410397,
-      "Data2": -9066896604787139986,
-      "Data3": -310554883975592190,
-      "Data4": -6214024301785119171
+      "Data1": 5318058906167445501,
+      "Data2": 811763005005381167,
+      "Data3": 2037166516259148688,
+      "Data4": 3608091220032195188
     },
     "Kind": "Components.EventHandler",
     "Name": "onkeydown",
@@ -88438,11 +88249,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onkeydown",
-            "DisplayName": "@onkeydown",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onkeydown"
           }
         ]
       },
@@ -88450,11 +88258,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onkeydown:preventDefault",
-            "DisplayName": "@onkeydown:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onkeydown:preventDefault"
           }
         ]
       },
@@ -88462,11 +88267,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onkeydown:stopPropagation",
-            "DisplayName": "@onkeydown:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onkeydown:stopPropagation"
           }
         ]
       }
@@ -88510,10 +88312,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3451933020005154529,
-      "Data2": -2363288638095261372,
-      "Data3": -7408539997117023526,
-      "Data4": 5722579297602786118
+      "Data1": 1907138261598451423,
+      "Data2": 9157562506662842482,
+      "Data3": 6174825600975950603,
+      "Data4": -8373721795343428558
     },
     "Kind": "Components.EventHandler",
     "Name": "onkeyup",
@@ -88526,11 +88328,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onkeyup",
-            "DisplayName": "@onkeyup",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onkeyup"
           }
         ]
       },
@@ -88538,11 +88337,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onkeyup:preventDefault",
-            "DisplayName": "@onkeyup:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onkeyup:preventDefault"
           }
         ]
       },
@@ -88550,11 +88346,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onkeyup:stopPropagation",
-            "DisplayName": "@onkeyup:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onkeyup:stopPropagation"
           }
         ]
       }
@@ -88598,10 +88391,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4372286476570551847,
-      "Data2": -1647204244638399910,
-      "Data3": -5434938110512986448,
-      "Data4": -1140738179753388870
+      "Data1": 2788349921591899730,
+      "Data2": 8224311495308535747,
+      "Data3": -1231785166914640335,
+      "Data4": -7509717588162453949
     },
     "Kind": "Components.EventHandler",
     "Name": "onkeypress",
@@ -88614,11 +88407,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onkeypress",
-            "DisplayName": "@onkeypress",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onkeypress"
           }
         ]
       },
@@ -88626,11 +88416,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onkeypress:preventDefault",
-            "DisplayName": "@onkeypress:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onkeypress:preventDefault"
           }
         ]
       },
@@ -88638,11 +88425,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onkeypress:stopPropagation",
-            "DisplayName": "@onkeypress:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onkeypress:stopPropagation"
           }
         ]
       }
@@ -88686,10 +88470,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7146818761235551508,
-      "Data2": 2204964737553865114,
-      "Data3": 9007368408570436325,
-      "Data4": 3503911248425216881
+      "Data1": -8495910277240177461,
+      "Data2": 241037893285316131,
+      "Data3": 2541009644436064320,
+      "Data4": -7877604584886407680
     },
     "Kind": "Components.EventHandler",
     "Name": "onchange",
@@ -88702,11 +88486,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onchange",
-            "DisplayName": "@onchange",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onchange"
           }
         ]
       },
@@ -88714,11 +88495,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onchange:preventDefault",
-            "DisplayName": "@onchange:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onchange:preventDefault"
           }
         ]
       },
@@ -88726,11 +88504,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onchange:stopPropagation",
-            "DisplayName": "@onchange:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onchange:stopPropagation"
           }
         ]
       }
@@ -88774,10 +88549,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8041585676407528832,
-      "Data2": -177400542946692827,
-      "Data3": -7140067122791456683,
-      "Data4": 1767545638128224492
+      "Data1": 5138111780035974751,
+      "Data2": -7828162583120824686,
+      "Data3": 1347634051027002625,
+      "Data4": -1975034247852187517
     },
     "Kind": "Components.EventHandler",
     "Name": "oninput",
@@ -88790,11 +88565,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oninput",
-            "DisplayName": "@oninput",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oninput"
           }
         ]
       },
@@ -88802,11 +88574,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oninput:preventDefault",
-            "DisplayName": "@oninput:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oninput:preventDefault"
           }
         ]
       },
@@ -88814,11 +88583,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oninput:stopPropagation",
-            "DisplayName": "@oninput:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oninput:stopPropagation"
           }
         ]
       }
@@ -88862,10 +88628,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -976082742642820831,
-      "Data2": -8604211272281991176,
-      "Data3": 967936762894759607,
-      "Data4": 5234927576935575895
+      "Data1": 7074812890747163750,
+      "Data2": -7814768020787183457,
+      "Data3": -6293380977058456905,
+      "Data4": -1588432922353593310
     },
     "Kind": "Components.EventHandler",
     "Name": "oninvalid",
@@ -88878,11 +88644,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oninvalid",
-            "DisplayName": "@oninvalid",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oninvalid"
           }
         ]
       },
@@ -88890,11 +88653,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oninvalid:preventDefault",
-            "DisplayName": "@oninvalid:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oninvalid:preventDefault"
           }
         ]
       },
@@ -88902,11 +88662,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oninvalid:stopPropagation",
-            "DisplayName": "@oninvalid:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oninvalid:stopPropagation"
           }
         ]
       }
@@ -88950,10 +88707,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6808473964169166288,
-      "Data2": -7675912997442969349,
-      "Data3": -4604993777349514317,
-      "Data4": -1200989218310710916
+      "Data1": 1140740099489415685,
+      "Data2": 5632547615796569162,
+      "Data3": 3069496813581430608,
+      "Data4": 2510998388557351992
     },
     "Kind": "Components.EventHandler",
     "Name": "onreset",
@@ -88966,11 +88723,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onreset",
-            "DisplayName": "@onreset",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onreset"
           }
         ]
       },
@@ -88978,11 +88732,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onreset:preventDefault",
-            "DisplayName": "@onreset:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onreset:preventDefault"
           }
         ]
       },
@@ -88990,11 +88741,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onreset:stopPropagation",
-            "DisplayName": "@onreset:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onreset:stopPropagation"
           }
         ]
       }
@@ -89038,10 +88786,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4177885159442933292,
-      "Data2": -1129482810142213837,
-      "Data3": 7974408388185247885,
-      "Data4": -5301644591809156180
+      "Data1": 6691045623812208019,
+      "Data2": -2745250276069715824,
+      "Data3": 3894540907788436283,
+      "Data4": -3017140072918460238
     },
     "Kind": "Components.EventHandler",
     "Name": "onselect",
@@ -89054,11 +88802,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onselect",
-            "DisplayName": "@onselect",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onselect"
           }
         ]
       },
@@ -89066,11 +88811,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onselect:preventDefault",
-            "DisplayName": "@onselect:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onselect:preventDefault"
           }
         ]
       },
@@ -89078,11 +88820,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onselect:stopPropagation",
-            "DisplayName": "@onselect:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onselect:stopPropagation"
           }
         ]
       }
@@ -89126,10 +88865,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 653332947246040897,
-      "Data2": 2539729174074297351,
-      "Data3": -2869441715872142527,
-      "Data4": 855425694007554639
+      "Data1": 1904056923791664059,
+      "Data2": 1839706549452550645,
+      "Data3": -5576204251449987699,
+      "Data4": -8194553676094593494
     },
     "Kind": "Components.EventHandler",
     "Name": "onselectstart",
@@ -89142,11 +88881,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onselectstart",
-            "DisplayName": "@onselectstart",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onselectstart"
           }
         ]
       },
@@ -89154,11 +88890,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onselectstart:preventDefault",
-            "DisplayName": "@onselectstart:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onselectstart:preventDefault"
           }
         ]
       },
@@ -89166,11 +88899,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onselectstart:stopPropagation",
-            "DisplayName": "@onselectstart:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onselectstart:stopPropagation"
           }
         ]
       }
@@ -89214,10 +88944,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6724679110949626691,
-      "Data2": -3214167320428175641,
-      "Data3": -1931798760997097090,
-      "Data4": 7126868194133096280
+      "Data1": 7665640218495995821,
+      "Data2": 2657411266412285484,
+      "Data3": -2234908280615295020,
+      "Data4": 6279965297603038388
     },
     "Kind": "Components.EventHandler",
     "Name": "onselectionchange",
@@ -89230,11 +88960,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onselectionchange",
-            "DisplayName": "@onselectionchange",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onselectionchange"
           }
         ]
       },
@@ -89242,11 +88969,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onselectionchange:preventDefault",
-            "DisplayName": "@onselectionchange:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onselectionchange:preventDefault"
           }
         ]
       },
@@ -89254,11 +88978,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onselectionchange:stopPropagation",
-            "DisplayName": "@onselectionchange:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onselectionchange:stopPropagation"
           }
         ]
       }
@@ -89302,10 +89023,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -143199196837509125,
-      "Data2": 5054853454233546183,
-      "Data3": -3310055233570163481,
-      "Data4": -2308187971095117321
+      "Data1": -6134743990594465150,
+      "Data2": -167381029692917499,
+      "Data3": 2875934320842949627,
+      "Data4": -6330005106751013161
     },
     "Kind": "Components.EventHandler",
     "Name": "onsubmit",
@@ -89318,11 +89039,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onsubmit",
-            "DisplayName": "@onsubmit",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onsubmit"
           }
         ]
       },
@@ -89330,11 +89048,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onsubmit:preventDefault",
-            "DisplayName": "@onsubmit:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onsubmit:preventDefault"
           }
         ]
       },
@@ -89342,11 +89057,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onsubmit:stopPropagation",
-            "DisplayName": "@onsubmit:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onsubmit:stopPropagation"
           }
         ]
       }
@@ -89390,10 +89102,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1409291538160157514,
-      "Data2": 1453422544186407654,
-      "Data3": -6886927143499914533,
-      "Data4": -2508829764354329485
+      "Data1": 5402148731461652341,
+      "Data2": 8002074219042627589,
+      "Data3": 3711324643717567181,
+      "Data4": 5804289245721541441
     },
     "Kind": "Components.EventHandler",
     "Name": "onbeforecopy",
@@ -89406,11 +89118,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforecopy",
-            "DisplayName": "@onbeforecopy",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforecopy"
           }
         ]
       },
@@ -89418,11 +89127,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforecopy:preventDefault",
-            "DisplayName": "@onbeforecopy:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforecopy:preventDefault"
           }
         ]
       },
@@ -89430,11 +89136,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforecopy:stopPropagation",
-            "DisplayName": "@onbeforecopy:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforecopy:stopPropagation"
           }
         ]
       }
@@ -89478,10 +89181,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8805652541231566631,
-      "Data2": 2735176127846968743,
-      "Data3": -3097557438953150336,
-      "Data4": -3240015581351425806
+      "Data1": 5143659793004970670,
+      "Data2": 7999315523830087766,
+      "Data3": -8470604757939955084,
+      "Data4": -2264611826987828658
     },
     "Kind": "Components.EventHandler",
     "Name": "onbeforecut",
@@ -89494,11 +89197,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforecut",
-            "DisplayName": "@onbeforecut",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforecut"
           }
         ]
       },
@@ -89506,11 +89206,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforecut:preventDefault",
-            "DisplayName": "@onbeforecut:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforecut:preventDefault"
           }
         ]
       },
@@ -89518,11 +89215,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforecut:stopPropagation",
-            "DisplayName": "@onbeforecut:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforecut:stopPropagation"
           }
         ]
       }
@@ -89566,10 +89260,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7424545839632137207,
-      "Data2": -3717057470883371788,
-      "Data3": 1467116517835997901,
-      "Data4": 3099527486472268172
+      "Data1": -1502507113385113441,
+      "Data2": 7337260726022084630,
+      "Data3": -3813231722836342284,
+      "Data4": 4304805245939898468
     },
     "Kind": "Components.EventHandler",
     "Name": "onbeforepaste",
@@ -89582,11 +89276,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforepaste",
-            "DisplayName": "@onbeforepaste",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforepaste"
           }
         ]
       },
@@ -89594,11 +89285,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforepaste:preventDefault",
-            "DisplayName": "@onbeforepaste:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforepaste:preventDefault"
           }
         ]
       },
@@ -89606,11 +89294,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforepaste:stopPropagation",
-            "DisplayName": "@onbeforepaste:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforepaste:stopPropagation"
           }
         ]
       }
@@ -89654,10 +89339,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -134848738593063519,
-      "Data2": -3651257906947580304,
-      "Data3": 1413675231712570498,
-      "Data4": 978684993046199366
+      "Data1": -9056354391836114083,
+      "Data2": -7636541409447881963,
+      "Data3": 7607712848391681348,
+      "Data4": -7203520940074380017
     },
     "Kind": "Components.EventHandler",
     "Name": "oncopy",
@@ -89670,11 +89355,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncopy",
-            "DisplayName": "@oncopy",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncopy"
           }
         ]
       },
@@ -89682,11 +89364,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncopy:preventDefault",
-            "DisplayName": "@oncopy:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncopy:preventDefault"
           }
         ]
       },
@@ -89694,11 +89373,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncopy:stopPropagation",
-            "DisplayName": "@oncopy:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncopy:stopPropagation"
           }
         ]
       }
@@ -89742,10 +89418,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7322064494069445117,
-      "Data2": 2494132458027238290,
-      "Data3": 8238429581458905756,
-      "Data4": -8507723274534037426
+      "Data1": 9001259016122590849,
+      "Data2": -5062447475707089746,
+      "Data3": -8807944877695879086,
+      "Data4": 8656116205160423415
     },
     "Kind": "Components.EventHandler",
     "Name": "oncut",
@@ -89758,11 +89434,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncut",
-            "DisplayName": "@oncut",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncut"
           }
         ]
       },
@@ -89770,11 +89443,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncut:preventDefault",
-            "DisplayName": "@oncut:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncut:preventDefault"
           }
         ]
       },
@@ -89782,11 +89452,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncut:stopPropagation",
-            "DisplayName": "@oncut:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncut:stopPropagation"
           }
         ]
       }
@@ -89830,10 +89497,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8946132169626022491,
-      "Data2": -4579557400628748953,
-      "Data3": 5372107507482432022,
-      "Data4": -8345899503767181827
+      "Data1": -5787927521312447675,
+      "Data2": 2006918792834619177,
+      "Data3": -440838139955064163,
+      "Data4": 4421908841150283135
     },
     "Kind": "Components.EventHandler",
     "Name": "onpaste",
@@ -89846,11 +89513,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpaste",
-            "DisplayName": "@onpaste",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpaste"
           }
         ]
       },
@@ -89858,11 +89522,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpaste:preventDefault",
-            "DisplayName": "@onpaste:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpaste:preventDefault"
           }
         ]
       },
@@ -89870,11 +89531,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpaste:stopPropagation",
-            "DisplayName": "@onpaste:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpaste:stopPropagation"
           }
         ]
       }
@@ -89918,10 +89576,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8787195935532179698,
-      "Data2": 2241067856970325518,
-      "Data3": 4183641674438244391,
-      "Data4": 2560561022760319543
+      "Data1": -8655403793565253235,
+      "Data2": -1705381659178546580,
+      "Data3": 7821771808996885085,
+      "Data4": -2080153237021717290
     },
     "Kind": "Components.EventHandler",
     "Name": "ontouchcancel",
@@ -89934,11 +89592,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchcancel",
-            "DisplayName": "@ontouchcancel",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchcancel"
           }
         ]
       },
@@ -89946,11 +89601,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchcancel:preventDefault",
-            "DisplayName": "@ontouchcancel:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchcancel:preventDefault"
           }
         ]
       },
@@ -89958,11 +89610,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchcancel:stopPropagation",
-            "DisplayName": "@ontouchcancel:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchcancel:stopPropagation"
           }
         ]
       }
@@ -90006,10 +89655,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2288049121236316193,
-      "Data2": -1871207230236988491,
-      "Data3": 6944367161041747027,
-      "Data4": 4953890562717020997
+      "Data1": -6791416107413653718,
+      "Data2": 8452457440289860717,
+      "Data3": -454894682765614120,
+      "Data4": 4125201768992197238
     },
     "Kind": "Components.EventHandler",
     "Name": "ontouchend",
@@ -90022,11 +89671,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchend",
-            "DisplayName": "@ontouchend",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchend"
           }
         ]
       },
@@ -90034,11 +89680,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchend:preventDefault",
-            "DisplayName": "@ontouchend:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchend:preventDefault"
           }
         ]
       },
@@ -90046,11 +89689,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchend:stopPropagation",
-            "DisplayName": "@ontouchend:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchend:stopPropagation"
           }
         ]
       }
@@ -90094,10 +89734,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7854509324481108200,
-      "Data2": 6391013723596232050,
-      "Data3": -5142152930799601290,
-      "Data4": 3317349838530494190
+      "Data1": -2563925757775643994,
+      "Data2": 2231467727714928968,
+      "Data3": -8571157199664261671,
+      "Data4": 225274573367087026
     },
     "Kind": "Components.EventHandler",
     "Name": "ontouchmove",
@@ -90110,11 +89750,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchmove",
-            "DisplayName": "@ontouchmove",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchmove"
           }
         ]
       },
@@ -90122,11 +89759,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchmove:preventDefault",
-            "DisplayName": "@ontouchmove:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchmove:preventDefault"
           }
         ]
       },
@@ -90134,11 +89768,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchmove:stopPropagation",
-            "DisplayName": "@ontouchmove:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchmove:stopPropagation"
           }
         ]
       }
@@ -90182,10 +89813,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5620939408186670455,
-      "Data2": 292692503247963677,
-      "Data3": 7923069958755785613,
-      "Data4": -8237117535436953139
+      "Data1": 9121421880454304996,
+      "Data2": 7636707005209136717,
+      "Data3": -6428917853766679114,
+      "Data4": 9101424944078371595
     },
     "Kind": "Components.EventHandler",
     "Name": "ontouchstart",
@@ -90198,11 +89829,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchstart",
-            "DisplayName": "@ontouchstart",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchstart"
           }
         ]
       },
@@ -90210,11 +89838,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchstart:preventDefault",
-            "DisplayName": "@ontouchstart:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchstart:preventDefault"
           }
         ]
       },
@@ -90222,11 +89847,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchstart:stopPropagation",
-            "DisplayName": "@ontouchstart:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchstart:stopPropagation"
           }
         ]
       }
@@ -90270,10 +89892,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5559870619942353257,
-      "Data2": -2515128103217133745,
-      "Data3": 3290008124799228189,
-      "Data4": -1605002053740442459
+      "Data1": 1428260837585945238,
+      "Data2": -468413329461436092,
+      "Data3": -2794773236514503591,
+      "Data4": -2271538216526710974
     },
     "Kind": "Components.EventHandler",
     "Name": "ontouchenter",
@@ -90286,11 +89908,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchenter",
-            "DisplayName": "@ontouchenter",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchenter"
           }
         ]
       },
@@ -90298,11 +89917,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchenter:preventDefault",
-            "DisplayName": "@ontouchenter:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchenter:preventDefault"
           }
         ]
       },
@@ -90310,11 +89926,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchenter:stopPropagation",
-            "DisplayName": "@ontouchenter:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchenter:stopPropagation"
           }
         ]
       }
@@ -90358,10 +89971,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4678244826717681004,
-      "Data2": -7948292378089273635,
-      "Data3": 5890036056180196763,
-      "Data4": 3721163039413753076
+      "Data1": -4105584682490330595,
+      "Data2": -3304642075338451327,
+      "Data3": 2370719614703803884,
+      "Data4": -7942993558344443954
     },
     "Kind": "Components.EventHandler",
     "Name": "ontouchleave",
@@ -90374,11 +89987,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchleave",
-            "DisplayName": "@ontouchleave",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchleave"
           }
         ]
       },
@@ -90386,11 +89996,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchleave:preventDefault",
-            "DisplayName": "@ontouchleave:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchleave:preventDefault"
           }
         ]
       },
@@ -90398,11 +90005,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontouchleave:stopPropagation",
-            "DisplayName": "@ontouchleave:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontouchleave:stopPropagation"
           }
         ]
       }
@@ -90446,10 +90050,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1364523120345097441,
-      "Data2": 4878664492750009084,
-      "Data3": -6170575973861589773,
-      "Data4": 7328832883393461169
+      "Data1": 6832196578788593188,
+      "Data2": 4987099840012367299,
+      "Data3": -4017550834596237868,
+      "Data4": 4475306787406484461
     },
     "Kind": "Components.EventHandler",
     "Name": "ongotpointercapture",
@@ -90462,11 +90066,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ongotpointercapture",
-            "DisplayName": "@ongotpointercapture",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ongotpointercapture"
           }
         ]
       },
@@ -90474,11 +90075,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ongotpointercapture:preventDefault",
-            "DisplayName": "@ongotpointercapture:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ongotpointercapture:preventDefault"
           }
         ]
       },
@@ -90486,11 +90084,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ongotpointercapture:stopPropagation",
-            "DisplayName": "@ongotpointercapture:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ongotpointercapture:stopPropagation"
           }
         ]
       }
@@ -90534,10 +90129,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7675427503204323266,
-      "Data2": -6069293883414311559,
-      "Data3": 8240861494710311248,
-      "Data4": 2255581679775309912
+      "Data1": -569476404354443496,
+      "Data2": -126663652538932805,
+      "Data3": -6762189851764776770,
+      "Data4": -4963642200190633430
     },
     "Kind": "Components.EventHandler",
     "Name": "onlostpointercapture",
@@ -90550,11 +90145,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onlostpointercapture",
-            "DisplayName": "@onlostpointercapture",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onlostpointercapture"
           }
         ]
       },
@@ -90562,11 +90154,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onlostpointercapture:preventDefault",
-            "DisplayName": "@onlostpointercapture:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onlostpointercapture:preventDefault"
           }
         ]
       },
@@ -90574,11 +90163,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onlostpointercapture:stopPropagation",
-            "DisplayName": "@onlostpointercapture:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onlostpointercapture:stopPropagation"
           }
         ]
       }
@@ -90622,10 +90208,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2838926228406491124,
-      "Data2": -6175772953967196640,
-      "Data3": 6588839912845184440,
-      "Data4": -1000730887297265878
+      "Data1": -8352693976394311958,
+      "Data2": 4133150449413561124,
+      "Data3": 5477135419473472037,
+      "Data4": -8780342583165811403
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointercancel",
@@ -90638,11 +90224,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointercancel",
-            "DisplayName": "@onpointercancel",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointercancel"
           }
         ]
       },
@@ -90650,11 +90233,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointercancel:preventDefault",
-            "DisplayName": "@onpointercancel:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointercancel:preventDefault"
           }
         ]
       },
@@ -90662,11 +90242,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointercancel:stopPropagation",
-            "DisplayName": "@onpointercancel:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointercancel:stopPropagation"
           }
         ]
       }
@@ -90710,10 +90287,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3380243718883495404,
-      "Data2": -2168791195024069717,
-      "Data3": 3925054206692295087,
-      "Data4": -1004234974649139214
+      "Data1": 6961359062792180589,
+      "Data2": 887289389919780518,
+      "Data3": 7417196727397474939,
+      "Data4": 3632151009004203360
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointerdown",
@@ -90726,11 +90303,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerdown",
-            "DisplayName": "@onpointerdown",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerdown"
           }
         ]
       },
@@ -90738,11 +90312,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerdown:preventDefault",
-            "DisplayName": "@onpointerdown:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerdown:preventDefault"
           }
         ]
       },
@@ -90750,11 +90321,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerdown:stopPropagation",
-            "DisplayName": "@onpointerdown:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerdown:stopPropagation"
           }
         ]
       }
@@ -90798,10 +90366,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7417932853263868411,
-      "Data2": 2706070890709379533,
-      "Data3": -5315157247835577500,
-      "Data4": 2591120864616565474
+      "Data1": 2271762852946509955,
+      "Data2": 8868965747442749644,
+      "Data3": 3333627586632422982,
+      "Data4": -864989811049758065
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointerenter",
@@ -90814,11 +90382,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerenter",
-            "DisplayName": "@onpointerenter",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerenter"
           }
         ]
       },
@@ -90826,11 +90391,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerenter:preventDefault",
-            "DisplayName": "@onpointerenter:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerenter:preventDefault"
           }
         ]
       },
@@ -90838,11 +90400,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerenter:stopPropagation",
-            "DisplayName": "@onpointerenter:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerenter:stopPropagation"
           }
         ]
       }
@@ -90886,10 +90445,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -333723114949261493,
-      "Data2": 3543695049323708994,
-      "Data3": 2559258477814069936,
-      "Data4": -2480624330656796384
+      "Data1": 4525278349654272559,
+      "Data2": -781108744498027995,
+      "Data3": 4890903014078761832,
+      "Data4": 4319145635710665649
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointerleave",
@@ -90902,11 +90461,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerleave",
-            "DisplayName": "@onpointerleave",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerleave"
           }
         ]
       },
@@ -90914,11 +90470,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerleave:preventDefault",
-            "DisplayName": "@onpointerleave:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerleave:preventDefault"
           }
         ]
       },
@@ -90926,11 +90479,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerleave:stopPropagation",
-            "DisplayName": "@onpointerleave:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerleave:stopPropagation"
           }
         ]
       }
@@ -90974,10 +90524,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4023832108436348501,
-      "Data2": -9171003223585055075,
-      "Data3": -5677085818387497176,
-      "Data4": 6785605268949744772
+      "Data1": 6748211512188153299,
+      "Data2": 2479203546030481858,
+      "Data3": -1821306827220502515,
+      "Data4": 8858916709203681267
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointermove",
@@ -90990,11 +90540,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointermove",
-            "DisplayName": "@onpointermove",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointermove"
           }
         ]
       },
@@ -91002,11 +90549,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointermove:preventDefault",
-            "DisplayName": "@onpointermove:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointermove:preventDefault"
           }
         ]
       },
@@ -91014,11 +90558,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointermove:stopPropagation",
-            "DisplayName": "@onpointermove:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointermove:stopPropagation"
           }
         ]
       }
@@ -91062,10 +90603,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1524611642636099521,
-      "Data2": -2398126550182061268,
-      "Data3": -3412481245964591077,
-      "Data4": 4789876393151134327
+      "Data1": 2151021362520797123,
+      "Data2": -5470248169476953075,
+      "Data3": 2440603387062674927,
+      "Data4": -2837829498562806536
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointerout",
@@ -91078,11 +90619,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerout",
-            "DisplayName": "@onpointerout",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerout"
           }
         ]
       },
@@ -91090,11 +90628,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerout:preventDefault",
-            "DisplayName": "@onpointerout:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerout:preventDefault"
           }
         ]
       },
@@ -91102,11 +90637,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerout:stopPropagation",
-            "DisplayName": "@onpointerout:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerout:stopPropagation"
           }
         ]
       }
@@ -91150,10 +90682,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1764133925010105615,
-      "Data2": 6944910244968171030,
-      "Data3": 2174605378829256835,
-      "Data4": 3207961724796044038
+      "Data1": -3874250925012142179,
+      "Data2": 2510989066124218169,
+      "Data3": 341589637302050637,
+      "Data4": 5996268841956204085
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointerover",
@@ -91166,11 +90698,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerover",
-            "DisplayName": "@onpointerover",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerover"
           }
         ]
       },
@@ -91178,11 +90707,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerover:preventDefault",
-            "DisplayName": "@onpointerover:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerover:preventDefault"
           }
         ]
       },
@@ -91190,11 +90716,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerover:stopPropagation",
-            "DisplayName": "@onpointerover:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerover:stopPropagation"
           }
         ]
       }
@@ -91238,10 +90761,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6821842765712828994,
-      "Data2": -4226281608127149934,
-      "Data3": -7880739631936909349,
-      "Data4": -3414381712075622475
+      "Data1": 1378252240097838437,
+      "Data2": -1512932546539803412,
+      "Data3": -2115306387075290856,
+      "Data4": 7125140396992615176
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointerup",
@@ -91254,11 +90777,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerup",
-            "DisplayName": "@onpointerup",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerup"
           }
         ]
       },
@@ -91266,11 +90786,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerup:preventDefault",
-            "DisplayName": "@onpointerup:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerup:preventDefault"
           }
         ]
       },
@@ -91278,11 +90795,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerup:stopPropagation",
-            "DisplayName": "@onpointerup:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerup:stopPropagation"
           }
         ]
       }
@@ -91326,10 +90840,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3045675482182792335,
-      "Data2": -725540663764021536,
-      "Data3": 3223700190460777409,
-      "Data4": 5756747948724704098
+      "Data1": -8260041073641734934,
+      "Data2": -294667405860144779,
+      "Data3": -209468405781364588,
+      "Data4": -8104525392429366909
     },
     "Kind": "Components.EventHandler",
     "Name": "oncanplay",
@@ -91342,11 +90856,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncanplay",
-            "DisplayName": "@oncanplay",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncanplay"
           }
         ]
       },
@@ -91354,11 +90865,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncanplay:preventDefault",
-            "DisplayName": "@oncanplay:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncanplay:preventDefault"
           }
         ]
       },
@@ -91366,11 +90874,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncanplay:stopPropagation",
-            "DisplayName": "@oncanplay:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncanplay:stopPropagation"
           }
         ]
       }
@@ -91414,10 +90919,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8181871578001563542,
-      "Data2": 1826591734159521399,
-      "Data3": -7741062053213750151,
-      "Data4": -1182760005620748541
+      "Data1": 4290904363661871757,
+      "Data2": 1345430124738467351,
+      "Data3": 7002154865908275111,
+      "Data4": -4559670416636265447
     },
     "Kind": "Components.EventHandler",
     "Name": "oncanplaythrough",
@@ -91430,11 +90935,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncanplaythrough",
-            "DisplayName": "@oncanplaythrough",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncanplaythrough"
           }
         ]
       },
@@ -91442,11 +90944,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncanplaythrough:preventDefault",
-            "DisplayName": "@oncanplaythrough:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncanplaythrough:preventDefault"
           }
         ]
       },
@@ -91454,11 +90953,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncanplaythrough:stopPropagation",
-            "DisplayName": "@oncanplaythrough:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncanplaythrough:stopPropagation"
           }
         ]
       }
@@ -91502,10 +90998,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 9159762585728613292,
-      "Data2": -5294162403467913170,
-      "Data3": 117370183853211654,
-      "Data4": -8924594526036229719
+      "Data1": 7543751051414026403,
+      "Data2": -9152666124089815670,
+      "Data3": -952088963688732556,
+      "Data4": 6023892225275401435
     },
     "Kind": "Components.EventHandler",
     "Name": "oncuechange",
@@ -91518,11 +91014,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncuechange",
-            "DisplayName": "@oncuechange",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncuechange"
           }
         ]
       },
@@ -91530,11 +91023,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncuechange:preventDefault",
-            "DisplayName": "@oncuechange:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncuechange:preventDefault"
           }
         ]
       },
@@ -91542,11 +91032,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@oncuechange:stopPropagation",
-            "DisplayName": "@oncuechange:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@oncuechange:stopPropagation"
           }
         ]
       }
@@ -91590,10 +91077,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -108522022600757672,
-      "Data2": 9047895504911954075,
-      "Data3": -3004984778560594811,
-      "Data4": -5571308925317578885
+      "Data1": 6264360370123668986,
+      "Data2": 9063524324151804262,
+      "Data3": 1755980965823852412,
+      "Data4": -1137214979312487087
     },
     "Kind": "Components.EventHandler",
     "Name": "ondurationchange",
@@ -91606,11 +91093,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondurationchange",
-            "DisplayName": "@ondurationchange",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondurationchange"
           }
         ]
       },
@@ -91618,11 +91102,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondurationchange:preventDefault",
-            "DisplayName": "@ondurationchange:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondurationchange:preventDefault"
           }
         ]
       },
@@ -91630,11 +91111,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondurationchange:stopPropagation",
-            "DisplayName": "@ondurationchange:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondurationchange:stopPropagation"
           }
         ]
       }
@@ -91678,10 +91156,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3191109992566101821,
-      "Data2": -2150100297240648704,
-      "Data3": -2370124475409828591,
-      "Data4": 450566494004535118
+      "Data1": 1181914078137022515,
+      "Data2": -7546455771397473490,
+      "Data3": 5574291926130966959,
+      "Data4": 3290961761657689819
     },
     "Kind": "Components.EventHandler",
     "Name": "onemptied",
@@ -91694,11 +91172,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onemptied",
-            "DisplayName": "@onemptied",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onemptied"
           }
         ]
       },
@@ -91706,11 +91181,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onemptied:preventDefault",
-            "DisplayName": "@onemptied:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onemptied:preventDefault"
           }
         ]
       },
@@ -91718,11 +91190,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onemptied:stopPropagation",
-            "DisplayName": "@onemptied:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onemptied:stopPropagation"
           }
         ]
       }
@@ -91766,10 +91235,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5188873233715447148,
-      "Data2": -2916738815401707685,
-      "Data3": -8430613452444614561,
-      "Data4": 3867636067106960859
+      "Data1": 3775408422392823512,
+      "Data2": 1717633801580549820,
+      "Data3": -8969625943310753017,
+      "Data4": 6353073420256005378
     },
     "Kind": "Components.EventHandler",
     "Name": "onpause",
@@ -91782,11 +91251,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpause",
-            "DisplayName": "@onpause",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpause"
           }
         ]
       },
@@ -91794,11 +91260,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpause:preventDefault",
-            "DisplayName": "@onpause:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpause:preventDefault"
           }
         ]
       },
@@ -91806,11 +91269,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpause:stopPropagation",
-            "DisplayName": "@onpause:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpause:stopPropagation"
           }
         ]
       }
@@ -91854,10 +91314,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5632646633310707114,
-      "Data2": -2004270965309493673,
-      "Data3": -571071265288013124,
-      "Data4": -5387412698673117824
+      "Data1": -7209297431343268414,
+      "Data2": 3491012238669071995,
+      "Data3": 6073322436043951928,
+      "Data4": 5340074232033158455
     },
     "Kind": "Components.EventHandler",
     "Name": "onplay",
@@ -91870,11 +91330,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onplay",
-            "DisplayName": "@onplay",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onplay"
           }
         ]
       },
@@ -91882,11 +91339,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onplay:preventDefault",
-            "DisplayName": "@onplay:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onplay:preventDefault"
           }
         ]
       },
@@ -91894,11 +91348,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onplay:stopPropagation",
-            "DisplayName": "@onplay:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onplay:stopPropagation"
           }
         ]
       }
@@ -91942,10 +91393,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3214259889372672665,
-      "Data2": -3061681193101422080,
-      "Data3": -8978688402969784726,
-      "Data4": 1419243707579733380
+      "Data1": -629344481651276043,
+      "Data2": -40702626363362513,
+      "Data3": 7783417046433802467,
+      "Data4": 636549830744566175
     },
     "Kind": "Components.EventHandler",
     "Name": "onplaying",
@@ -91958,11 +91409,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onplaying",
-            "DisplayName": "@onplaying",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onplaying"
           }
         ]
       },
@@ -91970,11 +91418,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onplaying:preventDefault",
-            "DisplayName": "@onplaying:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onplaying:preventDefault"
           }
         ]
       },
@@ -91982,11 +91427,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onplaying:stopPropagation",
-            "DisplayName": "@onplaying:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onplaying:stopPropagation"
           }
         ]
       }
@@ -92030,10 +91472,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3639812202865148481,
-      "Data2": 3947735091716626460,
-      "Data3": 131467721672026646,
-      "Data4": 1971418622805578794
+      "Data1": 1095701433045224142,
+      "Data2": -6553853352830832538,
+      "Data3": -7514564064806075318,
+      "Data4": -4512211859556663598
     },
     "Kind": "Components.EventHandler",
     "Name": "onratechange",
@@ -92046,11 +91488,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onratechange",
-            "DisplayName": "@onratechange",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onratechange"
           }
         ]
       },
@@ -92058,11 +91497,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onratechange:preventDefault",
-            "DisplayName": "@onratechange:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onratechange:preventDefault"
           }
         ]
       },
@@ -92070,11 +91506,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onratechange:stopPropagation",
-            "DisplayName": "@onratechange:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onratechange:stopPropagation"
           }
         ]
       }
@@ -92118,10 +91551,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6711155897990438040,
-      "Data2": 215022787691042145,
-      "Data3": 2257511852376788561,
-      "Data4": 7219471230970482625
+      "Data1": 3280304169662241449,
+      "Data2": 6272508916125507170,
+      "Data3": -2025332510749240840,
+      "Data4": -5415047537943957353
     },
     "Kind": "Components.EventHandler",
     "Name": "onseeked",
@@ -92134,11 +91567,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onseeked",
-            "DisplayName": "@onseeked",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onseeked"
           }
         ]
       },
@@ -92146,11 +91576,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onseeked:preventDefault",
-            "DisplayName": "@onseeked:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onseeked:preventDefault"
           }
         ]
       },
@@ -92158,11 +91585,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onseeked:stopPropagation",
-            "DisplayName": "@onseeked:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onseeked:stopPropagation"
           }
         ]
       }
@@ -92206,10 +91630,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -975626354357934277,
-      "Data2": -569972674275297495,
-      "Data3": 321778095351961531,
-      "Data4": 5641105949806679865
+      "Data1": -1717013442610550914,
+      "Data2": -7220008896961012774,
+      "Data3": -8187564091397288987,
+      "Data4": 4399960034656044644
     },
     "Kind": "Components.EventHandler",
     "Name": "onseeking",
@@ -92222,11 +91646,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onseeking",
-            "DisplayName": "@onseeking",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onseeking"
           }
         ]
       },
@@ -92234,11 +91655,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onseeking:preventDefault",
-            "DisplayName": "@onseeking:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onseeking:preventDefault"
           }
         ]
       },
@@ -92246,11 +91664,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onseeking:stopPropagation",
-            "DisplayName": "@onseeking:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onseeking:stopPropagation"
           }
         ]
       }
@@ -92294,10 +91709,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8551069464608282310,
-      "Data2": -8500694245797738565,
-      "Data3": 5413174501748851231,
-      "Data4": 7189224547357492747
+      "Data1": -4415544583374122773,
+      "Data2": -5627106023633945885,
+      "Data3": 8187187790753091499,
+      "Data4": -1359304201784611591
     },
     "Kind": "Components.EventHandler",
     "Name": "onstalled",
@@ -92310,11 +91725,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onstalled",
-            "DisplayName": "@onstalled",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onstalled"
           }
         ]
       },
@@ -92322,11 +91734,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onstalled:preventDefault",
-            "DisplayName": "@onstalled:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onstalled:preventDefault"
           }
         ]
       },
@@ -92334,11 +91743,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onstalled:stopPropagation",
-            "DisplayName": "@onstalled:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onstalled:stopPropagation"
           }
         ]
       }
@@ -92382,10 +91788,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8716539324389457730,
-      "Data2": 7629560137093173667,
-      "Data3": -5550944271325497898,
-      "Data4": -4258854524093193287
+      "Data1": 8808473240433361910,
+      "Data2": -8428769458139738843,
+      "Data3": 7757791491203445578,
+      "Data4": 8829376748447716735
     },
     "Kind": "Components.EventHandler",
     "Name": "onstop",
@@ -92398,11 +91804,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onstop",
-            "DisplayName": "@onstop",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onstop"
           }
         ]
       },
@@ -92410,11 +91813,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onstop:preventDefault",
-            "DisplayName": "@onstop:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onstop:preventDefault"
           }
         ]
       },
@@ -92422,11 +91822,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onstop:stopPropagation",
-            "DisplayName": "@onstop:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onstop:stopPropagation"
           }
         ]
       }
@@ -92470,10 +91867,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3307635867151641382,
-      "Data2": 1458343531669023242,
-      "Data3": -7604178372814465197,
-      "Data4": -8140998636961015275
+      "Data1": 2057289458032219725,
+      "Data2": 6249469206151999849,
+      "Data3": 4958326515847316699,
+      "Data4": 2833183310713278232
     },
     "Kind": "Components.EventHandler",
     "Name": "onsuspend",
@@ -92486,11 +91883,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onsuspend",
-            "DisplayName": "@onsuspend",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onsuspend"
           }
         ]
       },
@@ -92498,11 +91892,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onsuspend:preventDefault",
-            "DisplayName": "@onsuspend:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onsuspend:preventDefault"
           }
         ]
       },
@@ -92510,11 +91901,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onsuspend:stopPropagation",
-            "DisplayName": "@onsuspend:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onsuspend:stopPropagation"
           }
         ]
       }
@@ -92558,10 +91946,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5048811429771847686,
-      "Data2": 8436008766937675051,
-      "Data3": 2741470638531184907,
-      "Data4": -6444455413975791743
+      "Data1": -4282911939848607837,
+      "Data2": 255848734636914833,
+      "Data3": -5585199373569447533,
+      "Data4": 4398185540551524187
     },
     "Kind": "Components.EventHandler",
     "Name": "ontimeupdate",
@@ -92574,11 +91962,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontimeupdate",
-            "DisplayName": "@ontimeupdate",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontimeupdate"
           }
         ]
       },
@@ -92586,11 +91971,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontimeupdate:preventDefault",
-            "DisplayName": "@ontimeupdate:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontimeupdate:preventDefault"
           }
         ]
       },
@@ -92598,11 +91980,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontimeupdate:stopPropagation",
-            "DisplayName": "@ontimeupdate:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontimeupdate:stopPropagation"
           }
         ]
       }
@@ -92646,10 +92025,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5075751616016691395,
-      "Data2": -696145718369758395,
-      "Data3": 7059609534261242701,
-      "Data4": -490082889918863415
+      "Data1": -8889969957557245199,
+      "Data2": -1943056048231894524,
+      "Data3": 1483715344232804200,
+      "Data4": 297939793638897926
     },
     "Kind": "Components.EventHandler",
     "Name": "onvolumechange",
@@ -92662,11 +92041,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onvolumechange",
-            "DisplayName": "@onvolumechange",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onvolumechange"
           }
         ]
       },
@@ -92674,11 +92050,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onvolumechange:preventDefault",
-            "DisplayName": "@onvolumechange:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onvolumechange:preventDefault"
           }
         ]
       },
@@ -92686,11 +92059,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onvolumechange:stopPropagation",
-            "DisplayName": "@onvolumechange:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onvolumechange:stopPropagation"
           }
         ]
       }
@@ -92734,10 +92104,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7501802294604400000,
-      "Data2": -3625965255803750327,
-      "Data3": 1955356598152086536,
-      "Data4": 8983246261357243991
+      "Data1": 4581595702791025700,
+      "Data2": -650682114577990029,
+      "Data3": -3865627577462973665,
+      "Data4": 8562140472411588463
     },
     "Kind": "Components.EventHandler",
     "Name": "onwaiting",
@@ -92750,11 +92120,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onwaiting",
-            "DisplayName": "@onwaiting",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onwaiting"
           }
         ]
       },
@@ -92762,11 +92129,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onwaiting:preventDefault",
-            "DisplayName": "@onwaiting:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onwaiting:preventDefault"
           }
         ]
       },
@@ -92774,11 +92138,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onwaiting:stopPropagation",
-            "DisplayName": "@onwaiting:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onwaiting:stopPropagation"
           }
         ]
       }
@@ -92822,10 +92183,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7113408823953894580,
-      "Data2": -3385708258257047081,
-      "Data3": -5438728720618580624,
-      "Data4": -6568127681695805667
+      "Data1": 3980214514767061114,
+      "Data2": 2243515913390830978,
+      "Data3": 4458473238126311588,
+      "Data4": -7339470207870831560
     },
     "Kind": "Components.EventHandler",
     "Name": "onloadstart",
@@ -92838,11 +92199,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onloadstart",
-            "DisplayName": "@onloadstart",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onloadstart"
           }
         ]
       },
@@ -92850,11 +92208,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onloadstart:preventDefault",
-            "DisplayName": "@onloadstart:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onloadstart:preventDefault"
           }
         ]
       },
@@ -92862,11 +92217,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onloadstart:stopPropagation",
-            "DisplayName": "@onloadstart:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onloadstart:stopPropagation"
           }
         ]
       }
@@ -92910,10 +92262,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6525671490676382978,
-      "Data2": 4959469022873450698,
-      "Data3": -1162444693447415375,
-      "Data4": 2208043797458242040
+      "Data1": -5865182083348506217,
+      "Data2": 3634282655884384359,
+      "Data3": 3214806312999511257,
+      "Data4": -821079391921647513
     },
     "Kind": "Components.EventHandler",
     "Name": "ontimeout",
@@ -92926,11 +92278,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontimeout",
-            "DisplayName": "@ontimeout",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontimeout"
           }
         ]
       },
@@ -92938,11 +92287,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontimeout:preventDefault",
-            "DisplayName": "@ontimeout:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontimeout:preventDefault"
           }
         ]
       },
@@ -92950,11 +92296,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ontimeout:stopPropagation",
-            "DisplayName": "@ontimeout:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ontimeout:stopPropagation"
           }
         ]
       }
@@ -92998,10 +92341,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4229633964217994761,
-      "Data2": -2102011116319524402,
-      "Data3": -7556529433972524194,
-      "Data4": -5730129678864355507
+      "Data1": 2348955648911991546,
+      "Data2": 725603513620474660,
+      "Data3": -3211121306667756378,
+      "Data4": 2695590376428241980
     },
     "Kind": "Components.EventHandler",
     "Name": "onabort",
@@ -93014,11 +92357,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onabort",
-            "DisplayName": "@onabort",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onabort"
           }
         ]
       },
@@ -93026,11 +92366,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onabort:preventDefault",
-            "DisplayName": "@onabort:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onabort:preventDefault"
           }
         ]
       },
@@ -93038,11 +92375,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onabort:stopPropagation",
-            "DisplayName": "@onabort:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onabort:stopPropagation"
           }
         ]
       }
@@ -93086,10 +92420,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -9136669357741163771,
-      "Data2": 1911760616512839850,
-      "Data3": 7639489310527466486,
-      "Data4": -6787772486476911278
+      "Data1": 1486759669914636421,
+      "Data2": -3947506843152610021,
+      "Data3": 7521579994329142729,
+      "Data4": -8562366023266027617
     },
     "Kind": "Components.EventHandler",
     "Name": "onload",
@@ -93102,11 +92436,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onload",
-            "DisplayName": "@onload",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onload"
           }
         ]
       },
@@ -93114,11 +92445,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onload:preventDefault",
-            "DisplayName": "@onload:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onload:preventDefault"
           }
         ]
       },
@@ -93126,11 +92454,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onload:stopPropagation",
-            "DisplayName": "@onload:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onload:stopPropagation"
           }
         ]
       }
@@ -93174,10 +92499,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6411781117233724008,
-      "Data2": 1745164093169778459,
-      "Data3": 2922041960191452140,
-      "Data4": 774141106560927744
+      "Data1": 2686149288436001173,
+      "Data2": -676207165301945104,
+      "Data3": -8461591743909102296,
+      "Data4": 6178271497188923148
     },
     "Kind": "Components.EventHandler",
     "Name": "onloadend",
@@ -93190,11 +92515,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onloadend",
-            "DisplayName": "@onloadend",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onloadend"
           }
         ]
       },
@@ -93202,11 +92524,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onloadend:preventDefault",
-            "DisplayName": "@onloadend:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onloadend:preventDefault"
           }
         ]
       },
@@ -93214,11 +92533,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onloadend:stopPropagation",
-            "DisplayName": "@onloadend:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onloadend:stopPropagation"
           }
         ]
       }
@@ -93262,10 +92578,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1843333705757442405,
-      "Data2": 7063607424992216512,
-      "Data3": -5153345452836997926,
-      "Data4": -9158592589777154168
+      "Data1": -5324602378579995255,
+      "Data2": 6705330812659754262,
+      "Data3": -6318567476072813326,
+      "Data4": -4183305671074986314
     },
     "Kind": "Components.EventHandler",
     "Name": "onprogress",
@@ -93278,11 +92594,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onprogress",
-            "DisplayName": "@onprogress",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onprogress"
           }
         ]
       },
@@ -93290,11 +92603,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onprogress:preventDefault",
-            "DisplayName": "@onprogress:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onprogress:preventDefault"
           }
         ]
       },
@@ -93302,11 +92612,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onprogress:stopPropagation",
-            "DisplayName": "@onprogress:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onprogress:stopPropagation"
           }
         ]
       }
@@ -93350,10 +92657,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5275261640806896168,
-      "Data2": -377935845478442165,
-      "Data3": 5493783007796022781,
-      "Data4": -8198217971144186335
+      "Data1": 909978281410813892,
+      "Data2": 1800729933633829952,
+      "Data3": -600849021074361626,
+      "Data4": -8612861771245901282
     },
     "Kind": "Components.EventHandler",
     "Name": "onerror",
@@ -93366,11 +92673,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onerror",
-            "DisplayName": "@onerror",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onerror"
           }
         ]
       },
@@ -93378,11 +92682,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onerror:preventDefault",
-            "DisplayName": "@onerror:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onerror:preventDefault"
           }
         ]
       },
@@ -93390,11 +92691,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onerror:stopPropagation",
-            "DisplayName": "@onerror:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onerror:stopPropagation"
           }
         ]
       }
@@ -93438,10 +92736,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1846646005057525569,
-      "Data2": 6275644902687431905,
-      "Data3": -6255807839277774010,
-      "Data4": -7267880071975957830
+      "Data1": -9044270163043636586,
+      "Data2": -8298714254590752676,
+      "Data3": 6655694295822881874,
+      "Data4": -8998817550465935945
     },
     "Kind": "Components.EventHandler",
     "Name": "onactivate",
@@ -93454,11 +92752,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onactivate",
-            "DisplayName": "@onactivate",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onactivate"
           }
         ]
       },
@@ -93466,11 +92761,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onactivate:preventDefault",
-            "DisplayName": "@onactivate:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onactivate:preventDefault"
           }
         ]
       },
@@ -93478,11 +92770,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onactivate:stopPropagation",
-            "DisplayName": "@onactivate:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onactivate:stopPropagation"
           }
         ]
       }
@@ -93526,10 +92815,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2956012460807405167,
-      "Data2": -867632241710283175,
-      "Data3": -7911062764280315214,
-      "Data4": -7635907033254784455
+      "Data1": 5888406946057722841,
+      "Data2": -1534901260819286013,
+      "Data3": -6515200492911463807,
+      "Data4": 8975772949582293713
     },
     "Kind": "Components.EventHandler",
     "Name": "onbeforeactivate",
@@ -93542,11 +92831,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforeactivate",
-            "DisplayName": "@onbeforeactivate",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforeactivate"
           }
         ]
       },
@@ -93554,11 +92840,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforeactivate:preventDefault",
-            "DisplayName": "@onbeforeactivate:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforeactivate:preventDefault"
           }
         ]
       },
@@ -93566,11 +92849,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforeactivate:stopPropagation",
-            "DisplayName": "@onbeforeactivate:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforeactivate:stopPropagation"
           }
         ]
       }
@@ -93614,10 +92894,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5083621222632223664,
-      "Data2": -7615134300952047659,
-      "Data3": 3118125487024459121,
-      "Data4": 8454652953177990210
+      "Data1": 987946789713027347,
+      "Data2": -1879655152655051619,
+      "Data3": 6791278948676281123,
+      "Data4": 4306558487341534460
     },
     "Kind": "Components.EventHandler",
     "Name": "onbeforedeactivate",
@@ -93630,11 +92910,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforedeactivate",
-            "DisplayName": "@onbeforedeactivate",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforedeactivate"
           }
         ]
       },
@@ -93642,11 +92919,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforedeactivate:preventDefault",
-            "DisplayName": "@onbeforedeactivate:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforedeactivate:preventDefault"
           }
         ]
       },
@@ -93654,11 +92928,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onbeforedeactivate:stopPropagation",
-            "DisplayName": "@onbeforedeactivate:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onbeforedeactivate:stopPropagation"
           }
         ]
       }
@@ -93702,10 +92973,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7416150203321873266,
-      "Data2": 67892427498583310,
-      "Data3": 5035973770082671911,
-      "Data4": 1963127784556408834
+      "Data1": -5707847885218347990,
+      "Data2": 5424293117279750457,
+      "Data3": 3991900742886809229,
+      "Data4": 4351394108349693748
     },
     "Kind": "Components.EventHandler",
     "Name": "ondeactivate",
@@ -93718,11 +92989,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondeactivate",
-            "DisplayName": "@ondeactivate",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondeactivate"
           }
         ]
       },
@@ -93730,11 +92998,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondeactivate:preventDefault",
-            "DisplayName": "@ondeactivate:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondeactivate:preventDefault"
           }
         ]
       },
@@ -93742,11 +93007,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ondeactivate:stopPropagation",
-            "DisplayName": "@ondeactivate:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ondeactivate:stopPropagation"
           }
         ]
       }
@@ -93790,10 +93052,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4466175333291326729,
-      "Data2": 30107574859259056,
-      "Data3": 5067616611279907721,
-      "Data4": -2877928629764916929
+      "Data1": 6621453353848538990,
+      "Data2": 4350040179192877970,
+      "Data3": 7143531768891706263,
+      "Data4": -8090716138721196357
     },
     "Kind": "Components.EventHandler",
     "Name": "onended",
@@ -93806,11 +93068,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onended",
-            "DisplayName": "@onended",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onended"
           }
         ]
       },
@@ -93818,11 +93077,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onended:preventDefault",
-            "DisplayName": "@onended:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onended:preventDefault"
           }
         ]
       },
@@ -93830,11 +93086,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onended:stopPropagation",
-            "DisplayName": "@onended:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onended:stopPropagation"
           }
         ]
       }
@@ -93878,10 +93131,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1266843671011692775,
-      "Data2": -3391806959723457162,
-      "Data3": 2181819476764076762,
-      "Data4": -2306895156544048475
+      "Data1": 465733623366170878,
+      "Data2": -7564827546670891112,
+      "Data3": -7065682818867595237,
+      "Data4": 6352481419083494233
     },
     "Kind": "Components.EventHandler",
     "Name": "onfullscreenchange",
@@ -93894,11 +93147,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfullscreenchange",
-            "DisplayName": "@onfullscreenchange",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfullscreenchange"
           }
         ]
       },
@@ -93906,11 +93156,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfullscreenchange:preventDefault",
-            "DisplayName": "@onfullscreenchange:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfullscreenchange:preventDefault"
           }
         ]
       },
@@ -93918,11 +93165,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfullscreenchange:stopPropagation",
-            "DisplayName": "@onfullscreenchange:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfullscreenchange:stopPropagation"
           }
         ]
       }
@@ -93966,10 +93210,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8170957982007637632,
-      "Data2": 5943610380447956352,
-      "Data3": -232353549138932172,
-      "Data4": 8280047298208669097
+      "Data1": 8562810089838353621,
+      "Data2": -2793411031902148629,
+      "Data3": -6011119835747201314,
+      "Data4": -4435797442328040551
     },
     "Kind": "Components.EventHandler",
     "Name": "onfullscreenerror",
@@ -93982,11 +93226,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfullscreenerror",
-            "DisplayName": "@onfullscreenerror",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfullscreenerror"
           }
         ]
       },
@@ -93994,11 +93235,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfullscreenerror:preventDefault",
-            "DisplayName": "@onfullscreenerror:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfullscreenerror:preventDefault"
           }
         ]
       },
@@ -94006,11 +93244,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onfullscreenerror:stopPropagation",
-            "DisplayName": "@onfullscreenerror:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onfullscreenerror:stopPropagation"
           }
         ]
       }
@@ -94054,10 +93289,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2411726684098353984,
-      "Data2": -5802683937521213950,
-      "Data3": 6681577910692585143,
-      "Data4": 6516554411453905049
+      "Data1": 2993018262050566706,
+      "Data2": 9216507064341109421,
+      "Data3": -9045167349075775933,
+      "Data4": 6178055263856195468
     },
     "Kind": "Components.EventHandler",
     "Name": "onloadeddata",
@@ -94070,11 +93305,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onloadeddata",
-            "DisplayName": "@onloadeddata",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onloadeddata"
           }
         ]
       },
@@ -94082,11 +93314,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onloadeddata:preventDefault",
-            "DisplayName": "@onloadeddata:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onloadeddata:preventDefault"
           }
         ]
       },
@@ -94094,11 +93323,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onloadeddata:stopPropagation",
-            "DisplayName": "@onloadeddata:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onloadeddata:stopPropagation"
           }
         ]
       }
@@ -94142,10 +93368,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8448109721034244687,
-      "Data2": 4444578012429726208,
-      "Data3": 8058087262888006228,
-      "Data4": 1976552233714212259
+      "Data1": -7540589892831033624,
+      "Data2": 3613730491659990079,
+      "Data3": 912493743935000084,
+      "Data4": 5658106705060292917
     },
     "Kind": "Components.EventHandler",
     "Name": "onloadedmetadata",
@@ -94158,11 +93384,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onloadedmetadata",
-            "DisplayName": "@onloadedmetadata",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onloadedmetadata"
           }
         ]
       },
@@ -94170,11 +93393,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onloadedmetadata:preventDefault",
-            "DisplayName": "@onloadedmetadata:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onloadedmetadata:preventDefault"
           }
         ]
       },
@@ -94182,11 +93402,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onloadedmetadata:stopPropagation",
-            "DisplayName": "@onloadedmetadata:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onloadedmetadata:stopPropagation"
           }
         ]
       }
@@ -94230,10 +93447,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6230632528394100134,
-      "Data2": 1170920812939276168,
-      "Data3": 3428782354199001685,
-      "Data4": -1419987850355237211
+      "Data1": 6164385248411789395,
+      "Data2": -4705259876411981767,
+      "Data3": -3218940979745862862,
+      "Data4": -5130024146790662927
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointerlockchange",
@@ -94246,11 +93463,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerlockchange",
-            "DisplayName": "@onpointerlockchange",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerlockchange"
           }
         ]
       },
@@ -94258,11 +93472,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerlockchange:preventDefault",
-            "DisplayName": "@onpointerlockchange:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerlockchange:preventDefault"
           }
         ]
       },
@@ -94270,11 +93481,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerlockchange:stopPropagation",
-            "DisplayName": "@onpointerlockchange:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerlockchange:stopPropagation"
           }
         ]
       }
@@ -94318,10 +93526,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2777171276892945364,
-      "Data2": -384516344680759605,
-      "Data3": -6150855174947008331,
-      "Data4": -4246826583726816297
+      "Data1": 2655957128589276390,
+      "Data2": 6257933090285204072,
+      "Data3": -7750136189117935660,
+      "Data4": 4362163153135747790
     },
     "Kind": "Components.EventHandler",
     "Name": "onpointerlockerror",
@@ -94334,11 +93542,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerlockerror",
-            "DisplayName": "@onpointerlockerror",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerlockerror"
           }
         ]
       },
@@ -94346,11 +93551,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerlockerror:preventDefault",
-            "DisplayName": "@onpointerlockerror:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerlockerror:preventDefault"
           }
         ]
       },
@@ -94358,11 +93560,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onpointerlockerror:stopPropagation",
-            "DisplayName": "@onpointerlockerror:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onpointerlockerror:stopPropagation"
           }
         ]
       }
@@ -94406,10 +93605,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1575694811182832560,
-      "Data2": -7224428055139297008,
-      "Data3": 7606797203832047597,
-      "Data4": 824304385385201893
+      "Data1": 1340601374870992934,
+      "Data2": -3832167052672631662,
+      "Data3": 3486664565999971780,
+      "Data4": 3673916919015974165
     },
     "Kind": "Components.EventHandler",
     "Name": "onreadystatechange",
@@ -94422,11 +93621,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onreadystatechange",
-            "DisplayName": "@onreadystatechange",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onreadystatechange"
           }
         ]
       },
@@ -94434,11 +93630,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onreadystatechange:preventDefault",
-            "DisplayName": "@onreadystatechange:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onreadystatechange:preventDefault"
           }
         ]
       },
@@ -94446,11 +93639,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onreadystatechange:stopPropagation",
-            "DisplayName": "@onreadystatechange:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onreadystatechange:stopPropagation"
           }
         ]
       }
@@ -94494,10 +93684,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2366130293720396115,
-      "Data2": -8252723281102890415,
-      "Data3": -6865574408519181629,
-      "Data4": -1510619801844755040
+      "Data1": 138629789394509226,
+      "Data2": 8016302583523110354,
+      "Data3": 8224060611621735234,
+      "Data4": 3066810312016396591
     },
     "Kind": "Components.EventHandler",
     "Name": "onscroll",
@@ -94510,11 +93700,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onscroll",
-            "DisplayName": "@onscroll",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onscroll"
           }
         ]
       },
@@ -94522,11 +93709,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onscroll:preventDefault",
-            "DisplayName": "@onscroll:preventDefault",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onscroll:preventDefault"
           }
         ]
       },
@@ -94534,11 +93718,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onscroll:stopPropagation",
-            "DisplayName": "@onscroll:stopPropagation",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onscroll:stopPropagation"
           }
         ]
       }
@@ -94582,10 +93763,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5993389800879145712,
-      "Data2": 5834515734619596998,
-      "Data3": 2657305727581892587,
-      "Data4": -4769569267241856083
+      "Data1": 7247741263354160503,
+      "Data2": 4720671046165353570,
+      "Data3": -2402170270981226514,
+      "Data4": 8970129175085517939
     },
     "Kind": "Components.EventHandler",
     "Name": "onmouseenter",
@@ -94598,11 +93779,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmouseenter",
-            "DisplayName": "@onmouseenter",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmouseenter"
           }
         ]
       }
@@ -94630,10 +93808,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8239440954120753986,
-      "Data2": 4640148002043779480,
-      "Data3": 4069768105312052748,
-      "Data4": -2179017817889547287
+      "Data1": 2817388861919955578,
+      "Data2": 4667005586359683336,
+      "Data3": 6794005843633459079,
+      "Data4": 197436121312809550
     },
     "Kind": "Components.EventHandler",
     "Name": "onmouseleave",
@@ -94646,11 +93824,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@onmouseleave",
-            "DisplayName": "@onmouseleave",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@onmouseleave"
           }
         ]
       }
@@ -94678,10 +93853,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 923436023436884338,
-      "Data2": -15661048818383111,
-      "Data3": -3474282340628342777,
-      "Data4": -3955611111301749709
+      "Data1": -8246431313350010060,
+      "Data2": -5455057936436703257,
+      "Data3": -4516441486039178212,
+      "Data4": 6568493400453096550
     },
     "Kind": "Components.Splat",
     "Name": "Attributes",
@@ -94694,11 +93869,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@attributes",
-            "DisplayName": "@attributes",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@attributes"
           }
         ]
       }
@@ -94724,10 +93896,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6634548886485764743,
-      "Data2": -6314050652644339988,
-      "Data3": 5716825358353758790,
-      "Data4": -8735672641186677000
+      "Data1": 8273543196571701486,
+      "Data2": 5284297992040348873,
+      "Data3": 8094084687435037067,
+      "Data4": -8874341107016353104
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.Razor.TagHelpers.UrlResolutionTagHelper",
@@ -94741,11 +93913,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "itemid",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "itemid"
+            "ValueComparison": 2
           }
         ]
       },
@@ -94754,11 +93925,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "href",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "href"
+            "ValueComparison": 2
           }
         ]
       },
@@ -94767,11 +93937,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "archive",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "archive"
+            "ValueComparison": 2
           }
         ]
       },
@@ -94781,11 +93950,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "href",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "href"
+            "ValueComparison": 2
           }
         ]
       },
@@ -94794,11 +93962,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "src",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "src"
+            "ValueComparison": 2
           }
         ]
       },
@@ -94808,11 +93975,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "href",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "href"
+            "ValueComparison": 2
           }
         ]
       },
@@ -94821,11 +93987,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "cite",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "cite"
+            "ValueComparison": 2
           }
         ]
       },
@@ -94834,11 +93999,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "formaction",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "formaction"
+            "ValueComparison": 2
           }
         ]
       },
@@ -94847,11 +94011,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "cite",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "cite"
+            "ValueComparison": 2
           }
         ]
       },
@@ -94861,11 +94024,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "src",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "src"
+            "ValueComparison": 2
           }
         ]
       },
@@ -94874,11 +94036,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "action",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "action"
+            "ValueComparison": 2
           }
         ]
       },
@@ -94887,11 +94048,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "manifest",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "manifest"
+            "ValueComparison": 2
           }
         ]
       },
@@ -94900,11 +94060,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "src",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "src"
+            "ValueComparison": 2
           }
         ]
       },
@@ -94914,11 +94073,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "src",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "src"
+            "ValueComparison": 2
           }
         ]
       },
@@ -94928,11 +94086,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "srcset",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "srcset"
+            "ValueComparison": 2
           }
         ]
       },
@@ -94942,11 +94099,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "formaction",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "formaction"
+            "ValueComparison": 2
           }
         ]
       },
@@ -94956,11 +94112,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "src",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "src"
+            "ValueComparison": 2
           }
         ]
       },
@@ -94969,11 +94124,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "cite",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "cite"
+            "ValueComparison": 2
           }
         ]
       },
@@ -94983,11 +94137,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "href",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "href"
+            "ValueComparison": 2
           }
         ]
       },
@@ -94996,11 +94149,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "icon",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "icon"
+            "ValueComparison": 2
           }
         ]
       },
@@ -95009,11 +94161,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "archive",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "archive"
+            "ValueComparison": 2
           }
         ]
       },
@@ -95022,11 +94173,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "data",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "data"
+            "ValueComparison": 2
           }
         ]
       },
@@ -95035,11 +94185,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "cite",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "cite"
+            "ValueComparison": 2
           }
         ]
       },
@@ -95048,11 +94197,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "src",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "src"
+            "ValueComparison": 2
           }
         ]
       },
@@ -95062,11 +94210,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "src",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "src"
+            "ValueComparison": 2
           }
         ]
       },
@@ -95076,11 +94223,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "srcset",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "srcset"
+            "ValueComparison": 2
           }
         ]
       },
@@ -95090,11 +94236,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "src",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "src"
+            "ValueComparison": 2
           }
         ]
       },
@@ -95103,11 +94248,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "poster",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "poster"
+            "ValueComparison": 2
           }
         ]
       },
@@ -95116,11 +94260,10 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "src",
-            "CaseSensitive": false,
             "Value": "~/",
-            "ValueComparison": 2,
-            "DisplayName": "src"
+            "ValueComparison": 2
           }
         ]
       }
@@ -95132,10 +94275,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3401007417382215071,
-      "Data2": 3994976025974855162,
-      "Data3": 8733459938308844951,
-      "Data4": 8017187981459554565
+      "Data1": -3028432690144074266,
+      "Data2": -5584829913745301182,
+      "Data3": -4605659362286003568,
+      "Data4": -4991205412453904591
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper",
@@ -95149,9 +94292,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-action",
-            "CaseSensitive": false,
-            "DisplayName": "asp-action"
+            "Flags": 0,
+            "Name": "asp-action"
           }
         ]
       },
@@ -95160,9 +94302,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-all-route-data",
-            "CaseSensitive": false,
-            "DisplayName": "asp-all-route-data"
+            "Flags": 0,
+            "Name": "asp-all-route-data"
           }
         ]
       },
@@ -95171,9 +94312,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-area",
-            "CaseSensitive": false,
-            "DisplayName": "asp-area"
+            "Flags": 0,
+            "Name": "asp-area"
           }
         ]
       },
@@ -95182,9 +94322,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-controller",
-            "CaseSensitive": false,
-            "DisplayName": "asp-controller"
+            "Flags": 0,
+            "Name": "asp-controller"
           }
         ]
       },
@@ -95193,9 +94332,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-fragment",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fragment"
+            "Flags": 0,
+            "Name": "asp-fragment"
           }
         ]
       },
@@ -95204,9 +94342,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-host",
-            "CaseSensitive": false,
-            "DisplayName": "asp-host"
+            "Flags": 0,
+            "Name": "asp-host"
           }
         ]
       },
@@ -95215,9 +94352,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-page",
-            "CaseSensitive": false,
-            "DisplayName": "asp-page"
+            "Flags": 0,
+            "Name": "asp-page"
           }
         ]
       },
@@ -95226,9 +94362,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-page-handler",
-            "CaseSensitive": false,
-            "DisplayName": "asp-page-handler"
+            "Flags": 0,
+            "Name": "asp-page-handler"
           }
         ]
       },
@@ -95237,9 +94372,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-protocol",
-            "CaseSensitive": false,
-            "DisplayName": "asp-protocol"
+            "Flags": 0,
+            "Name": "asp-protocol"
           }
         ]
       },
@@ -95248,9 +94382,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-route",
-            "CaseSensitive": false,
-            "DisplayName": "asp-route"
+            "Flags": 0,
+            "Name": "asp-route"
           }
         ]
       },
@@ -95259,10 +94392,9 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "asp-route-",
-            "NameComparison": 1,
-            "CaseSensitive": false,
-            "DisplayName": "asp-route-..."
+            "NameComparison": 1
           }
         ]
       }
@@ -95525,10 +94657,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8610839040851354787,
-      "Data2": -529247728727636645,
-      "Data3": 8057908682337726780,
-      "Data4": 7393168741089597603
+      "Data1": 2677216214688818353,
+      "Data2": -8695672458036964460,
+      "Data3": 1335249068616825640,
+      "Data4": 973360484576882157
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.ComponentTagHelper",
@@ -95543,9 +94675,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "type",
-            "CaseSensitive": false,
-            "DisplayName": "type"
+            "Flags": 0,
+            "Name": "type"
           }
         ]
       }
@@ -95593,10 +94724,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7205999463229047125,
-      "Data2": 412588967852933559,
-      "Data3": 4542519793789764487,
-      "Data4": -4752066987746613233
+      "Data1": 1828660180351055176,
+      "Data2": 6717211274143524898,
+      "Data3": 1166387702228253202,
+      "Data4": 3851030446920623567
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.DistributedCacheTagHelper",
@@ -95610,9 +94741,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "name",
-            "CaseSensitive": false,
-            "DisplayName": "name"
+            "Flags": 0,
+            "Name": "name"
           }
         ]
       }
@@ -95802,10 +94932,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3311371485669034703,
-      "Data2": 7597560590530922285,
-      "Data3": -4761355513676082886,
-      "Data4": -6874848816833411131
+      "Data1": 7644192896559199045,
+      "Data2": -3444139480479350904,
+      "Data3": 1858194957043714716,
+      "Data4": 4733167430055608050
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.FormActionTagHelper",
@@ -95819,9 +94949,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-action",
-            "CaseSensitive": false,
-            "DisplayName": "asp-action"
+            "Flags": 0,
+            "Name": "asp-action"
           }
         ]
       },
@@ -95830,9 +94959,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-all-route-data",
-            "CaseSensitive": false,
-            "DisplayName": "asp-all-route-data"
+            "Flags": 0,
+            "Name": "asp-all-route-data"
           }
         ]
       },
@@ -95841,9 +94969,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-area",
-            "CaseSensitive": false,
-            "DisplayName": "asp-area"
+            "Flags": 0,
+            "Name": "asp-area"
           }
         ]
       },
@@ -95852,9 +94979,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-controller",
-            "CaseSensitive": false,
-            "DisplayName": "asp-controller"
+            "Flags": 0,
+            "Name": "asp-controller"
           }
         ]
       },
@@ -95863,9 +94989,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-fragment",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fragment"
+            "Flags": 0,
+            "Name": "asp-fragment"
           }
         ]
       },
@@ -95874,9 +94999,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-page",
-            "CaseSensitive": false,
-            "DisplayName": "asp-page"
+            "Flags": 0,
+            "Name": "asp-page"
           }
         ]
       },
@@ -95885,9 +95009,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-page-handler",
-            "CaseSensitive": false,
-            "DisplayName": "asp-page-handler"
+            "Flags": 0,
+            "Name": "asp-page-handler"
           }
         ]
       },
@@ -95896,9 +95019,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-route",
-            "CaseSensitive": false,
-            "DisplayName": "asp-route"
+            "Flags": 0,
+            "Name": "asp-route"
           }
         ]
       },
@@ -95907,10 +95029,9 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "asp-route-",
-            "NameComparison": 1,
-            "CaseSensitive": false,
-            "DisplayName": "asp-route-..."
+            "NameComparison": 1
           }
         ]
       },
@@ -95920,16 +95041,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "image",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-action",
-            "CaseSensitive": false,
-            "DisplayName": "asp-action"
+            "Flags": 0,
+            "Name": "asp-action"
           }
         ]
       },
@@ -95939,16 +95058,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "image",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-all-route-data",
-            "CaseSensitive": false,
-            "DisplayName": "asp-all-route-data"
+            "Flags": 0,
+            "Name": "asp-all-route-data"
           }
         ]
       },
@@ -95958,16 +95075,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "image",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-area",
-            "CaseSensitive": false,
-            "DisplayName": "asp-area"
+            "Flags": 0,
+            "Name": "asp-area"
           }
         ]
       },
@@ -95977,16 +95092,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "image",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-controller",
-            "CaseSensitive": false,
-            "DisplayName": "asp-controller"
+            "Flags": 0,
+            "Name": "asp-controller"
           }
         ]
       },
@@ -95996,16 +95109,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "image",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-fragment",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fragment"
+            "Flags": 0,
+            "Name": "asp-fragment"
           }
         ]
       },
@@ -96015,16 +95126,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "image",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-page",
-            "CaseSensitive": false,
-            "DisplayName": "asp-page"
+            "Flags": 0,
+            "Name": "asp-page"
           }
         ]
       },
@@ -96034,16 +95143,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "image",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-page-handler",
-            "CaseSensitive": false,
-            "DisplayName": "asp-page-handler"
+            "Flags": 0,
+            "Name": "asp-page-handler"
           }
         ]
       },
@@ -96053,16 +95160,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "image",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-route",
-            "CaseSensitive": false,
-            "DisplayName": "asp-route"
+            "Flags": 0,
+            "Name": "asp-route"
           }
         ]
       },
@@ -96072,17 +95177,15 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "image",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
+            "Flags": 0,
             "Name": "asp-route-",
-            "NameComparison": 1,
-            "CaseSensitive": false,
-            "DisplayName": "asp-route-..."
+            "NameComparison": 1
           }
         ]
       },
@@ -96092,16 +95195,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "submit",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-action",
-            "CaseSensitive": false,
-            "DisplayName": "asp-action"
+            "Flags": 0,
+            "Name": "asp-action"
           }
         ]
       },
@@ -96111,16 +95212,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "submit",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-all-route-data",
-            "CaseSensitive": false,
-            "DisplayName": "asp-all-route-data"
+            "Flags": 0,
+            "Name": "asp-all-route-data"
           }
         ]
       },
@@ -96130,16 +95229,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "submit",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-area",
-            "CaseSensitive": false,
-            "DisplayName": "asp-area"
+            "Flags": 0,
+            "Name": "asp-area"
           }
         ]
       },
@@ -96149,16 +95246,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "submit",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-controller",
-            "CaseSensitive": false,
-            "DisplayName": "asp-controller"
+            "Flags": 0,
+            "Name": "asp-controller"
           }
         ]
       },
@@ -96168,16 +95263,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "submit",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-fragment",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fragment"
+            "Flags": 0,
+            "Name": "asp-fragment"
           }
         ]
       },
@@ -96187,16 +95280,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "submit",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-page",
-            "CaseSensitive": false,
-            "DisplayName": "asp-page"
+            "Flags": 0,
+            "Name": "asp-page"
           }
         ]
       },
@@ -96206,16 +95297,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "submit",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-page-handler",
-            "CaseSensitive": false,
-            "DisplayName": "asp-page-handler"
+            "Flags": 0,
+            "Name": "asp-page-handler"
           }
         ]
       },
@@ -96225,16 +95314,14 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "submit",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "asp-route",
-            "CaseSensitive": false,
-            "DisplayName": "asp-route"
+            "Flags": 0,
+            "Name": "asp-route"
           }
         ]
       },
@@ -96244,17 +95331,15 @@
         "CaseSensitive": false,
         "Attributes": [
           {
+            "Flags": 0,
             "Name": "type",
-            "CaseSensitive": false,
             "Value": "submit",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
+            "Flags": 0,
             "Name": "asp-route-",
-            "NameComparison": 1,
-            "CaseSensitive": false,
-            "DisplayName": "asp-route-..."
+            "NameComparison": 1
           }
         ]
       }
@@ -96470,10 +95555,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1368684189955224456,
-      "Data2": -7749377663892461632,
-      "Data3": -1914068815721383649,
-      "Data4": -8143266470844080531
+      "Data1": 6916255195576197099,
+      "Data2": 6268108396248310216,
+      "Data3": -2416224642721750921,
+      "Data4": -8893314079965855718
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.ImageTagHelper",
@@ -96488,14 +95573,12 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-append-version",
-            "CaseSensitive": false,
-            "DisplayName": "asp-append-version"
+            "Flags": 0,
+            "Name": "asp-append-version"
           },
           {
-            "Name": "src",
-            "CaseSensitive": false,
-            "DisplayName": "src"
+            "Flags": 0,
+            "Name": "src"
           }
         ]
       }
@@ -96529,10 +95612,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1235849669608033494,
-      "Data2": 1466871560702621492,
-      "Data3": 4953641463171939055,
-      "Data4": -6749455068881282620
+      "Data1": 9005900307624159588,
+      "Data2": -2735183725942169114,
+      "Data3": 4401101958641762959,
+      "Data4": 3501968986044160202
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.InputTagHelper",
@@ -96547,9 +95630,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-for",
-            "CaseSensitive": false,
-            "DisplayName": "asp-for"
+            "Flags": 0,
+            "Name": "asp-for"
           }
         ]
       }
@@ -96613,10 +95695,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6538284375358252268,
-      "Data2": 8438061150836934445,
-      "Data3": -8680525247321660295,
-      "Data4": 6796415605217361571
+      "Data1": 296546491246861290,
+      "Data2": 3236723824802718316,
+      "Data3": 50819776879331231,
+      "Data4": 9036890837213689614
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.LabelTagHelper",
@@ -96630,9 +95712,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-for",
-            "CaseSensitive": false,
-            "DisplayName": "asp-for"
+            "Flags": 0,
+            "Name": "asp-for"
           }
         ]
       }
@@ -96656,10 +95737,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 745085652259563621,
-      "Data2": -2777874212384575097,
-      "Data3": -883524181756505317,
-      "Data4": 312162584788245550
+      "Data1": -6673152175650978307,
+      "Data2": -1676434181512829524,
+      "Data3": 971307149407093340,
+      "Data4": -1133381657858560237
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.LinkTagHelper",
@@ -96674,9 +95755,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-append-version",
-            "CaseSensitive": false,
-            "DisplayName": "asp-append-version"
+            "Flags": 0,
+            "Name": "asp-append-version"
           }
         ]
       },
@@ -96686,9 +95766,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-fallback-href",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fallback-href"
+            "Flags": 0,
+            "Name": "asp-fallback-href"
           }
         ]
       },
@@ -96698,9 +95777,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-fallback-href-exclude",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fallback-href-exclude"
+            "Flags": 0,
+            "Name": "asp-fallback-href-exclude"
           }
         ]
       },
@@ -96710,9 +95788,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-fallback-href-include",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fallback-href-include"
+            "Flags": 0,
+            "Name": "asp-fallback-href-include"
           }
         ]
       },
@@ -96722,9 +95799,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-fallback-test-class",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fallback-test-class"
+            "Flags": 0,
+            "Name": "asp-fallback-test-class"
           }
         ]
       },
@@ -96734,9 +95810,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-fallback-test-property",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fallback-test-property"
+            "Flags": 0,
+            "Name": "asp-fallback-test-property"
           }
         ]
       },
@@ -96746,9 +95821,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-fallback-test-value",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fallback-test-value"
+            "Flags": 0,
+            "Name": "asp-fallback-test-value"
           }
         ]
       },
@@ -96758,9 +95832,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-href-exclude",
-            "CaseSensitive": false,
-            "DisplayName": "asp-href-exclude"
+            "Flags": 0,
+            "Name": "asp-href-exclude"
           }
         ]
       },
@@ -96770,9 +95843,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-href-include",
-            "CaseSensitive": false,
-            "DisplayName": "asp-href-include"
+            "Flags": 0,
+            "Name": "asp-href-include"
           }
         ]
       }
@@ -96932,10 +96004,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7705051720271077222,
-      "Data2": -1509544726016464331,
-      "Data3": 7688967061269244112,
-      "Data4": 5301684463322567450
+      "Data1": 7442654099134082651,
+      "Data2": 5256344479311990282,
+      "Data3": 1314417833631571320,
+      "Data4": 5909487337657985891
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.PartialTagHelper",
@@ -96950,9 +96022,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "name",
-            "CaseSensitive": false,
-            "DisplayName": "name"
+            "Flags": 0,
+            "Name": "name"
           }
         ]
       }
@@ -97029,10 +96100,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5746070205318587217,
-      "Data2": -1958061950908427902,
-      "Data3": -742283216396181103,
-      "Data4": 3924723174431879595
+      "Data1": -867129316472699364,
+      "Data2": 1815613493586644508,
+      "Data3": 753351451603996946,
+      "Data4": -6233675667416056546
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.ScriptTagHelper",
@@ -97046,9 +96117,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-append-version",
-            "CaseSensitive": false,
-            "DisplayName": "asp-append-version"
+            "Flags": 0,
+            "Name": "asp-append-version"
           }
         ]
       },
@@ -97057,9 +96127,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-fallback-src",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fallback-src"
+            "Flags": 0,
+            "Name": "asp-fallback-src"
           }
         ]
       },
@@ -97068,9 +96137,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-fallback-src-exclude",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fallback-src-exclude"
+            "Flags": 0,
+            "Name": "asp-fallback-src-exclude"
           }
         ]
       },
@@ -97079,9 +96147,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-fallback-src-include",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fallback-src-include"
+            "Flags": 0,
+            "Name": "asp-fallback-src-include"
           }
         ]
       },
@@ -97090,9 +96157,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-fallback-test",
-            "CaseSensitive": false,
-            "DisplayName": "asp-fallback-test"
+            "Flags": 0,
+            "Name": "asp-fallback-test"
           }
         ]
       },
@@ -97101,9 +96167,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-src-exclude",
-            "CaseSensitive": false,
-            "DisplayName": "asp-src-exclude"
+            "Flags": 0,
+            "Name": "asp-src-exclude"
           }
         ]
       },
@@ -97112,9 +96177,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-src-include",
-            "CaseSensitive": false,
-            "DisplayName": "asp-src-include"
+            "Flags": 0,
+            "Name": "asp-src-include"
           }
         ]
       }
@@ -97218,10 +96282,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2918756153368632534,
-      "Data2": 2416514903196142911,
-      "Data3": 1735699935565667267,
-      "Data4": 3806853094983987246
+      "Data1": 6992985371015868557,
+      "Data2": 8093084248386296535,
+      "Data3": 1849942869030771933,
+      "Data4": 7111286555726286151
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.SelectTagHelper",
@@ -97235,9 +96299,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-for",
-            "CaseSensitive": false,
-            "DisplayName": "asp-for"
+            "Flags": 0,
+            "Name": "asp-for"
           }
         ]
       },
@@ -97246,9 +96309,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-items",
-            "CaseSensitive": false,
-            "DisplayName": "asp-items"
+            "Flags": 0,
+            "Name": "asp-items"
           }
         ]
       }
@@ -97292,10 +96354,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2329055726928267273,
-      "Data2": -7276678818371123077,
-      "Data3": 3094794762176631209,
-      "Data4": 8542257215181973089
+      "Data1": 602078565260468686,
+      "Data2": 8356117054420901710,
+      "Data3": 5319862754751066939,
+      "Data4": -688417041075020653
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.TextAreaTagHelper",
@@ -97309,9 +96371,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-for",
-            "CaseSensitive": false,
-            "DisplayName": "asp-for"
+            "Flags": 0,
+            "Name": "asp-for"
           }
         ]
       }
@@ -97345,10 +96406,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4998969394918482688,
-      "Data2": -4656633363976093063,
-      "Data3": -4586947716904825396,
-      "Data4": -5278086349196303258
+      "Data1": 1077293800876120415,
+      "Data2": -9141664622132903352,
+      "Data3": -5876605421929920884,
+      "Data4": -1265124631376876249
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.ValidationMessageTagHelper",
@@ -97362,9 +96423,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-validation-for",
-            "CaseSensitive": false,
-            "DisplayName": "asp-validation-for"
+            "Flags": 0,
+            "Name": "asp-validation-for"
           }
         ]
       }
@@ -97388,10 +96448,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7618870538581331400,
-      "Data2": -3303868643332299111,
-      "Data3": 1793235052191874358,
-      "Data4": 3744091064291900686
+      "Data1": -2069294840032334643,
+      "Data2": 5832854995843420421,
+      "Data3": 4720756868462209588,
+      "Data4": 2286596565380066457
     },
     "Kind": "ITagHelper",
     "Name": "Microsoft.AspNetCore.Mvc.TagHelpers.ValidationSummaryTagHelper",
@@ -97405,9 +96465,8 @@
         "CaseSensitive": false,
         "Attributes": [
           {
-            "Name": "asp-validation-summary",
-            "CaseSensitive": false,
-            "DisplayName": "asp-validation-summary"
+            "Flags": 0,
+            "Name": "asp-validation-summary"
           }
         ]
       }
@@ -97432,10 +96491,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2030417771588122430,
-      "Data2": 4649382723659229669,
-      "Data3": -3918336093822036200,
-      "Data4": 4610720508231723798
+      "Data1": -2373768758067235415,
+      "Data2": 1549044327633911884,
+      "Data3": -251206385485219878,
+      "Data4": -3505083880262833245
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -97448,12 +96507,9 @@
         "TagName": "*",
         "Attributes": [
           {
+            "Flags": 3,
             "Name": "@bind-",
-            "NameComparison": 1,
-            "DisplayName": "@bind-...",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "NameComparison": 1
           }
         ]
       }
@@ -97506,10 +96562,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1210505036186437714,
-      "Data2": -7315522048179997119,
-      "Data3": 1349016996544024302,
-      "Data4": -8316633923907749017
+      "Data1": 2140558624128902003,
+      "Data2": 6476823194783638156,
+      "Data3": 6609456619221033680,
+      "Data4": -1099214012353018887
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -97522,11 +96578,8 @@
         "TagName": "input",
         "Attributes": [
           {
-            "Name": "@bind",
-            "DisplayName": "@bind",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind"
           }
         ]
       }
@@ -97588,10 +96641,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1212939845715174819,
-      "Data2": 5188116788817344827,
-      "Data3": 1349099396914319995,
-      "Data4": -4521890797742595647
+      "Data1": -9042773629527569529,
+      "Data2": 8250463513177597986,
+      "Data3": 2564904092834377550,
+      "Data4": 137897288476090472
     },
     "Kind": "Components.Bind",
     "Name": "Bind_value",
@@ -97604,11 +96657,8 @@
         "TagName": "input",
         "Attributes": [
           {
-            "Name": "@bind-value",
-            "DisplayName": "@bind-value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-value"
           }
         ]
       }
@@ -97670,10 +96720,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -362164550491707754,
-      "Data2": 2777284378238771303,
-      "Data3": -3366346204600779385,
-      "Data4": 8946851022927769159
+      "Data1": -4783100178047831605,
+      "Data2": 8792671172454143292,
+      "Data3": 7293971598166208668,
+      "Data4": -178753227669926297
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -97686,17 +96736,14 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "checkbox",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind",
-            "DisplayName": "@bind",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind"
           }
         ]
       }
@@ -97759,10 +96806,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 725320005321615146,
-      "Data2": 1012471518868282571,
-      "Data3": 8498256487955384749,
-      "Data4": -6688041426864399971
+      "Data1": -6674072809783652203,
+      "Data2": -603428492891478249,
+      "Data3": 8483821582309246258,
+      "Data4": 3569814610126236958
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -97775,17 +96822,14 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "text",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind",
-            "DisplayName": "@bind",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind"
           }
         ]
       }
@@ -97848,10 +96892,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8680527777266706299,
-      "Data2": 1613590494683319693,
-      "Data3": -8729265923934647707,
-      "Data4": 8887843060352388478
+      "Data1": 8721636397311084285,
+      "Data2": -2013613956433346112,
+      "Data3": -6877765528709310320,
+      "Data4": 1059151296954002944
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -97864,17 +96908,14 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "number",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind",
-            "DisplayName": "@bind",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind"
           }
         ]
       }
@@ -97937,10 +96978,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3951156008671269133,
-      "Data2": -7269429696171838567,
-      "Data3": -6304752799041863939,
-      "Data4": 5750399052233182741
+      "Data1": -4400217034632938528,
+      "Data2": 7204955826981875133,
+      "Data3": 2638694787246360618,
+      "Data4": 9133037267700204012
     },
     "Kind": "Components.Bind",
     "Name": "Bind_value",
@@ -97953,17 +96994,14 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "number",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind-value",
-            "DisplayName": "@bind-value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-value"
           }
         ]
       }
@@ -98026,10 +97064,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3671373402261864187,
-      "Data2": -3308318261959432649,
-      "Data3": 5889295602216036153,
-      "Data4": 4730920332648837364
+      "Data1": -1505455654814213346,
+      "Data2": 7014068525418383066,
+      "Data3": -2130874486139250788,
+      "Data4": 1609815335856694379
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -98042,17 +97080,14 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "date",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind",
-            "DisplayName": "@bind",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind"
           }
         ]
       }
@@ -98115,10 +97150,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8198063170761176694,
-      "Data2": 2413893409913277124,
-      "Data3": -2258257473200775021,
-      "Data4": -5434674989322277612
+      "Data1": 8053531539324643686,
+      "Data2": -3238321587615976967,
+      "Data3": 3751732287489154185,
+      "Data4": 5476036993977734088
     },
     "Kind": "Components.Bind",
     "Name": "Bind_value",
@@ -98131,17 +97166,14 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "date",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind-value",
-            "DisplayName": "@bind-value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-value"
           }
         ]
       }
@@ -98204,10 +97236,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1787641582166330324,
-      "Data2": 607267097139183868,
-      "Data3": 5685325688047013584,
-      "Data4": 7959914804303944348
+      "Data1": -6259905966658427582,
+      "Data2": -6575551984287168449,
+      "Data3": 8334298108223418501,
+      "Data4": 5379837840395453226
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -98220,17 +97252,14 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "datetime-local",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind",
-            "DisplayName": "@bind",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind"
           }
         ]
       }
@@ -98293,10 +97322,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 678783425702656105,
-      "Data2": 8306043116854060449,
-      "Data3": -262824979775104703,
-      "Data4": 8814715819587985538
+      "Data1": -6706016980882707400,
+      "Data2": -6192591583035853671,
+      "Data3": -6675028130912765259,
+      "Data4": 4302739247768921499
     },
     "Kind": "Components.Bind",
     "Name": "Bind_value",
@@ -98309,17 +97338,14 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "datetime-local",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind-value",
-            "DisplayName": "@bind-value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-value"
           }
         ]
       }
@@ -98382,10 +97408,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2340433969139716888,
-      "Data2": 8984810464205449649,
-      "Data3": -6846547194378684933,
-      "Data4": 5090566316611756723
+      "Data1": 223373491740589757,
+      "Data2": 7991391949880367816,
+      "Data3": 5265525755979756327,
+      "Data4": -7431492110821428143
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -98398,17 +97424,14 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "month",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind",
-            "DisplayName": "@bind",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind"
           }
         ]
       }
@@ -98471,10 +97494,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -145082677277093033,
-      "Data2": 1507680201851058644,
-      "Data3": 432970881947382418,
-      "Data4": -6701818064339445084
+      "Data1": 5103223740349480241,
+      "Data2": 1300701318660622931,
+      "Data3": 7129443797278526777,
+      "Data4": -8156572299503324862
     },
     "Kind": "Components.Bind",
     "Name": "Bind_value",
@@ -98487,17 +97510,14 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "month",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind-value",
-            "DisplayName": "@bind-value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-value"
           }
         ]
       }
@@ -98560,10 +97580,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3992603556555791750,
-      "Data2": 2227158943300699894,
-      "Data3": -3559342739536529791,
-      "Data4": -3316799628767781254
+      "Data1": -3019812307073224648,
+      "Data2": -4700517051480221810,
+      "Data3": 4824524015200002022,
+      "Data4": 2755275949186349287
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -98576,17 +97596,14 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "time",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind",
-            "DisplayName": "@bind",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind"
           }
         ]
       }
@@ -98649,10 +97666,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1441084740904999400,
-      "Data2": 4054802321038606973,
-      "Data3": -792948061075655411,
-      "Data4": -2122663307489725410
+      "Data1": 6350472875638632752,
+      "Data2": -5067870012712511595,
+      "Data3": -4570866653980018027,
+      "Data4": -5349824814064855373
     },
     "Kind": "Components.Bind",
     "Name": "Bind_value",
@@ -98665,17 +97682,14 @@
         "TagName": "input",
         "Attributes": [
           {
+            "Flags": 1,
             "Name": "type",
             "Value": "time",
-            "ValueComparison": 1,
-            "DisplayName": "type"
+            "ValueComparison": 1
           },
           {
-            "Name": "@bind-value",
-            "DisplayName": "@bind-value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-value"
           }
         ]
       }
@@ -98738,10 +97752,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6542143710754663069,
-      "Data2": 3180225049241576418,
-      "Data3": 7666372933947722198,
-      "Data4": 8593994182272536861
+      "Data1": -3427027175330610607,
+      "Data2": 4849580393854186677,
+      "Data3": -3336388771864994676,
+      "Data4": -5795450997658324566
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -98754,11 +97768,8 @@
         "TagName": "select",
         "Attributes": [
           {
-            "Name": "@bind",
-            "DisplayName": "@bind",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind"
           }
         ]
       }
@@ -98820,10 +97831,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 592080593764400075,
-      "Data2": -5297579682017099290,
-      "Data3": -203993226769686585,
-      "Data4": 5861745965761994617
+      "Data1": 2466774428295441462,
+      "Data2": 2708467187375299892,
+      "Data3": -8200191448421732664,
+      "Data4": -8417912490824530840
     },
     "Kind": "Components.Bind",
     "Name": "Bind",
@@ -98836,11 +97847,8 @@
         "TagName": "textarea",
         "Attributes": [
           {
-            "Name": "@bind",
-            "DisplayName": "@bind",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind"
           }
         ]
       }
@@ -98902,10 +97910,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2586497692928774176,
-      "Data2": 7044217066164686315,
-      "Data3": 5096742373643397608,
-      "Data4": 3883890764538110988
+      "Data1": -3624660984837161721,
+      "Data2": -8693707168431079889,
+      "Data3": 9043190741369748686,
+      "Data4": 2303255310638922283
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputCheckbox",
@@ -98918,11 +97926,8 @@
         "TagName": "InputCheckbox",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -98950,10 +97955,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3956378875473709405,
-      "Data2": -7997588426451174930,
-      "Data3": -5788754261934207894,
-      "Data4": -2701541698832825486
+      "Data1": -4822530954378979770,
+      "Data2": 4747385850364486370,
+      "Data3": -4762210118514747683,
+      "Data4": -4953309758906075084
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputCheckbox",
@@ -98966,11 +97971,8 @@
         "TagName": "Microsoft.AspNetCore.Components.Forms.InputCheckbox",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -98999,10 +98001,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4244679474258151225,
-      "Data2": -6105350733137009238,
-      "Data3": -8566718164009178995,
-      "Data4": 924897734365244601
+      "Data1": 8490936641422855306,
+      "Data2": 284241738209470322,
+      "Data3": -6706053247246662775,
+      "Data4": 3108221916887633802
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputDate<TValue>",
@@ -99015,11 +98017,8 @@
         "TagName": "InputDate",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -99047,10 +98046,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6151773199605888714,
-      "Data2": -7820191227607146395,
-      "Data3": 671125308703254719,
-      "Data4": -1546924389438059483
+      "Data1": -148293407737564300,
+      "Data2": 1933006499844654675,
+      "Data3": 7745134327342017315,
+      "Data4": -1205143929400242436
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputDate<TValue>",
@@ -99063,11 +98062,8 @@
         "TagName": "Microsoft.AspNetCore.Components.Forms.InputDate",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -99096,10 +98092,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6877518824495260655,
-      "Data2": -8890514409336891644,
-      "Data3": -1015941248813701755,
-      "Data4": 7184814391435326336
+      "Data1": -2201351611746382818,
+      "Data2": -1979480247687688439,
+      "Data3": -6192814325445349657,
+      "Data4": -2145306353565341147
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>",
@@ -99112,11 +98108,8 @@
         "TagName": "InputNumber",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -99144,10 +98137,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8251081822385771324,
-      "Data2": 7880448890060853580,
-      "Data3": 2550550520922899514,
-      "Data4": -6928475676545426908
+      "Data1": 7718778208097762338,
+      "Data2": -2131651480662777044,
+      "Data3": 2386525956897318737,
+      "Data4": 1572977447776320770
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>",
@@ -99160,11 +98153,8 @@
         "TagName": "Microsoft.AspNetCore.Components.Forms.InputNumber",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -99193,10 +98183,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6671780465570344366,
-      "Data2": -4555140608334520367,
-      "Data3": 2577397257393218629,
-      "Data4": 5496541031567226134
+      "Data1": 5787014579770809051,
+      "Data2": 3158206569626104103,
+      "Data3": 6107081178484068567,
+      "Data4": -1295541768508438363
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>",
@@ -99209,11 +98199,8 @@
         "TagName": "InputSelect",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -99241,10 +98228,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3406117664671933625,
-      "Data2": 870791611837482740,
-      "Data3": 8871520009717407917,
-      "Data4": -5878524076060766317
+      "Data1": 6700871296772289237,
+      "Data2": -6719315775751389948,
+      "Data3": 9078909673768625523,
+      "Data4": -4114788624010997789
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>",
@@ -99257,11 +98244,8 @@
         "TagName": "Microsoft.AspNetCore.Components.Forms.InputSelect",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -99290,10 +98274,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6018980053238185933,
-      "Data2": 889142435081147400,
-      "Data3": -4704626566970886974,
-      "Data4": -9159011662940391470
+      "Data1": -4007313290976091982,
+      "Data2": 3048324897335577438,
+      "Data3": -4484888589887923157,
+      "Data4": -5604845593193442785
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputText",
@@ -99306,11 +98290,8 @@
         "TagName": "InputText",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -99338,10 +98319,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1087492484222367606,
-      "Data2": 4609014784316697426,
-      "Data3": 7568300856460521881,
-      "Data4": -1636964325105931139
+      "Data1": 8503768142914185483,
+      "Data2": 9184628702813321878,
+      "Data3": 8915186090093404949,
+      "Data4": -3477922892482789239
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputText",
@@ -99354,11 +98335,8 @@
         "TagName": "Microsoft.AspNetCore.Components.Forms.InputText",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -99387,10 +98365,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 27699418998489637,
-      "Data2": -7944124830088635875,
-      "Data3": 7188950015329304507,
-      "Data4": -4095185021597451403
+      "Data1": 7085713007711323163,
+      "Data2": 4839311136465423158,
+      "Data3": 7132777542739889266,
+      "Data4": 7918034851000446857
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputTextArea",
@@ -99403,11 +98381,8 @@
         "TagName": "InputTextArea",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -99435,10 +98410,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6649004660313921112,
-      "Data2": 7527529413826081385,
-      "Data3": -1179052566128549785,
-      "Data4": 1017108375929562474
+      "Data1": -2528452097771222966,
+      "Data2": -6090728617288720118,
+      "Data3": 8023065170695991154,
+      "Data4": 6374262284195685173
     },
     "Kind": "Components.Bind",
     "Name": "Microsoft.AspNetCore.Components.Forms.InputTextArea",
@@ -99451,11 +98426,8 @@
         "TagName": "Microsoft.AspNetCore.Components.Forms.InputTextArea",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -99484,10 +98456,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1673400514582756700,
-      "Data2": 6753420819703321246,
-      "Data3": -833346199221834212,
-      "Data4": 2909169768601667317
+      "Data1": -2513852086610024004,
+      "Data2": 4964514032231261915,
+      "Data3": -5876767902672096511,
+      "Data4": 4910744516679456807
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikAutoComplete<TItem>",
@@ -99500,11 +98472,8 @@
         "TagName": "TelerikAutoComplete",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -99532,10 +98501,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1644942769427739622,
-      "Data2": 6859119589038982246,
-      "Data3": 7196449429951528397,
-      "Data4": -4011027239278967713
+      "Data1": 9089170224079383751,
+      "Data2": -1149054802365559047,
+      "Data3": -3371596977020868340,
+      "Data4": -2211342705888173904
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikAutoComplete<TItem>",
@@ -99548,11 +98517,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikAutoComplete",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -99581,10 +98547,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3220064616706841586,
-      "Data2": -6890588721300271363,
-      "Data3": -1120369950738757400,
-      "Data4": -3030159482549463644
+      "Data1": -25247965202482618,
+      "Data2": 7232915166638865184,
+      "Data3": 1765675543592636732,
+      "Data4": -5572883517110846624
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.ButtonGroupToggleButton",
@@ -99597,11 +98563,8 @@
         "TagName": "ButtonGroupToggleButton",
         "Attributes": [
           {
-            "Name": "@bind-Selected",
-            "DisplayName": "@bind-Selected",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Selected"
           }
         ]
       }
@@ -99628,10 +98591,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4707575790078997437,
-      "Data2": -8869710617548058493,
-      "Data3": -2255057197411859319,
-      "Data4": 2987810418591556748
+      "Data1": 1960135194951694402,
+      "Data2": 3601774066175672126,
+      "Data3": 3772078388405127714,
+      "Data4": 8823560366413745842
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.ButtonGroupToggleButton",
@@ -99644,11 +98607,8 @@
         "TagName": "Telerik.Blazor.Components.ButtonGroupToggleButton",
         "Attributes": [
           {
-            "Name": "@bind-Selected",
-            "DisplayName": "@bind-Selected",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Selected"
           }
         ]
       }
@@ -99676,10 +98636,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8519596000627030226,
-      "Data2": 1609884937692645076,
-      "Data3": -6335288424356412441,
-      "Data4": 2131333063161119157
+      "Data1": -3294100972140912525,
+      "Data2": -8251655914018633003,
+      "Data3": -3759684056504098169,
+      "Data4": 5781575373361656690
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikCalendar",
@@ -99692,11 +98652,8 @@
         "TagName": "TelerikCalendar",
         "Attributes": [
           {
-            "Name": "@bind-View",
-            "DisplayName": "@bind-View",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-View"
           }
         ]
       }
@@ -99724,10 +98681,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5662064228102349978,
-      "Data2": 8297061958244718085,
-      "Data3": -9184044474865181062,
-      "Data4": 8210809924220350058
+      "Data1": 6282025045678817184,
+      "Data2": -8864874794042267599,
+      "Data3": -2672342357965452559,
+      "Data4": 4274531652398883269
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikCalendar",
@@ -99740,11 +98697,8 @@
         "TagName": "TelerikCalendar",
         "Attributes": [
           {
-            "Name": "@bind-Date",
-            "DisplayName": "@bind-Date",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Date"
           }
         ]
       }
@@ -99771,10 +98725,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8220877905377003278,
-      "Data2": 6404810920968144211,
-      "Data3": -6734283481389661946,
-      "Data4": -6016823049232643663
+      "Data1": -7147647712769067697,
+      "Data2": 2997472832375835269,
+      "Data3": 8383678821027358631,
+      "Data4": 7124757525434815706
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikCalendar",
@@ -99787,11 +98741,8 @@
         "TagName": "TelerikCalendar",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -99818,10 +98769,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7949614571230129293,
-      "Data2": 4182091240115816134,
-      "Data3": 1178507659629231934,
-      "Data4": -4566887131766167702
+      "Data1": -3668949943276883529,
+      "Data2": 5745551295393355491,
+      "Data3": 6606224480374744353,
+      "Data4": -5475111108372219559
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikCalendar",
@@ -99834,11 +98785,8 @@
         "TagName": "TelerikCalendar",
         "Attributes": [
           {
-            "Name": "@bind-RangeStart",
-            "DisplayName": "@bind-RangeStart",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-RangeStart"
           }
         ]
       }
@@ -99865,10 +98813,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4181818209023833457,
-      "Data2": 4386283392148307487,
-      "Data3": -4743928378057573312,
-      "Data4": 5993625530982983193
+      "Data1": 516318009739355137,
+      "Data2": 4136156535651907933,
+      "Data3": 6073765334701298094,
+      "Data4": -3215226311854524412
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikCalendar",
@@ -99881,11 +98829,8 @@
         "TagName": "TelerikCalendar",
         "Attributes": [
           {
-            "Name": "@bind-RangeEnd",
-            "DisplayName": "@bind-RangeEnd",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-RangeEnd"
           }
         ]
       }
@@ -99912,10 +98857,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3433131828551636431,
-      "Data2": 4756004846410563826,
-      "Data3": -8254899916766613203,
-      "Data4": -5473813583281123994
+      "Data1": -7920450779708310451,
+      "Data2": 2514883439548286607,
+      "Data3": 434183398091648418,
+      "Data4": -8048657250601969404
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikCalendar",
@@ -99928,11 +98873,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikCalendar",
         "Attributes": [
           {
-            "Name": "@bind-View",
-            "DisplayName": "@bind-View",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-View"
           }
         ]
       }
@@ -99961,10 +98903,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5711387757446454489,
-      "Data2": -1578219976664520381,
-      "Data3": 781767906091119956,
-      "Data4": 8403726873030885317
+      "Data1": 8073326520717151105,
+      "Data2": 5273924464669300174,
+      "Data3": -528652498747765905,
+      "Data4": -6463434754845576045
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikCalendar",
@@ -99977,11 +98919,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikCalendar",
         "Attributes": [
           {
-            "Name": "@bind-Date",
-            "DisplayName": "@bind-Date",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Date"
           }
         ]
       }
@@ -100009,10 +98948,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1906749657796028975,
-      "Data2": -856621199399573742,
-      "Data3": -2389075316986726568,
-      "Data4": 3945861373076825057
+      "Data1": 919226436066941683,
+      "Data2": -9165265529490259623,
+      "Data3": 3307575991218534088,
+      "Data4": -3524972079110773227
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikCalendar",
@@ -100025,11 +98964,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikCalendar",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -100057,10 +98993,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 61256772719927560,
-      "Data2": 4322978815650555261,
-      "Data3": -205401397400573421,
-      "Data4": -8961929665888398554
+      "Data1": -2193777918635023706,
+      "Data2": 1174024566009082290,
+      "Data3": -5938225756722065355,
+      "Data4": -4703034441381018287
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikCalendar",
@@ -100073,11 +99009,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikCalendar",
         "Attributes": [
           {
-            "Name": "@bind-RangeStart",
-            "DisplayName": "@bind-RangeStart",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-RangeStart"
           }
         ]
       }
@@ -100105,10 +99038,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6524299002768185239,
-      "Data2": -1066403872647603310,
-      "Data3": -2896638228258036513,
-      "Data4": -4069081918819204801
+      "Data1": -47986714161834760,
+      "Data2": 4789436430321330242,
+      "Data3": -2691839022554217502,
+      "Data4": -2555881091102375578
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikCalendar",
@@ -100121,11 +99054,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikCalendar",
         "Attributes": [
           {
-            "Name": "@bind-RangeEnd",
-            "DisplayName": "@bind-RangeEnd",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-RangeEnd"
           }
         ]
       }
@@ -100153,10 +99083,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3349194336391206484,
-      "Data2": -7163663198492936945,
-      "Data3": 1710781698734280780,
-      "Data4": -7296688404060159188
+      "Data1": -5121874856720835411,
+      "Data2": -5805392911727040077,
+      "Data3": -4782913626792002919,
+      "Data4": -8362526725605948697
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikCheckBox<TValue>",
@@ -100169,11 +99099,8 @@
         "TagName": "TelerikCheckBox",
         "Attributes": [
           {
-            "Name": "@bind-Indeterminate",
-            "DisplayName": "@bind-Indeterminate",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Indeterminate"
           }
         ]
       }
@@ -100200,10 +99127,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2835930098288129579,
-      "Data2": 132097003324414322,
-      "Data3": 8573991900011675143,
-      "Data4": 7240654260070661228
+      "Data1": 3498562621330092988,
+      "Data2": -7575271544380215805,
+      "Data3": 670302693112571444,
+      "Data4": 5645002793327368733
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikCheckBox<TValue>",
@@ -100216,11 +99143,8 @@
         "TagName": "TelerikCheckBox",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -100248,10 +99172,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8578568672509075412,
-      "Data2": 7337619139142185589,
-      "Data3": -8860338271789125966,
-      "Data4": -8524379309522257853
+      "Data1": 8574083117123239695,
+      "Data2": 4228946930941324018,
+      "Data3": -4086357224199455330,
+      "Data4": 7510696906550820244
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikCheckBox<TValue>",
@@ -100264,11 +99188,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikCheckBox",
         "Attributes": [
           {
-            "Name": "@bind-Indeterminate",
-            "DisplayName": "@bind-Indeterminate",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Indeterminate"
           }
         ]
       }
@@ -100296,10 +99217,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8381340075201913224,
-      "Data2": -45470198046399903,
-      "Data3": 4955604183753640122,
-      "Data4": -1568954434402586237
+      "Data1": -1843071893964074159,
+      "Data2": -6559771974600384928,
+      "Data3": -8555925056329035685,
+      "Data4": 4686836548160314550
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikCheckBox<TValue>",
@@ -100312,11 +99233,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikCheckBox",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -100345,10 +99263,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1565190017955358655,
-      "Data2": 2352747119979301744,
-      "Data3": 4692928516718874351,
-      "Data4": -8590897704551784641
+      "Data1": -5809527788365290938,
+      "Data2": -3753728614635891200,
+      "Data3": -4192619310689142039,
+      "Data4": 827841544018858002
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikComboBox<TItem,TValue>",
@@ -100361,11 +99279,8 @@
         "TagName": "TelerikComboBox",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -100393,10 +99308,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2234612802854036494,
-      "Data2": -8998538612696112029,
-      "Data3": 1012312274777546482,
-      "Data4": -5293630618220392482
+      "Data1": -1729998224812059217,
+      "Data2": -7285469779804533577,
+      "Data3": -255713724919173352,
+      "Data4": -3573384264697629935
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikComboBox<TItem,TValue>",
@@ -100409,11 +99324,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikComboBox",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -100442,10 +99354,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6333051841906427047,
-      "Data2": -6623961685836437102,
-      "Data3": 1388104804069744691,
-      "Data4": -1607344372812307707
+      "Data1": -22690894223683686,
+      "Data2": 6076845706924657137,
+      "Data3": 3706572773745365952,
+      "Data4": 6106525375709499632
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikDateInput<T>",
@@ -100458,11 +99370,8 @@
         "TagName": "TelerikDateInput",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -100490,10 +99399,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6384268516214248539,
-      "Data2": 4743962670061450651,
-      "Data3": 6978609302905837556,
-      "Data4": 180770628699804766
+      "Data1": -5906916295561335919,
+      "Data2": -7175126395872440537,
+      "Data3": 9148785702183598619,
+      "Data4": 2684864731516152078
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikDateInput<T>",
@@ -100506,11 +99415,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikDateInput",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -100539,10 +99445,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2723475642229403808,
-      "Data2": 6341557343451355287,
-      "Data3": -2999375831887838696,
-      "Data4": -4390625515166144654
+      "Data1": 1517722309776717911,
+      "Data2": 7099017814996775891,
+      "Data3": 4131288468391389498,
+      "Data4": -8635116567321732003
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikDatePicker<T>",
@@ -100555,11 +99461,8 @@
         "TagName": "TelerikDatePicker",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -100587,10 +99490,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2178658677481238764,
-      "Data2": 5875403003829352175,
-      "Data3": -1480202935448772990,
-      "Data4": 2704406950256767863
+      "Data1": 2870373532248067156,
+      "Data2": 8563598157526695599,
+      "Data3": -3071920014483369920,
+      "Data4": 2406035108931597348
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikDatePicker<T>",
@@ -100603,11 +99506,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikDatePicker",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -100636,10 +99536,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6503074177207171729,
-      "Data2": -5254171977715164907,
-      "Data3": -1707309099911656731,
-      "Data4": -556794273310206686
+      "Data1": 8001400500300903851,
+      "Data2": -4058299933661501984,
+      "Data3": -3497236947252386229,
+      "Data4": 2229256494944995348
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikDateRangePicker<T>",
@@ -100652,11 +99552,8 @@
         "TagName": "TelerikDateRangePicker",
         "Attributes": [
           {
-            "Name": "@bind-StartValue",
-            "DisplayName": "@bind-StartValue",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-StartValue"
           }
         ]
       }
@@ -100684,10 +99581,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6270507049658686708,
-      "Data2": -6350230356478345203,
-      "Data3": 2050430916563380817,
-      "Data4": -6293653392778849521
+      "Data1": -3588849205858992861,
+      "Data2": -2624352548678523846,
+      "Data3": 5246077883079710408,
+      "Data4": -8111404326545572838
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikDateRangePicker<T>",
@@ -100700,11 +99597,8 @@
         "TagName": "TelerikDateRangePicker",
         "Attributes": [
           {
-            "Name": "@bind-EndValue",
-            "DisplayName": "@bind-EndValue",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-EndValue"
           }
         ]
       }
@@ -100732,10 +99626,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7057348476714675298,
-      "Data2": 1048709349992711594,
-      "Data3": 4426549540849486353,
-      "Data4": -3699786984213070828
+      "Data1": -5013175154460334686,
+      "Data2": 7257197218970028916,
+      "Data3": 3241509247734358588,
+      "Data4": -4956010677279770057
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikDateRangePicker<T>",
@@ -100748,11 +99642,8 @@
         "TagName": "TelerikDateRangePicker",
         "Attributes": [
           {
-            "Name": "@bind-View",
-            "DisplayName": "@bind-View",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-View"
           }
         ]
       }
@@ -100780,10 +99671,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1561111836725247577,
-      "Data2": 2804300749508359435,
-      "Data3": -446734289031139213,
-      "Data4": -5856575828498619842
+      "Data1": 5132160464542441495,
+      "Data2": 1751578927060795505,
+      "Data3": -76993576488747072,
+      "Data4": -7316662622142336251
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikDateRangePicker<T>",
@@ -100796,11 +99687,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikDateRangePicker",
         "Attributes": [
           {
-            "Name": "@bind-StartValue",
-            "DisplayName": "@bind-StartValue",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-StartValue"
           }
         ]
       }
@@ -100829,10 +99717,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6226421371492674532,
-      "Data2": -644306910166513220,
-      "Data3": -3500478350850374815,
-      "Data4": -4686046584464419751
+      "Data1": -5291816476884221126,
+      "Data2": -8786104235158531455,
+      "Data3": -3831393605654275778,
+      "Data4": 1537101836437885764
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikDateRangePicker<T>",
@@ -100845,11 +99733,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikDateRangePicker",
         "Attributes": [
           {
-            "Name": "@bind-EndValue",
-            "DisplayName": "@bind-EndValue",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-EndValue"
           }
         ]
       }
@@ -100878,10 +99763,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 539412864098754779,
-      "Data2": 3317657727408098170,
-      "Data3": 81224073252435343,
-      "Data4": -5075190280666688840
+      "Data1": -5129809074917105756,
+      "Data2": -6354390893082110183,
+      "Data3": 5706622052170064348,
+      "Data4": -6414570101703370470
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikDateRangePicker<T>",
@@ -100894,11 +99779,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikDateRangePicker",
         "Attributes": [
           {
-            "Name": "@bind-View",
-            "DisplayName": "@bind-View",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-View"
           }
         ]
       }
@@ -100927,10 +99809,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 759201629069936795,
-      "Data2": -7039490277506173287,
-      "Data3": 3374537100006895178,
-      "Data4": -1266201681977602794
+      "Data1": -1855177593637226749,
+      "Data2": -5526751053604567924,
+      "Data3": -371070730793828168,
+      "Data4": 2207816406654403693
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikDateTimePicker<T>",
@@ -100943,11 +99825,8 @@
         "TagName": "TelerikDateTimePicker",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -100975,10 +99854,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -609181740100971044,
-      "Data2": 4574778843052860982,
-      "Data3": 265674068438871,
-      "Data4": 7824045491851152744
+      "Data1": 7056663105244407202,
+      "Data2": -3302700198453121050,
+      "Data3": 4923694847807203123,
+      "Data4": 1962277946307255801
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikDateTimePicker<T>",
@@ -100991,11 +99870,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikDateTimePicker",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -101024,10 +99900,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7154665922341500094,
-      "Data2": -856602309330339449,
-      "Data3": 3722160305997300768,
-      "Data4": 5364070468646505592
+      "Data1": 918015907229259307,
+      "Data2": -7500692034376524695,
+      "Data3": 3356631508067687694,
+      "Data4": -267933212965909400
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikDrawer<TItem>",
@@ -101040,11 +99916,8 @@
         "TagName": "TelerikDrawer",
         "Attributes": [
           {
-            "Name": "@bind-Expanded",
-            "DisplayName": "@bind-Expanded",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Expanded"
           }
         ]
       }
@@ -101071,10 +99944,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7458603081940731528,
-      "Data2": -8083420691965330160,
-      "Data3": -619387511722314,
-      "Data4": -5588830436036030430
+      "Data1": -300874127424959623,
+      "Data2": 5534023236672376071,
+      "Data3": 829394627908443993,
+      "Data4": 1926369454585275458
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikDrawer<TItem>",
@@ -101087,11 +99960,8 @@
         "TagName": "TelerikDrawer",
         "Attributes": [
           {
-            "Name": "@bind-SelectedItem",
-            "DisplayName": "@bind-SelectedItem",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-SelectedItem"
           }
         ]
       }
@@ -101118,10 +99988,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2748095388892110733,
-      "Data2": -4871813970348020957,
-      "Data3": 5977065717396694775,
-      "Data4": -6408882702608124473
+      "Data1": 981357644350012032,
+      "Data2": 3847377568498259535,
+      "Data3": 5655795544519642054,
+      "Data4": -7929681127048591494
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikDrawer<TItem>",
@@ -101134,11 +100004,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikDrawer",
         "Attributes": [
           {
-            "Name": "@bind-Expanded",
-            "DisplayName": "@bind-Expanded",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Expanded"
           }
         ]
       }
@@ -101166,10 +100033,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6753683021345143496,
-      "Data2": 8215756572684589981,
-      "Data3": -8527998014785686112,
-      "Data4": -6995246107070901951
+      "Data1": -5297724283912778923,
+      "Data2": -7931003584329098838,
+      "Data3": 1333844957933270255,
+      "Data4": 5850763283841774533
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikDrawer<TItem>",
@@ -101182,11 +100049,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikDrawer",
         "Attributes": [
           {
-            "Name": "@bind-SelectedItem",
-            "DisplayName": "@bind-SelectedItem",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-SelectedItem"
           }
         ]
       }
@@ -101214,10 +100078,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3814994548035224692,
-      "Data2": 7328731093113497713,
-      "Data3": 8839347315750889639,
-      "Data4": 5434450556299486640
+      "Data1": -6793582589229474964,
+      "Data2": -6192175068679581512,
+      "Data3": -8354476267191529947,
+      "Data4": -5824779961824038018
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikDropDownList<TItem,TValue>",
@@ -101230,11 +100094,8 @@
         "TagName": "TelerikDropDownList",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -101262,10 +100123,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2941736717341054945,
-      "Data2": -1281750390876038397,
-      "Data3": -2105062559469474986,
-      "Data4": -3633788552733783452
+      "Data1": -4222855432575041362,
+      "Data2": 535569875516699339,
+      "Data3": 3977035204019289420,
+      "Data4": 8353754473362689826
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikDropDownList<TItem,TValue>",
@@ -101278,11 +100139,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikDropDownList",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -101311,10 +100169,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4250458864677788317,
-      "Data2": 4842911796044370936,
-      "Data3": 5301811123921983762,
-      "Data4": 78726396900845902
+      "Data1": -4819406389981202520,
+      "Data2": 6475516466162820043,
+      "Data3": -611349830230847947,
+      "Data4": -4594221324192790140
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikEditor",
@@ -101327,11 +100185,8 @@
         "TagName": "TelerikEditor",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -101359,10 +100214,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6493547556198601433,
-      "Data2": -430207616875587830,
-      "Data3": 6844663551250558897,
-      "Data4": 6525013728236890691
+      "Data1": -8319085415150827137,
+      "Data2": -6484748228950199600,
+      "Data3": 1764401333383603525,
+      "Data4": -4154254570886007157
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikEditor",
@@ -101375,11 +100230,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikEditor",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -101408,10 +100260,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6033447765255374586,
-      "Data2": 2681857109189825035,
-      "Data3": -3238790246398453167,
-      "Data4": 2799081507290993691
+      "Data1": 1872856750683547046,
+      "Data2": -8843915147596307807,
+      "Data3": -2786874921921074877,
+      "Data4": 3284078261739279630
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikGrid<TItem>",
@@ -101424,11 +100276,8 @@
         "TagName": "TelerikGrid",
         "Attributes": [
           {
-            "Name": "@bind-SelectedItems",
-            "DisplayName": "@bind-SelectedItems",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-SelectedItems"
           }
         ]
       }
@@ -101455,10 +100304,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 337751858465150433,
-      "Data2": 6393953102439883397,
-      "Data3": -7788026431412118039,
-      "Data4": 3922875043044706624
+      "Data1": -2983687944660639562,
+      "Data2": -6888082586891512696,
+      "Data3": -2744446039702389340,
+      "Data4": 5065747089811387543
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikGrid<TItem>",
@@ -101471,11 +100320,8 @@
         "TagName": "TelerikGrid",
         "Attributes": [
           {
-            "Name": "@bind-Page",
-            "DisplayName": "@bind-Page",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Page"
           }
         ]
       }
@@ -101502,10 +100348,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6284389247198706418,
-      "Data2": 2472612468159340203,
-      "Data3": 4097967203819353790,
-      "Data4": 7474096245964012202
+      "Data1": 2842249931897455359,
+      "Data2": 1366033126929546745,
+      "Data3": -4087180076807907166,
+      "Data4": 1923287541177098902
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikGrid<TItem>",
@@ -101518,11 +100364,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikGrid",
         "Attributes": [
           {
-            "Name": "@bind-SelectedItems",
-            "DisplayName": "@bind-SelectedItems",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-SelectedItems"
           }
         ]
       }
@@ -101550,10 +100393,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2744066102081013731,
-      "Data2": 3007580925135891318,
-      "Data3": -8028220488334281510,
-      "Data4": 9100002990360403981
+      "Data1": -3357296209676447555,
+      "Data2": 3723629270903697096,
+      "Data3": -6022175047238676237,
+      "Data4": 2517320735620192011
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikGrid<TItem>",
@@ -101566,11 +100409,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikGrid",
         "Attributes": [
           {
-            "Name": "@bind-Page",
-            "DisplayName": "@bind-Page",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Page"
           }
         ]
       }
@@ -101598,10 +100438,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3444993468109497917,
-      "Data2": 7215179460655213988,
-      "Data3": 1018642604635157127,
-      "Data4": -4832952997910843770
+      "Data1": -8106163930415670665,
+      "Data2": -4987153696865450268,
+      "Data3": 315274933401574489,
+      "Data4": -3584855223046169390
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikListView<TItem>",
@@ -101614,11 +100454,8 @@
         "TagName": "TelerikListView",
         "Attributes": [
           {
-            "Name": "@bind-Page",
-            "DisplayName": "@bind-Page",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Page"
           }
         ]
       }
@@ -101645,10 +100482,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8366359905629721034,
-      "Data2": 3999054184784192517,
-      "Data3": 5850500480334363973,
-      "Data4": -3882424926878466492
+      "Data1": -1974647167911401702,
+      "Data2": -1400618841265262585,
+      "Data3": -804905888785496411,
+      "Data4": -1739961284703519108
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikListView<TItem>",
@@ -101661,11 +100498,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikListView",
         "Attributes": [
           {
-            "Name": "@bind-Page",
-            "DisplayName": "@bind-Page",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Page"
           }
         ]
       }
@@ -101693,10 +100527,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1655833883442723181,
-      "Data2": 3766972149780080094,
-      "Data3": -8075908258564642610,
-      "Data4": 7853320612173235283
+      "Data1": 248976684257163677,
+      "Data2": 6789201008735650985,
+      "Data3": 3937360671992932601,
+      "Data4": -804332704264905626
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikMultiSelect<TItem,TValue>",
@@ -101709,11 +100543,8 @@
         "TagName": "TelerikMultiSelect",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -101741,10 +100572,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4840383074174160859,
-      "Data2": -4659285772586907981,
-      "Data3": -7229839631321745461,
-      "Data4": 8191775260101946594
+      "Data1": -6408834823159105633,
+      "Data2": -2708849253185232614,
+      "Data3": 1275598009953685230,
+      "Data4": 536956744400742997
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikMultiSelect<TItem,TValue>",
@@ -101757,11 +100588,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikMultiSelect",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -101790,10 +100618,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3974204942768645952,
-      "Data2": 3550584078894780573,
-      "Data3": -8438153865912723505,
-      "Data4": -753696249312689348
+      "Data1": -7509054783179357690,
+      "Data2": 6874492306361368036,
+      "Data3": -8587334273857615329,
+      "Data4": -9037808207567251866
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikNumericTextBox<T>",
@@ -101806,11 +100634,8 @@
         "TagName": "TelerikNumericTextBox",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -101838,10 +100663,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8232943385393175988,
-      "Data2": -255397909811333128,
-      "Data3": 379344373306886699,
-      "Data4": 474604329992478097
+      "Data1": -2165862692056006059,
+      "Data2": -5439387707844347710,
+      "Data3": 6645513730297629734,
+      "Data4": 6990700230553003162
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikNumericTextBox<T>",
@@ -101854,11 +100679,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikNumericTextBox",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -101887,10 +100709,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1159005246072768486,
-      "Data2": -2032073922554690459,
-      "Data3": 1255404010765943862,
-      "Data4": 2719412342956155554
+      "Data1": -8469129588066687212,
+      "Data2": -5580993234012793516,
+      "Data3": 492818169028383887,
+      "Data4": -6727928180602509618
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikPager",
@@ -101903,11 +100725,8 @@
         "TagName": "TelerikPager",
         "Attributes": [
           {
-            "Name": "@bind-Page",
-            "DisplayName": "@bind-Page",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Page"
           }
         ]
       }
@@ -101934,10 +100753,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8910930806742936099,
-      "Data2": -2025617166323767994,
-      "Data3": -7878586140263870637,
-      "Data4": -6484185715127730953
+      "Data1": 2393253480355395033,
+      "Data2": 123897938436876032,
+      "Data3": -8400814628537468999,
+      "Data4": 5632498275304100056
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikPager",
@@ -101950,11 +100769,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikPager",
         "Attributes": [
           {
-            "Name": "@bind-Page",
-            "DisplayName": "@bind-Page",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Page"
           }
         ]
       }
@@ -101982,10 +100798,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2703260863311243240,
-      "Data2": -1922195010555954614,
-      "Data3": -7158542143593652721,
-      "Data4": 4834900749018895856
+      "Data1": -3584196832105813295,
+      "Data2": 558012550027677670,
+      "Data3": -1348747708357388151,
+      "Data4": 5853846535579544473
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikScheduler<TItem>",
@@ -101998,11 +100814,8 @@
         "TagName": "TelerikScheduler",
         "Attributes": [
           {
-            "Name": "@bind-Date",
-            "DisplayName": "@bind-Date",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Date"
           }
         ]
       }
@@ -102029,10 +100842,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2973460897605333108,
-      "Data2": -7307626776916051673,
-      "Data3": -9155597478096917396,
-      "Data4": -5522740984080463567
+      "Data1": -7316266659964178813,
+      "Data2": 8115288971557051150,
+      "Data3": 2767697322990795852,
+      "Data4": -7426553789246598466
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikScheduler<TItem>",
@@ -102045,11 +100858,8 @@
         "TagName": "TelerikScheduler",
         "Attributes": [
           {
-            "Name": "@bind-View",
-            "DisplayName": "@bind-View",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-View"
           }
         ]
       }
@@ -102077,10 +100887,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3089660438600392799,
-      "Data2": 3979816240595929563,
-      "Data3": -3017348851053730854,
-      "Data4": -624466638686771491
+      "Data1": 7073797603160974553,
+      "Data2": 1963877154055139966,
+      "Data3": -3022948526368425295,
+      "Data4": -1457604540014935831
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikScheduler<TItem>",
@@ -102093,11 +100903,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikScheduler",
         "Attributes": [
           {
-            "Name": "@bind-Date",
-            "DisplayName": "@bind-Date",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Date"
           }
         ]
       }
@@ -102125,10 +100932,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7699396988084187840,
-      "Data2": 1240747730941071675,
-      "Data3": 4746591434825417038,
-      "Data4": 6749915979568927495
+      "Data1": -66114278878446621,
+      "Data2": 3796959611355434232,
+      "Data3": 3342231250125313424,
+      "Data4": -5203273903725519040
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikScheduler<TItem>",
@@ -102141,11 +100948,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikScheduler",
         "Attributes": [
           {
-            "Name": "@bind-View",
-            "DisplayName": "@bind-View",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-View"
           }
         ]
       }
@@ -102174,10 +100978,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4687582466137648668,
-      "Data2": -3005559901583085662,
-      "Data3": -7474652460798685783,
-      "Data4": 8064469786205129538
+      "Data1": -7396844530954653913,
+      "Data2": -303497457813073659,
+      "Data3": 6512855043112953010,
+      "Data4": 4686117649738121289
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikSwitch<TValue>",
@@ -102190,11 +100994,8 @@
         "TagName": "TelerikSwitch",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -102222,10 +101023,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6276924827359053288,
-      "Data2": -5291797200011625216,
-      "Data3": 6060410794683240193,
-      "Data4": -7487269854032144552
+      "Data1": 6306875154723216677,
+      "Data2": -8573307044066553859,
+      "Data3": -5820507391764976246,
+      "Data4": 2992143222598101177
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikSwitch<TValue>",
@@ -102238,11 +101039,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikSwitch",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -102271,10 +101069,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2972462727403686984,
-      "Data2": 3296488821540936956,
-      "Data3": 7932914994732922639,
-      "Data4": -2636962800831006877
+      "Data1": -7285904751714957974,
+      "Data2": -8321270439401428833,
+      "Data3": -5095694822216647422,
+      "Data4": 2199136087263090480
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikTabStrip",
@@ -102287,11 +101085,8 @@
         "TagName": "TelerikTabStrip",
         "Attributes": [
           {
-            "Name": "@bind-ActiveTabIndex",
-            "DisplayName": "@bind-ActiveTabIndex",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-ActiveTabIndex"
           }
         ]
       }
@@ -102318,10 +101113,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3842444110185372026,
-      "Data2": -4940464516905304886,
-      "Data3": -5713595048012636050,
-      "Data4": 2994248804491227468
+      "Data1": 4038240636823341691,
+      "Data2": -8468248371372996569,
+      "Data3": -2011504203976679283,
+      "Data4": 8149098527282230435
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikTabStrip",
@@ -102334,11 +101129,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikTabStrip",
         "Attributes": [
           {
-            "Name": "@bind-ActiveTabIndex",
-            "DisplayName": "@bind-ActiveTabIndex",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-ActiveTabIndex"
           }
         ]
       }
@@ -102366,10 +101158,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1315722791175176356,
-      "Data2": 5125259443567483881,
-      "Data3": -7689603703934186482,
-      "Data4": 8310178511300154867
+      "Data1": -6948931782231506623,
+      "Data2": -1486365715833860674,
+      "Data3": 20624417422771121,
+      "Data4": -3636073912579194189
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikTextBox",
@@ -102382,11 +101174,8 @@
         "TagName": "TelerikTextBox",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -102414,10 +101203,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6987195797996134498,
-      "Data2": 1503079787965187202,
-      "Data3": -5748442848800425155,
-      "Data4": -9178634645973889923
+      "Data1": -4711455052879565897,
+      "Data2": -5319809357026360889,
+      "Data3": -486039009221792745,
+      "Data4": -7543019846388991949
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikTextBox",
@@ -102430,11 +101219,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikTextBox",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -102463,10 +101249,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8286760167578847787,
-      "Data2": -81080907583172713,
-      "Data3": 1300490082512587389,
-      "Data4": -2275674798137302796
+      "Data1": -5614025678736348005,
+      "Data2": -3137026303550486105,
+      "Data3": -780696442428143259,
+      "Data4": 567925349561776072
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikTimePicker<T>",
@@ -102479,11 +101265,8 @@
         "TagName": "TelerikTimePicker",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -102511,10 +101294,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4823067930038485797,
-      "Data2": 7306489307910478821,
-      "Data3": 5982442283496712017,
-      "Data4": -494903501245176166
+      "Data1": 5458533994219912892,
+      "Data2": -1798867082461014199,
+      "Data3": 7906987031514551846,
+      "Data4": -1011777144079383531
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikTimePicker<T>",
@@ -102527,11 +101310,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikTimePicker",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -102560,10 +101340,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6517980560225582758,
-      "Data2": -4225495170069701428,
-      "Data3": 627761270120595127,
-      "Data4": 5253601593712523548
+      "Data1": 5770399279724418714,
+      "Data2": 4496407599500627150,
+      "Data3": 811294433913590036,
+      "Data4": 4694783247659870430
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikToggleButton",
@@ -102576,11 +101356,8 @@
         "TagName": "TelerikToggleButton",
         "Attributes": [
           {
-            "Name": "@bind-Selected",
-            "DisplayName": "@bind-Selected",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Selected"
           }
         ]
       }
@@ -102607,10 +101384,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8110872799375799508,
-      "Data2": -6859111258607987321,
-      "Data3": 706197707064694772,
-      "Data4": -4079323197997304139
+      "Data1": 2636851497778522106,
+      "Data2": 1589625701593620709,
+      "Data3": -4634653261765333066,
+      "Data4": -2665953580651218110
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikToggleButton",
@@ -102623,11 +101400,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikToggleButton",
         "Attributes": [
           {
-            "Name": "@bind-Selected",
-            "DisplayName": "@bind-Selected",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Selected"
           }
         ]
       }
@@ -102655,10 +101429,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7657239989202410177,
-      "Data2": -6646745453639145611,
-      "Data3": -3066047592475009493,
-      "Data4": 8756516881720405716
+      "Data1": -1594110339492459501,
+      "Data2": 7719248531267312758,
+      "Data3": -8241623558829573538,
+      "Data4": -2513590350544354143
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikTreeList<TItem>",
@@ -102671,11 +101445,8 @@
         "TagName": "TelerikTreeList",
         "Attributes": [
           {
-            "Name": "@bind-SelectedItems",
-            "DisplayName": "@bind-SelectedItems",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-SelectedItems"
           }
         ]
       }
@@ -102702,10 +101473,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -416203375169911491,
-      "Data2": 7981631231254960701,
-      "Data3": 2539352876826227071,
-      "Data4": 159262834268362389
+      "Data1": -171917315224266324,
+      "Data2": -7195442127266304009,
+      "Data3": 1703337927783903276,
+      "Data4": 5705244189200112979
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikTreeList<TItem>",
@@ -102718,11 +101489,8 @@
         "TagName": "TelerikTreeList",
         "Attributes": [
           {
-            "Name": "@bind-Page",
-            "DisplayName": "@bind-Page",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Page"
           }
         ]
       }
@@ -102749,10 +101517,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4776024781378142653,
-      "Data2": 525744746217976988,
-      "Data3": 5588541131157058607,
-      "Data4": 1032992211163951929
+      "Data1": -6660187913533043121,
+      "Data2": -46048105860237861,
+      "Data3": -4589891082099211826,
+      "Data4": 7788487018646008577
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikTreeList<TItem>",
@@ -102765,11 +101533,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikTreeList",
         "Attributes": [
           {
-            "Name": "@bind-SelectedItems",
-            "DisplayName": "@bind-SelectedItems",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-SelectedItems"
           }
         ]
       }
@@ -102797,10 +101562,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8426631804206765338,
-      "Data2": -2072666166936014362,
-      "Data3": 2237896081070355974,
-      "Data4": 3763181656581450173
+      "Data1": 9192438152629878069,
+      "Data2": -6514265278770041573,
+      "Data3": -7182783606367238774,
+      "Data4": -8914304987045672002
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikTreeList<TItem>",
@@ -102813,11 +101578,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikTreeList",
         "Attributes": [
           {
-            "Name": "@bind-Page",
-            "DisplayName": "@bind-Page",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Page"
           }
         ]
       }
@@ -102845,10 +101607,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5970486060101808140,
-      "Data2": 3376858286259051801,
-      "Data3": -8061549117957669662,
-      "Data4": -5367143959356587476
+      "Data1": 3716544560503955323,
+      "Data2": -1471105311464929650,
+      "Data3": -1190682993514486527,
+      "Data4": -8141492243704125485
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikTreeView",
@@ -102861,11 +101623,8 @@
         "TagName": "TelerikTreeView",
         "Attributes": [
           {
-            "Name": "@bind-SelectedItems",
-            "DisplayName": "@bind-SelectedItems",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-SelectedItems"
           }
         ]
       }
@@ -102892,10 +101651,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8107061166456807561,
-      "Data2": -7424194028325530369,
-      "Data3": -8119375345241917646,
-      "Data4": -3380581441702793082
+      "Data1": 5395008143191169695,
+      "Data2": 3467286025245368254,
+      "Data3": 6517052994308190616,
+      "Data4": -2410454306005550935
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikTreeView",
@@ -102908,11 +101667,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikTreeView",
         "Attributes": [
           {
-            "Name": "@bind-SelectedItems",
-            "DisplayName": "@bind-SelectedItems",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-SelectedItems"
           }
         ]
       }
@@ -102940,10 +101696,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4944237730257341955,
-      "Data2": -4318999075549466458,
-      "Data3": -8112228430555133681,
-      "Data4": -8051404681421885353
+      "Data1": -808872613024861542,
+      "Data2": 3500191103347713114,
+      "Data3": -4353616937535779867,
+      "Data4": -781499419030214530
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikWindow",
@@ -102956,11 +101712,8 @@
         "TagName": "TelerikWindow",
         "Attributes": [
           {
-            "Name": "@bind-Visible",
-            "DisplayName": "@bind-Visible",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Visible"
           }
         ]
       }
@@ -102987,10 +101740,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 861786897781775765,
-      "Data2": 2512485041059768194,
-      "Data3": -8638448754840733773,
-      "Data4": 7792590876073072541
+      "Data1": -7013214328369193503,
+      "Data2": -3376038957542975136,
+      "Data3": -3830364925366583576,
+      "Data4": -2959458023883189033
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikWindow",
@@ -103003,11 +101756,8 @@
         "TagName": "TelerikWindow",
         "Attributes": [
           {
-            "Name": "@bind-State",
-            "DisplayName": "@bind-State",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-State"
           }
         ]
       }
@@ -103035,10 +101785,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7329396434751865441,
-      "Data2": 4932119937045496296,
-      "Data3": 7727938110557696302,
-      "Data4": 5730351447024960836
+      "Data1": 6399449927147682063,
+      "Data2": -6427608806549188898,
+      "Data3": 6123061411146061352,
+      "Data4": -6194478353383869662
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikWindow",
@@ -103051,11 +101801,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikWindow",
         "Attributes": [
           {
-            "Name": "@bind-Visible",
-            "DisplayName": "@bind-Visible",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Visible"
           }
         ]
       }
@@ -103083,10 +101830,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 118450530304971485,
-      "Data2": -4577255784155847775,
-      "Data3": -4341840177190174557,
-      "Data4": -3575222024448580945
+      "Data1": 7822489021902908585,
+      "Data2": -5229379511354033943,
+      "Data3": 1009559579707373581,
+      "Data4": 4635466842676652596
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TelerikWindow",
@@ -103099,11 +101846,8 @@
         "TagName": "Telerik.Blazor.Components.TelerikWindow",
         "Attributes": [
           {
-            "Name": "@bind-State",
-            "DisplayName": "@bind-State",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-State"
           }
         ]
       }
@@ -103132,10 +101876,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6383339529595563299,
-      "Data2": 2702612152017647284,
-      "Data3": 2065885769070480204,
-      "Data4": -107446552740440701
+      "Data1": 3383428986538968648,
+      "Data2": -6684995515849173036,
+      "Data3": -1517854302029393487,
+      "Data4": -2463943675843834447
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.TelerikInputBase<T>",
@@ -103148,11 +101892,8 @@
         "TagName": "TelerikInputBase",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -103180,10 +101921,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8125693921081823743,
-      "Data2": -623163287988246369,
-      "Data3": 4946556853966410580,
-      "Data4": 2949981316559260557
+      "Data1": -5919616662450980722,
+      "Data2": -2239580385900978896,
+      "Data3": -6761809797985680486,
+      "Data4": -7301385383681228210
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.TelerikInputBase<T>",
@@ -103196,11 +101937,8 @@
         "TagName": "Telerik.Blazor.Components.Common.TelerikInputBase",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -103229,10 +101967,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8439176994925728571,
-      "Data2": 1686964211012570069,
-      "Data3": 5514270816175353344,
-      "Data4": -6102980375316613828
+      "Data1": 3311132404976729607,
+      "Data2": 8540463057303349795,
+      "Data3": 8099494875223853349,
+      "Data4": -5481402641732276875
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.ColumnMenu.ColumnMenu",
@@ -103245,11 +101983,8 @@
         "TagName": "ColumnMenu",
         "Attributes": [
           {
-            "Name": "@bind-FilterDescriptor",
-            "DisplayName": "@bind-FilterDescriptor",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-FilterDescriptor"
           }
         ]
       }
@@ -103276,10 +102011,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8114338428996945542,
-      "Data2": -5747433888958569734,
-      "Data3": 3092796871311789224,
-      "Data4": 5699376071697535781
+      "Data1": -7802356199600866963,
+      "Data2": 7128678614500088938,
+      "Data3": -1028362963700629471,
+      "Data4": 7387101293112362818
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.ColumnMenu.ColumnMenu",
@@ -103292,11 +102027,8 @@
         "TagName": "Telerik.Blazor.Components.Common.ColumnMenu.ColumnMenu",
         "Attributes": [
           {
-            "Name": "@bind-FilterDescriptor",
-            "DisplayName": "@bind-FilterDescriptor",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-FilterDescriptor"
           }
         ]
       }
@@ -103324,10 +102056,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6069610168999565513,
-      "Data2": -4894928364576265615,
-      "Data3": -2968735635829428073,
-      "Data4": -5724410661075232620
+      "Data1": 1312240497556965302,
+      "Data2": -1758586842853273832,
+      "Data3": 6212381867365794806,
+      "Data4": -2085247360972911860
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.ColumnMenu.ColumnMenuFilter",
@@ -103340,11 +102072,8 @@
         "TagName": "ColumnMenuFilter",
         "Attributes": [
           {
-            "Name": "@bind-FilterDescriptor",
-            "DisplayName": "@bind-FilterDescriptor",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-FilterDescriptor"
           }
         ]
       }
@@ -103371,10 +102100,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6011058249173039097,
-      "Data2": 2000607393266348619,
-      "Data3": 1828175754051942736,
-      "Data4": -2860419772358621038
+      "Data1": 100477968504305938,
+      "Data2": -9179074836310616785,
+      "Data3": 2746683008290127528,
+      "Data4": -3180840988253058029
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.ColumnMenu.ColumnMenuFilter",
@@ -103387,11 +102116,8 @@
         "TagName": "Telerik.Blazor.Components.Common.ColumnMenu.ColumnMenuFilter",
         "Attributes": [
           {
-            "Name": "@bind-FilterDescriptor",
-            "DisplayName": "@bind-FilterDescriptor",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-FilterDescriptor"
           }
         ]
       }
@@ -103419,10 +102145,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7751762364107706674,
-      "Data2": 7962414296355402151,
-      "Data3": -566473488523864272,
-      "Data4": 1414713144435631634
+      "Data1": -6013253844149666386,
+      "Data2": -7756071235334379766,
+      "Data3": 3855447714442600347,
+      "Data4": -8518253655811779868
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikBooleanEditorBase",
@@ -103435,11 +102161,8 @@
         "TagName": "TelerikBooleanEditorBase",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -103466,10 +102189,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2302152902672176239,
-      "Data2": 4180842152767587448,
-      "Data3": -8350583839361376768,
-      "Data4": 4028685461082379934
+      "Data1": -2364880908831410995,
+      "Data2": -4810365681906731987,
+      "Data3": -5462217932568631250,
+      "Data4": -2817601475273102872
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikBooleanEditorBase",
@@ -103482,11 +102205,8 @@
         "TagName": "Telerik.Blazor.Components.Common.Editors.TelerikBooleanEditorBase",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -103514,10 +102234,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2602138756234264474,
-      "Data2": -5746340050516322417,
-      "Data3": -7890009809783355516,
-      "Data4": 4990440970465334637
+      "Data1": 3119104178583747706,
+      "Data2": 6827382255132834285,
+      "Data3": -6102177090764420122,
+      "Data4": 1782282763265494008
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikEditorBase<T>",
@@ -103530,11 +102250,8 @@
         "TagName": "TelerikEditorBase",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -103561,10 +102278,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1888728862627370713,
-      "Data2": 4736913448720236075,
-      "Data3": -3808486026645029882,
-      "Data4": 4876131075221341135
+      "Data1": 5950178360891887968,
+      "Data2": -5932229958438340282,
+      "Data3": 5739508430095499028,
+      "Data4": 1185077223430766460
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikEditorBase<T>",
@@ -103577,11 +102294,8 @@
         "TagName": "Telerik.Blazor.Components.Common.Editors.TelerikEditorBase",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -103609,10 +102323,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3261254925014563743,
-      "Data2": 8773865941716103385,
-      "Data3": 5741486996495818366,
-      "Data4": -2584665880572457733
+      "Data1": 1354238561620852904,
+      "Data2": -6628676383338231443,
+      "Data3": -6729987227493960239,
+      "Data4": 2177601211130103344
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikEnumEditor",
@@ -103625,11 +102339,8 @@
         "TagName": "TelerikEnumEditor",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -103656,10 +102367,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8181536723460728197,
-      "Data2": 4029853623348574221,
-      "Data3": -3032237436386274773,
-      "Data4": -2326498138996313615
+      "Data1": -8349239283743139871,
+      "Data2": -513764907099155340,
+      "Data3": -5656444825604847114,
+      "Data4": -8492314241185960952
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikEnumEditor",
@@ -103672,11 +102383,8 @@
         "TagName": "Telerik.Blazor.Components.Common.Editors.TelerikEnumEditor",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -103704,10 +102412,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3193187044699400574,
-      "Data2": 8347909203223494145,
-      "Data3": 6434762104827773575,
-      "Data4": -5488829890978769074
+      "Data1": -2771016239499808987,
+      "Data2": 5619654146967763688,
+      "Data3": -7044647890886467296,
+      "Data4": 8874774955761115464
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikBooleanCheckBox",
@@ -103720,11 +102428,8 @@
         "TagName": "TelerikBooleanCheckBox",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -103751,10 +102456,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3836046362253652689,
-      "Data2": 653351141203760852,
-      "Data3": -6297152101362022733,
-      "Data4": 1625899496083470402
+      "Data1": 6851927041498119420,
+      "Data2": 8144894781569433563,
+      "Data3": 5190622554655066634,
+      "Data4": -2028546625437444751
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikBooleanCheckBox",
@@ -103767,11 +102472,8 @@
         "TagName": "Telerik.Blazor.Components.Common.Editors.TelerikBooleanCheckBox",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -103799,10 +102501,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7754198207348284178,
-      "Data2": -8695223233811161628,
-      "Data3": 3416696673733053721,
-      "Data4": 4416155194779899822
+      "Data1": 7919896382395311901,
+      "Data2": -8140805733449145286,
+      "Data3": -4157191244930852078,
+      "Data4": 856640903998752710
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikBooleanDropDownList",
@@ -103815,11 +102517,8 @@
         "TagName": "TelerikBooleanDropDownList",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -103846,10 +102545,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3172706534641437999,
-      "Data2": 3797669466661111875,
-      "Data3": -7866573434164216892,
-      "Data4": -5454847704404894726
+      "Data1": -3345642588541025482,
+      "Data2": -6378093426316157205,
+      "Data3": -5789112730842094942,
+      "Data4": -8672759121953621248
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikBooleanDropDownList",
@@ -103862,11 +102561,8 @@
         "TagName": "Telerik.Blazor.Components.Common.Editors.TelerikBooleanDropDownList",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -103894,10 +102590,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7709868594272750266,
-      "Data2": 1348792591086662588,
-      "Data3": -1285093378502529492,
-      "Data4": -2366355243177792975
+      "Data1": 4988243308307020421,
+      "Data2": 8021940243261873108,
+      "Data3": -2406037947882695170,
+      "Data4": 3279314091242133070
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikDateTimeEditor",
@@ -103910,11 +102606,8 @@
         "TagName": "TelerikDateTimeEditor",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -103941,10 +102634,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8880390585028481974,
-      "Data2": -6075869931860678147,
-      "Data3": 1013589158981229480,
-      "Data4": -2937551498516771189
+      "Data1": -8308655362094395807,
+      "Data2": -1454572542693808149,
+      "Data3": 3957023613481857496,
+      "Data4": -2201399076111424433
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikDateTimeEditor",
@@ -103957,11 +102650,8 @@
         "TagName": "Telerik.Blazor.Components.Common.Editors.TelerikDateTimeEditor",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -103989,10 +102679,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5207725436467134585,
-      "Data2": -3359702172509813999,
-      "Data3": 964003055013784826,
-      "Data4": -8981082051887527090
+      "Data1": -9129523071196187962,
+      "Data2": -1795553412900510535,
+      "Data3": -3203944032155745520,
+      "Data4": 1050559222479833246
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikDecimalEditor",
@@ -104005,11 +102695,8 @@
         "TagName": "TelerikDecimalEditor",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -104036,10 +102723,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1934227055325656311,
-      "Data2": 8144222726709353790,
-      "Data3": -8670430820399223064,
-      "Data4": 6852474600954856654
+      "Data1": -2745100830491068248,
+      "Data2": 8557833965186280006,
+      "Data3": -6976470496520046783,
+      "Data4": 9000631509994662815
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikDecimalEditor",
@@ -104052,11 +102739,8 @@
         "TagName": "Telerik.Blazor.Components.Common.Editors.TelerikDecimalEditor",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -104084,10 +102768,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4280236938353092068,
-      "Data2": -5111196638387438471,
-      "Data3": -3923208245508165860,
-      "Data4": -4488308508564374403
+      "Data1": 3625406781214908343,
+      "Data2": 8298708016677927708,
+      "Data3": -3179590632426454159,
+      "Data4": 9151688249398707097
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikDoubleEditor",
@@ -104100,11 +102784,8 @@
         "TagName": "TelerikDoubleEditor",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -104131,10 +102812,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2118519839077305935,
-      "Data2": -4996829400505062248,
-      "Data3": -8814927189209043295,
-      "Data4": 4158232522478234687
+      "Data1": -2118201539115937711,
+      "Data2": -3464199751012960352,
+      "Data3": -5621685614743614116,
+      "Data4": 1863001512910109303
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikDoubleEditor",
@@ -104147,11 +102828,8 @@
         "TagName": "Telerik.Blazor.Components.Common.Editors.TelerikDoubleEditor",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -104179,10 +102857,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 8925619686222109739,
-      "Data2": -5334312173353818178,
-      "Data3": 1478297126954169252,
-      "Data4": -8278774356423556053
+      "Data1": -2117716468058862498,
+      "Data2": 6304575694892144380,
+      "Data3": 3154908162987802597,
+      "Data4": 3699491211633212247
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikEditorFactory",
@@ -104195,11 +102873,8 @@
         "TagName": "TelerikEditorFactory",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -104226,10 +102901,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -796075559234816769,
-      "Data2": -8641497829784288457,
-      "Data3": -5024475532589771286,
-      "Data4": 2704395019780687823
+      "Data1": -5400931179886455984,
+      "Data2": 7797247647599096962,
+      "Data3": -7080872041064058093,
+      "Data4": -1165960646654115121
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikEditorFactory",
@@ -104242,11 +102917,8 @@
         "TagName": "Telerik.Blazor.Components.Common.Editors.TelerikEditorFactory",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -104274,10 +102946,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5861498805493923302,
-      "Data2": 2436979849701734163,
-      "Data3": -249250044323784892,
-      "Data4": 8694069092634856130
+      "Data1": 6023175333562140173,
+      "Data2": 8304958394213543580,
+      "Data3": -8174470937721909794,
+      "Data4": 6306940207724253455
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikFloatEditor",
@@ -104290,11 +102962,8 @@
         "TagName": "TelerikFloatEditor",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -104321,10 +102990,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7306583815988545502,
-      "Data2": 3592792739575340595,
-      "Data3": -6421833667822696064,
-      "Data4": 5906335705660210708
+      "Data1": 7324771089445400328,
+      "Data2": -6781559938203194904,
+      "Data3": -3453571898736372744,
+      "Data4": 6591674153250433962
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikFloatEditor",
@@ -104337,11 +103006,8 @@
         "TagName": "Telerik.Blazor.Components.Common.Editors.TelerikFloatEditor",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -104369,10 +103035,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5641416582191172771,
-      "Data2": -1155226294840266327,
-      "Data3": -2317265985055562473,
-      "Data4": -8425704632254538204
+      "Data1": -7980317515080791896,
+      "Data2": 8505699393285850589,
+      "Data3": 7825589947546017680,
+      "Data4": 8394059152055298759
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikIntEditor",
@@ -104385,11 +103051,8 @@
         "TagName": "TelerikIntEditor",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -104416,10 +103079,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -6819456177219792314,
-      "Data2": 1967352511189019032,
-      "Data3": -8596472878967900357,
-      "Data4": 3736639760285130002
+      "Data1": 9116057818500588821,
+      "Data2": 5856210655132755421,
+      "Data3": -4324219346441017888,
+      "Data4": -1441682355616834171
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikIntEditor",
@@ -104432,11 +103095,8 @@
         "TagName": "Telerik.Blazor.Components.Common.Editors.TelerikIntEditor",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -104464,10 +103124,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 9061460086519301454,
-      "Data2": 3462945739014725407,
-      "Data3": 4771176027275449397,
-      "Data4": -6649756929680499966
+      "Data1": 4665661787705546385,
+      "Data2": 2389693056119952877,
+      "Data3": -3181447589673513812,
+      "Data4": -1894332098698589902
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikLongEditor",
@@ -104480,11 +103140,8 @@
         "TagName": "TelerikLongEditor",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -104511,10 +103168,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3896852796984250923,
-      "Data2": -1430464130463575564,
-      "Data3": 1599373674436556615,
-      "Data4": -2850142481297559087
+      "Data1": -3190241692665542853,
+      "Data2": 2387068637538045351,
+      "Data3": 7994578367741475887,
+      "Data4": -5496164814016789163
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikLongEditor",
@@ -104527,11 +103184,8 @@
         "TagName": "Telerik.Blazor.Components.Common.Editors.TelerikLongEditor",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -104559,10 +103213,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7680059107533756596,
-      "Data2": 3333176301806109932,
-      "Data3": -5097807357906968938,
-      "Data4": 4589913926174080900
+      "Data1": -1541340749422207577,
+      "Data2": 5247470962352026971,
+      "Data3": -827624200256681841,
+      "Data4": 2692520862684912977
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikShortEditor",
@@ -104575,11 +103229,8 @@
         "TagName": "TelerikShortEditor",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -104606,10 +103257,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3138879958197069396,
-      "Data2": 7377495398206601345,
-      "Data3": -5440974854650852508,
-      "Data4": -4774414576456432358
+      "Data1": 5307951188091332224,
+      "Data2": -7809696455780096299,
+      "Data3": -7912858862186736150,
+      "Data4": 6650969784233401062
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikShortEditor",
@@ -104622,11 +103273,8 @@
         "TagName": "Telerik.Blazor.Components.Common.Editors.TelerikShortEditor",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -104654,10 +103302,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3882366095335065365,
-      "Data2": -5225082700050459097,
-      "Data3": 3275795861102572528,
-      "Data4": -7284201059981273849
+      "Data1": 2077361714257542882,
+      "Data2": -5572002045224219991,
+      "Data3": 7529558416899957487,
+      "Data4": 6964733247354464623
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikStringEditor",
@@ -104670,11 +103318,8 @@
         "TagName": "TelerikStringEditor",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -104701,10 +103346,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4031301291476971047,
-      "Data2": 7468232458292406839,
-      "Data3": -358999444419967682,
-      "Data4": 507185558252768613
+      "Data1": 5184399448092062850,
+      "Data2": 5304572958608759316,
+      "Data3": -8903432082750593215,
+      "Data4": -3582192294454928870
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Editors.TelerikStringEditor",
@@ -104717,11 +103362,8 @@
         "TagName": "Telerik.Blazor.Components.Common.Editors.TelerikStringEditor",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -104749,10 +103391,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1187223030982927076,
-      "Data2": -5847942770445276509,
-      "Data3": 880038258101329946,
-      "Data4": -828931466571968245
+      "Data1": -744995595170993346,
+      "Data2": -3049050461508787710,
+      "Data3": 338706702333905502,
+      "Data4": -390761362692125985
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Filters.Filter.TelerikFilter",
@@ -104765,11 +103407,8 @@
         "TagName": "TelerikFilter",
         "Attributes": [
           {
-            "Name": "@bind-FilterDescriptor",
-            "DisplayName": "@bind-FilterDescriptor",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-FilterDescriptor"
           }
         ]
       }
@@ -104796,10 +103435,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8627134097938975087,
-      "Data2": 7082680966092563877,
-      "Data3": -3437331510059105305,
-      "Data4": -5449483743962932432
+      "Data1": 3733615260340688205,
+      "Data2": -5404673097173363095,
+      "Data3": 2630384009200827666,
+      "Data4": -2130508557159513241
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Filters.Filter.TelerikFilter",
@@ -104812,11 +103451,8 @@
         "TagName": "Telerik.Blazor.Components.Common.Filters.Filter.TelerikFilter",
         "Attributes": [
           {
-            "Name": "@bind-FilterDescriptor",
-            "DisplayName": "@bind-FilterDescriptor",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-FilterDescriptor"
           }
         ]
       }
@@ -104844,10 +103480,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7610780339019652588,
-      "Data2": -7639469986763655855,
-      "Data3": -3843569705537291526,
-      "Data4": -1847100339748050089
+      "Data1": 7774768167227579669,
+      "Data2": -7325863949839550320,
+      "Data3": -691814198873850404,
+      "Data4": 3529947676739521057
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Filters.Filter.TelerikFilterExpression",
@@ -104860,11 +103496,8 @@
         "TagName": "TelerikFilterExpression",
         "Attributes": [
           {
-            "Name": "@bind-FilterDescriptor",
-            "DisplayName": "@bind-FilterDescriptor",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-FilterDescriptor"
           }
         ]
       }
@@ -104891,10 +103524,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2589265494641049352,
-      "Data2": -2649445863730099235,
-      "Data3": -6347255374548832922,
-      "Data4": -8860095390896302125
+      "Data1": -5019908945804677864,
+      "Data2": 3037194534522887019,
+      "Data3": 2076271593359005157,
+      "Data4": 4269518616034844607
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Filters.Filter.TelerikFilterExpression",
@@ -104907,11 +103540,8 @@
         "TagName": "Telerik.Blazor.Components.Common.Filters.Filter.TelerikFilterExpression",
         "Attributes": [
           {
-            "Name": "@bind-FilterDescriptor",
-            "DisplayName": "@bind-FilterDescriptor",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-FilterDescriptor"
           }
         ]
       }
@@ -104939,10 +103569,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7043142458081133984,
-      "Data2": -2150685431841474493,
-      "Data3": -8480184990936416325,
-      "Data4": -6446966274799865820
+      "Data1": 5812901214431944772,
+      "Data2": 4497310599134324158,
+      "Data3": 2567891286289158887,
+      "Data4": 6222487747692308851
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Filters.FilterList.TelerikFilterList",
@@ -104955,11 +103585,8 @@
         "TagName": "TelerikFilterList",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -104987,10 +103614,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1047078871679937470,
-      "Data2": 5784336394402429654,
-      "Data3": -8728688621353529095,
-      "Data4": -5690308918457317170
+      "Data1": 5523786085149808509,
+      "Data2": 7100627587609649051,
+      "Data3": -3155173017745555695,
+      "Data4": 2768020981087110380
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Filters.FilterList.TelerikFilterList",
@@ -105003,11 +103630,8 @@
         "TagName": "Telerik.Blazor.Components.Common.Filters.FilterList.TelerikFilterList",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -105036,10 +103660,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4762135147927575188,
-      "Data2": 2161308281029651761,
-      "Data3": -3696636450511092126,
-      "Data4": -135047217711397241
+      "Data1": -3757371625242227520,
+      "Data2": 5173596481721124336,
+      "Data3": -2010643803483417637,
+      "Data4": -4390494679045233371
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Filters.FilterMenu.FilterMenuForm",
@@ -105052,11 +103676,8 @@
         "TagName": "FilterMenuForm",
         "Attributes": [
           {
-            "Name": "@bind-FilterDescriptor",
-            "DisplayName": "@bind-FilterDescriptor",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-FilterDescriptor"
           }
         ]
       }
@@ -105083,10 +103704,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -545893000290877882,
-      "Data2": -2160805652792108014,
-      "Data3": 1173863451113320326,
-      "Data4": -5438230552486213209
+      "Data1": -8342317740505710292,
+      "Data2": -2148199351118186414,
+      "Data3": -8021368552226313277,
+      "Data4": -4290735497772339187
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Filters.FilterMenu.FilterMenuForm",
@@ -105099,11 +103720,8 @@
         "TagName": "Telerik.Blazor.Components.Common.Filters.FilterMenu.FilterMenuForm",
         "Attributes": [
           {
-            "Name": "@bind-FilterDescriptor",
-            "DisplayName": "@bind-FilterDescriptor",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-FilterDescriptor"
           }
         ]
       }
@@ -105131,10 +103749,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2084467927786193951,
-      "Data2": 5355468741068609639,
-      "Data3": 5446919232643395551,
-      "Data4": 1641752959259839721
+      "Data1": 5664364536191393193,
+      "Data2": -4584528744465974523,
+      "Data3": -5590629444395485243,
+      "Data4": 8645271743101341612
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Filters.FilterMenu.TelerikFilterMenu",
@@ -105147,11 +103765,8 @@
         "TagName": "TelerikFilterMenu",
         "Attributes": [
           {
-            "Name": "@bind-FilterDescriptor",
-            "DisplayName": "@bind-FilterDescriptor",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-FilterDescriptor"
           }
         ]
       }
@@ -105178,10 +103793,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 7170219948519090770,
-      "Data2": -4055051594570403143,
-      "Data3": 5435499569876959392,
-      "Data4": -1864516204358556764
+      "Data1": 8138750659376671737,
+      "Data2": -5289059936228713149,
+      "Data3": -1580604071108005393,
+      "Data4": 2286045755068401161
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Filters.FilterMenu.TelerikFilterMenu",
@@ -105194,11 +103809,8 @@
         "TagName": "Telerik.Blazor.Components.Common.Filters.FilterMenu.TelerikFilterMenu",
         "Attributes": [
           {
-            "Name": "@bind-FilterDescriptor",
-            "DisplayName": "@bind-FilterDescriptor",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-FilterDescriptor"
           }
         ]
       }
@@ -105226,10 +103838,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1109136803223569622,
-      "Data2": -7193790078948574477,
-      "Data3": -8463493760483517696,
-      "Data4": 4846255392012145123
+      "Data1": -3152498593721332914,
+      "Data2": 217833781896422505,
+      "Data3": -6096265995171603793,
+      "Data4": 2651882584474218795
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Filters.FilterMenu.TelerikFilterMenuHeader<TItem>",
@@ -105242,11 +103854,8 @@
         "TagName": "TelerikFilterMenuHeader",
         "Attributes": [
           {
-            "Name": "@bind-FilterDescriptor",
-            "DisplayName": "@bind-FilterDescriptor",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-FilterDescriptor"
           }
         ]
       }
@@ -105273,10 +103882,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -660272120487599431,
-      "Data2": -1888963771693038588,
-      "Data3": 1773461050177981405,
-      "Data4": 811743455035239356
+      "Data1": -275002179376649156,
+      "Data2": -2391793594698876632,
+      "Data3": 7040744867582988043,
+      "Data4": -4834233293903167848
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.Filters.FilterMenu.TelerikFilterMenuHeader<TItem>",
@@ -105289,11 +103898,8 @@
         "TagName": "Telerik.Blazor.Components.Common.Filters.FilterMenu.TelerikFilterMenuHeader",
         "Attributes": [
           {
-            "Name": "@bind-FilterDescriptor",
-            "DisplayName": "@bind-FilterDescriptor",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-FilterDescriptor"
           }
         ]
       }
@@ -105321,10 +103927,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4006247946742310459,
-      "Data2": 9145089643969336298,
-      "Data3": 5131231313355766052,
-      "Data4": 7507971197297052781
+      "Data1": 7621598850442294115,
+      "Data2": 3507383950095652838,
+      "Data3": 5133945838211583436,
+      "Data4": 5634531661970040824
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.VirtualScroller.VirtualScrollContainer",
@@ -105337,11 +103943,8 @@
         "TagName": "VirtualScrollContainer",
         "Attributes": [
           {
-            "Name": "@bind-Skip",
-            "DisplayName": "@bind-Skip",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Skip"
           }
         ]
       }
@@ -105368,10 +103971,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -3947883187885567013,
-      "Data2": -5810885267092553477,
-      "Data3": 2641250997356681721,
-      "Data4": 2282892997943196705
+      "Data1": -2463301110646252940,
+      "Data2": 701833176545132687,
+      "Data3": 5768350164984835169,
+      "Data4": -3367437581247884470
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.VirtualScroller.VirtualScrollContainer",
@@ -105384,11 +103987,8 @@
         "TagName": "Telerik.Blazor.Components.Common.VirtualScroller.VirtualScrollContainer",
         "Attributes": [
           {
-            "Name": "@bind-Skip",
-            "DisplayName": "@bind-Skip",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Skip"
           }
         ]
       }
@@ -105416,10 +104016,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -5442376781697678264,
-      "Data2": 2707883738956816766,
-      "Data3": 1195893042432926893,
-      "Data4": 2429554826953660101
+      "Data1": 3694014325330550820,
+      "Data2": 8676665885061273019,
+      "Data3": 2349046751476405047,
+      "Data4": -8755139814354826347
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.VirtualScroller.VirtualScroller",
@@ -105432,11 +104032,8 @@
         "TagName": "VirtualScroller",
         "Attributes": [
           {
-            "Name": "@bind-Skip",
-            "DisplayName": "@bind-Skip",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Skip"
           }
         ]
       }
@@ -105463,10 +104060,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 674123970539014106,
-      "Data2": -4407095654028310981,
-      "Data3": 5018826723904115902,
-      "Data4": -3752509906208463659
+      "Data1": 1466615554223742359,
+      "Data2": -8334697959619485334,
+      "Data3": 493062878722593513,
+      "Data4": 2487219585677577091
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Common.VirtualScroller.VirtualScroller",
@@ -105479,11 +104076,8 @@
         "TagName": "Telerik.Blazor.Components.Common.VirtualScroller.VirtualScroller",
         "Attributes": [
           {
-            "Name": "@bind-Skip",
-            "DisplayName": "@bind-Skip",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Skip"
           }
         ]
       }
@@ -105511,10 +104105,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1149741998705365086,
-      "Data2": 6195798860843882965,
-      "Data3": 6155717368203438587,
-      "Data4": 5717014748573282170
+      "Data1": -7050325366361330175,
+      "Data2": 2690224210175639735,
+      "Data3": -7552841611438209798,
+      "Data4": -2348849051574579595
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Editor.Dialogs.EditorDialog",
@@ -105527,11 +104121,8 @@
         "TagName": "EditorDialog",
         "Attributes": [
           {
-            "Name": "@bind-Visible",
-            "DisplayName": "@bind-Visible",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Visible"
           }
         ]
       }
@@ -105558,10 +104149,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7238103070435372274,
-      "Data2": -3324640556789293285,
-      "Data3": 3498716410484668707,
-      "Data4": 8682277249083434719
+      "Data1": 3570076355358163128,
+      "Data2": 6843493339936072110,
+      "Data3": 309074393412650827,
+      "Data4": -6770511425245120849
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Editor.Dialogs.EditorDialog",
@@ -105574,11 +104165,8 @@
         "TagName": "Telerik.Blazor.Components.Editor.Dialogs.EditorDialog",
         "Attributes": [
           {
-            "Name": "@bind-Visible",
-            "DisplayName": "@bind-Visible",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Visible"
           }
         ]
       }
@@ -105606,10 +104194,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5957176382645431814,
-      "Data2": -5471007933167494361,
-      "Data3": 2091808830471385383,
-      "Data4": 7628228491198299483
+      "Data1": -3517806206701243038,
+      "Data2": 5162557387741744637,
+      "Data3": 4748339324752486632,
+      "Data4": -5048302817826389958
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Grid.GridHeaderCell<TItem>",
@@ -105622,11 +104210,8 @@
         "TagName": "GridHeaderCell",
         "Attributes": [
           {
-            "Name": "@bind-FilterDescriptor",
-            "DisplayName": "@bind-FilterDescriptor",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-FilterDescriptor"
           }
         ]
       }
@@ -105653,10 +104238,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 5060930097255232668,
-      "Data2": 7957830515716279406,
-      "Data3": -3674376802280770960,
-      "Data4": -2236234874620876187
+      "Data1": -4893021150051955328,
+      "Data2": -9117825663413034432,
+      "Data3": -1445944766946984794,
+      "Data4": -350431257296711023
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Grid.GridHeaderCell<TItem>",
@@ -105669,11 +104254,8 @@
         "TagName": "Telerik.Blazor.Components.Grid.GridHeaderCell",
         "Attributes": [
           {
-            "Name": "@bind-FilterDescriptor",
-            "DisplayName": "@bind-FilterDescriptor",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-FilterDescriptor"
           }
         ]
       }
@@ -105701,10 +104283,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1838186269082458719,
-      "Data2": -3672443636485794439,
-      "Data3": -3858721430483418071,
-      "Data4": -6841106178917190710
+      "Data1": -3993804794302457333,
+      "Data2": 7553566321489299206,
+      "Data3": 7981230669872490082,
+      "Data4": 2849886313185789199
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Scheduler.SchedulerFooter",
@@ -105717,11 +104299,8 @@
         "TagName": "SchedulerFooter",
         "Attributes": [
           {
-            "Name": "@bind-ShowWorkHours",
-            "DisplayName": "@bind-ShowWorkHours",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-ShowWorkHours"
           }
         ]
       }
@@ -105748,10 +104327,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 1337142722230807921,
-      "Data2": 7973378717351479950,
-      "Data3": 8832461258156141209,
-      "Data4": -6779309755242702512
+      "Data1": 1541168833987506176,
+      "Data2": -8392157892092725731,
+      "Data3": 3697350059254445204,
+      "Data4": 7541365352586189797
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Scheduler.SchedulerFooter",
@@ -105764,11 +104343,8 @@
         "TagName": "Telerik.Blazor.Components.Scheduler.SchedulerFooter",
         "Attributes": [
           {
-            "Name": "@bind-ShowWorkHours",
-            "DisplayName": "@bind-ShowWorkHours",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-ShowWorkHours"
           }
         ]
       }
@@ -105796,10 +104372,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -2329058121726435641,
-      "Data2": -4014206987915070703,
-      "Data3": 527893527170287224,
-      "Data4": 7017890452186206328
+      "Data1": -996468247675569667,
+      "Data2": -1345696154594286422,
+      "Data3": 8474927989103734797,
+      "Data4": -3510984869599425503
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Scheduler.SchedulerToolbar",
@@ -105812,11 +104388,8 @@
         "TagName": "SchedulerToolbar",
         "Attributes": [
           {
-            "Name": "@bind-Date",
-            "DisplayName": "@bind-Date",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Date"
           }
         ]
       }
@@ -105843,10 +104416,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4399576561432961654,
-      "Data2": 6936767031151358290,
-      "Data3": -5322310200579377692,
-      "Data4": -5496773768160097882
+      "Data1": 444824597034453339,
+      "Data2": -6764888231966094654,
+      "Data3": -1334318186769126070,
+      "Data4": 2525346254361751823
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Scheduler.SchedulerToolbar",
@@ -105859,11 +104432,8 @@
         "TagName": "SchedulerToolbar",
         "Attributes": [
           {
-            "Name": "@bind-ViewType",
-            "DisplayName": "@bind-ViewType",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-ViewType"
           }
         ]
       }
@@ -105891,10 +104461,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8700597435752154718,
-      "Data2": 4830595658047790531,
-      "Data3": -5910919570002782492,
-      "Data4": -3565704776204282129
+      "Data1": -1579213932419498135,
+      "Data2": -6291081068005045311,
+      "Data3": 7229478328702518803,
+      "Data4": -2148692969491347750
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Scheduler.SchedulerToolbar",
@@ -105907,11 +104477,8 @@
         "TagName": "Telerik.Blazor.Components.Scheduler.SchedulerToolbar",
         "Attributes": [
           {
-            "Name": "@bind-Date",
-            "DisplayName": "@bind-Date",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Date"
           }
         ]
       }
@@ -105939,10 +104506,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -642869174534642542,
-      "Data2": -3941037737767810547,
-      "Data3": -567448713851131630,
-      "Data4": 4557811556543639394
+      "Data1": 445118589940922142,
+      "Data2": -2657869403582024533,
+      "Data3": 7813261606709385710,
+      "Data4": 4161273471953673348
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Scheduler.SchedulerToolbar",
@@ -105955,11 +104522,8 @@
         "TagName": "Telerik.Blazor.Components.Scheduler.SchedulerToolbar",
         "Attributes": [
           {
-            "Name": "@bind-ViewType",
-            "DisplayName": "@bind-ViewType",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-ViewType"
           }
         ]
       }
@@ -105988,10 +104552,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4445587194307209494,
-      "Data2": -3753651370428562516,
-      "Data3": -8005035456298788833,
-      "Data4": 7064235155962955094
+      "Data1": 7363808155335375766,
+      "Data2": -8326048337818220543,
+      "Data3": -3457506658779635320,
+      "Data4": -6844227764982589806
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Scheduler.SchedulerToolbarCalendar",
@@ -106004,11 +104568,8 @@
         "TagName": "SchedulerToolbarCalendar",
         "Attributes": [
           {
-            "Name": "@bind-Date",
-            "DisplayName": "@bind-Date",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Date"
           }
         ]
       }
@@ -106035,10 +104596,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -1320380308366762413,
-      "Data2": -4239966310333328884,
-      "Data3": -3859255340985405856,
-      "Data4": -6582343579035285283
+      "Data1": 4052275365150831578,
+      "Data2": 3819421558928458448,
+      "Data3": -1147907436874789810,
+      "Data4": 9073254154866888910
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Scheduler.SchedulerToolbarCalendar",
@@ -106051,11 +104612,8 @@
         "TagName": "Telerik.Blazor.Components.Scheduler.SchedulerToolbarCalendar",
         "Attributes": [
           {
-            "Name": "@bind-Date",
-            "DisplayName": "@bind-Date",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Date"
           }
         ]
       }
@@ -106083,10 +104641,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2324786665068712726,
-      "Data2": 4022616078493598797,
-      "Data3": -1590084092634719080,
-      "Data4": 8791912258173728328
+      "Data1": -7402693173368959217,
+      "Data2": 5774896994283887125,
+      "Data3": 760235803041413383,
+      "Data4": -6303240359640646996
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Scheduler.EditForm.RecurrenceEditor.RecurrenceEditor",
@@ -106099,11 +104657,8 @@
         "TagName": "RecurrenceEditor",
         "Attributes": [
           {
-            "Name": "@bind-Rule",
-            "DisplayName": "@bind-Rule",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Rule"
           }
         ]
       }
@@ -106130,10 +104685,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8568840873388072689,
-      "Data2": 1496895400590429682,
-      "Data3": -5432948087668863992,
-      "Data4": -5512231350819051613
+      "Data1": -3000851484814679903,
+      "Data2": -4152874716278576248,
+      "Data3": -8601405469438587084,
+      "Data4": -2078799156917777902
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Scheduler.EditForm.RecurrenceEditor.RecurrenceEditor",
@@ -106146,11 +104701,8 @@
         "TagName": "Telerik.Blazor.Components.Scheduler.EditForm.RecurrenceEditor.RecurrenceEditor",
         "Attributes": [
           {
-            "Name": "@bind-Rule",
-            "DisplayName": "@bind-Rule",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Rule"
           }
         ]
       }
@@ -106178,10 +104730,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 3116885370564836358,
-      "Data2": 3087493111284678089,
-      "Data3": 2083033926774134755,
-      "Data4": -7180646052795741288
+      "Data1": -1281226089285317501,
+      "Data2": -4481662279249264734,
+      "Data3": -5513046747295473804,
+      "Data4": -683625856009426502
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Scheduler.EditForm.RecurrenceEditor.RecurrenceFrequencyEditor",
@@ -106194,11 +104746,8 @@
         "TagName": "RecurrenceFrequencyEditor",
         "Attributes": [
           {
-            "Name": "@bind-Rule",
-            "DisplayName": "@bind-Rule",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Rule"
           }
         ]
       }
@@ -106225,10 +104774,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -9001229462327150230,
-      "Data2": 4644391220072966800,
-      "Data3": -4138085007185205168,
-      "Data4": -8323004169518348236
+      "Data1": -6120684342591318053,
+      "Data2": 5088377442785847698,
+      "Data3": 5840439542335999590,
+      "Data4": -7258875152660217701
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.Scheduler.EditForm.RecurrenceEditor.RecurrenceFrequencyEditor",
@@ -106241,11 +104790,8 @@
         "TagName": "Telerik.Blazor.Components.Scheduler.EditForm.RecurrenceEditor.RecurrenceFrequencyEditor",
         "Attributes": [
           {
-            "Name": "@bind-Rule",
-            "DisplayName": "@bind-Rule",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Rule"
           }
         ]
       }
@@ -106273,10 +104819,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -4041851024167591022,
-      "Data2": 8066046650311231215,
-      "Data3": 2999676424610158722,
-      "Data4": 3062711443912615323
+      "Data1": 6652922798713116749,
+      "Data2": 3366537155591995674,
+      "Data3": 765523408159175404,
+      "Data4": -4415895392346087934
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TimePicker.TimeSelectorCarouselBase",
@@ -106289,11 +104835,8 @@
         "TagName": "TimeSelectorCarouselBase",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -106320,10 +104863,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7620921744764723562,
-      "Data2": -1317031464609107985,
-      "Data3": 8780990180703542616,
-      "Data4": 7464656282147465007
+      "Data1": 8900276862475341041,
+      "Data2": 3278093493860541518,
+      "Data3": -1868715958851097427,
+      "Data4": -3746245003958891912
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TimePicker.TimeSelectorCarouselBase",
@@ -106336,11 +104879,8 @@
         "TagName": "Telerik.Blazor.Components.TimePicker.TimeSelectorCarouselBase",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -106368,10 +104908,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6069726961506147068,
-      "Data2": 2424390455770419073,
-      "Data3": 2880459585385756573,
-      "Data4": 6638715046941086992
+      "Data1": 3948195243864556634,
+      "Data2": -6562068538543761577,
+      "Data3": -495829025641139208,
+      "Data4": -5193290257535659222
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TimePicker.TimeSelectorCarousel",
@@ -106384,11 +104924,8 @@
         "TagName": "TimeSelectorCarousel",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -106415,10 +104952,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8179926578273160851,
-      "Data2": 1354718272810712795,
-      "Data3": -5193742821891389908,
-      "Data4": 785569011504310255
+      "Data1": 3261784939498228352,
+      "Data2": 2113523464935575660,
+      "Data3": 1891208933947104757,
+      "Data4": 1585468087011709815
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TimePicker.TimeSelectorCarousel",
@@ -106431,11 +104968,8 @@
         "TagName": "Telerik.Blazor.Components.TimePicker.TimeSelectorCarousel",
         "Attributes": [
           {
-            "Name": "@bind-Value",
-            "DisplayName": "@bind-Value",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Value"
           }
         ]
       }
@@ -106463,10 +104997,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4521019000446994387,
-      "Data2": -6481412596062629828,
-      "Data3": 7723019210628404369,
-      "Data4": 7774067642230351718
+      "Data1": 9008079390813217149,
+      "Data2": 5036104934827665143,
+      "Data3": -2722231783306522844,
+      "Data4": 4976994165951205231
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.ToolBar.ToolBarToggleButton",
@@ -106479,11 +105013,8 @@
         "TagName": "ToolBarToggleButton",
         "Attributes": [
           {
-            "Name": "@bind-Selected",
-            "DisplayName": "@bind-Selected",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Selected"
           }
         ]
       }
@@ -106510,10 +105041,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 6916404026518630962,
-      "Data2": 729560889867507995,
-      "Data3": 6178215823728770702,
-      "Data4": 7495248017237300698
+      "Data1": 1205718862768436220,
+      "Data2": 2198844359559719538,
+      "Data3": 751108892968191021,
+      "Data4": 6636764731984725739
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.ToolBar.ToolBarToggleButton",
@@ -106526,11 +105057,8 @@
         "TagName": "Telerik.Blazor.Components.ToolBar.ToolBarToggleButton",
         "Attributes": [
           {
-            "Name": "@bind-Selected",
-            "DisplayName": "@bind-Selected",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-Selected"
           }
         ]
       }
@@ -106558,10 +105086,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -7149099378339848163,
-      "Data2": 4166570299802907966,
-      "Data3": 8590567711634277638,
-      "Data4": -3252900290767167157
+      "Data1": 5625592817867788219,
+      "Data2": -7916882655326709041,
+      "Data3": -2436241396627715703,
+      "Data4": -1033358310444151299
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TreeList.TreeListHeaderCell<TItem>",
@@ -106574,11 +105102,8 @@
         "TagName": "TreeListHeaderCell",
         "Attributes": [
           {
-            "Name": "@bind-FilterDescriptor",
-            "DisplayName": "@bind-FilterDescriptor",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-FilterDescriptor"
           }
         ]
       }
@@ -106605,10 +105130,10 @@
   },
   {
     "__Checksum": {
-      "Data1": -8176892831759939701,
-      "Data2": 8212700255971919613,
-      "Data3": -8950417559897455097,
-      "Data4": -8289711185241474718
+      "Data1": -5635321698405445151,
+      "Data2": 8910708815375973118,
+      "Data3": 6565736597765607956,
+      "Data4": -4812831887443355908
     },
     "Kind": "Components.Bind",
     "Name": "Telerik.Blazor.Components.TreeList.TreeListHeaderCell<TItem>",
@@ -106621,11 +105146,8 @@
         "TagName": "Telerik.Blazor.Components.TreeList.TreeListHeaderCell",
         "Attributes": [
           {
-            "Name": "@bind-FilterDescriptor",
-            "DisplayName": "@bind-FilterDescriptor",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@bind-FilterDescriptor"
           }
         ]
       }
@@ -106653,10 +105175,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 4102723061224647593,
-      "Data2": 4857627520970374811,
-      "Data3": -74214136497740781,
-      "Data4": -1956006785535428516
+      "Data1": 1957875837170816796,
+      "Data2": -6818996979004571037,
+      "Data3": 697075976643601741,
+      "Data4": 532162150715961857
     },
     "Kind": "Components.Ref",
     "Name": "Ref",
@@ -106669,11 +105191,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@ref",
-            "DisplayName": "@ref",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@ref"
           }
         ]
       }
@@ -106699,10 +105218,10 @@
   },
   {
     "__Checksum": {
-      "Data1": 2430283302692339690,
-      "Data2": -3706792934705351988,
-      "Data3": -6808539033781834759,
-      "Data4": 2182667615803869390
+      "Data1": 2367170055839669400,
+      "Data2": 7517082500533989361,
+      "Data3": 9093483600944421722,
+      "Data4": -3348098094423071850
     },
     "Kind": "Components.Key",
     "Name": "Key",
@@ -106715,11 +105234,8 @@
         "TagName": "*",
         "Attributes": [
           {
-            "Name": "@key",
-            "DisplayName": "@key",
-            "Metadata": {
-              "Common.DirectiveAttribute": "True"
-            }
+            "Flags": 3,
+            "Name": "@key"
           }
         ]
       }


### PR DESCRIPTION
> [!IMPORTANT]
> This affects the Razor SDK. When the compiler flows to the .NET VMR, this commit will be needed: https://github.com/dotnet/dotnet/commit/a10383a5fe77787b26e81a87f0c07c996d8bba8c.

This change makes a few updates `RequiredAttributeDescriptor`:

- Un-nest and rename the `RequiredAttributeDescriptor.NameComparisonMode` and `RequiredAttributeDescriptor.ValueComparisonMode` enums to `RequiredAttributeNameComparison` and `RequiredAttributeValueComparison`, respectively.
- Remove the `Metadata` property. There's only one bit of data that was ever stored in the `Metadata` property: `IsDirectiveAttribute`. This has been moved to a property on `RequiredAttributeDescriptor` itself. Interestingly, the compiler doesn't actually use `IsDirectiveAttribute`. However, it might sometime, so I've left it.
- Don't serialize the `DisplayName` property. This always has exactly the same format for any `RequiredAttributeDescriptor`.

----
CI Build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2736049&view=results
https://dev.azure.com/dnceng/internal/_build/results?buildId=2736052&view=results