### PR TITLE
Compiler: Avoid allocating strings in the RazorHtmlWriter

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.cs
@@ -435,6 +435,12 @@ public sealed partial class CodeWriter : IDisposable
 
                 foreach (var chunk in chunks)
                 {
+                    if (destination.IsEmpty)
+                    {
+                        // If we have no more space in the destination, we're done.
+                        break;
+                    }
+
                     var source = chunk.Span;
 
                     // Slice if the first chunk is partial. Note that this only occurs for the first chunk.
@@ -470,12 +476,6 @@ public sealed partial class CodeWriter : IDisposable
                     destination = destination[source.Length..];
 
                     charsWritten += source.Length;
-
-                    // Break if we are done writing. chunkIndex and charIndex should have their correct values at this point.
-                    if (destination.IsEmpty)
-                    {
-                        break;
-                    }
                 }
 
                 if (destination.IsEmpty)

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.cs
@@ -415,7 +415,7 @@ public sealed partial class CodeWriter : IDisposable
 
             if (_page is null)
             {
-                return -1;
+                return 0;
             }
 
             var destination = buffer.AsSpan(index, count);
@@ -461,6 +461,11 @@ public sealed partial class CodeWriter : IDisposable
                         charIndex = 0;
                     }
 
+                    if (source.IsEmpty)
+                    {
+                        continue;
+                    }
+
                     source.CopyTo(destination);
                     destination = destination[source.Length..];
 
@@ -496,6 +501,8 @@ public sealed partial class CodeWriter : IDisposable
                 _chunkIndex = -1;
                 _charIndex = -1;
             }
+
+            _remainingLength -= charsWritten;
 
             return charsWritten;
         }
@@ -551,6 +558,7 @@ public sealed partial class CodeWriter : IDisposable
             _page = null;
             _chunkIndex = -1;
             _charIndex = 1;
+            _remainingLength = 0;
 
             return result;
         }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorHtmlWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorHtmlWriter.cs
@@ -341,7 +341,7 @@ internal sealed class RazorHtmlWriter : SyntaxWalker
     }
 
     /// <summary>
-    ///  Returns <see langword="true"/> if the new span starts after the last span.
+    ///  Returns <see langword="true"/> if the new span starts immediately after the last span.
     /// </summary>
     private static bool TouchesLastSpan(SourceSpan newSpan, SourceSpan lastSpan)
         => newSpan.AbsoluteIndex == lastSpan.AbsoluteIndex + lastSpan.Length;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorHtmlWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorHtmlWriter.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
@@ -15,6 +16,13 @@ namespace Microsoft.AspNetCore.Razor.Language;
 // not all characters in the document are included in the ClassifiedSpans.
 internal sealed class RazorHtmlWriter : SyntaxWalker
 {
+    // 32 '~' characters followed by comment start and end text.
+    private const string KnownText = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~/**/";
+
+    private static ReadOnlyMemory<char> Tildes => KnownText.AsMemory(0, 32);
+    private static ReadOnlyMemory<char> CommentStart => KnownText.AsMemory(32, 2);
+    private static ReadOnlyMemory<char> CommentEnd => KnownText.AsMemory(34, 2);
+
     private readonly RazorSourceDocument _source;
     private readonly CodeWriter _codeWriter;
     private readonly ImmutableArray<SourceMapping>.Builder _sourceMappings;
@@ -27,7 +35,7 @@ internal sealed class RazorHtmlWriter : SyntaxWalker
     // can be written as a block, allowing any block of 4 characters or more to be written as a comment (ie '/**/`)
     // which takes pressure off the TypeScript/JavaScript compiler. Doing this per token means we can end up with
     // "@className" being written as '~/*~~~~~*/', which means Html formatting will insert a space which breaks things.
-    private int _csharpCharacterCount;
+    private int _tildesToWrite;
 
     private RazorHtmlWriter(RazorSourceDocument source, CodeWriter codeWriter, ImmutableArray<SourceMapping>.Builder sourceMappings)
     {
@@ -63,7 +71,7 @@ internal sealed class RazorHtmlWriter : SyntaxWalker
     {
         Visit(syntaxTree.Root);
 
-        WriteDeferredCSharpContent();
+        WriteCSharpContentPlaceholder();
 
         if (_lastGeneratedSourceSpan != SourceSpan.Undefined)
         {
@@ -226,7 +234,7 @@ internal sealed class RazorHtmlWriter : SyntaxWalker
         var content = token.Content;
         if (_isWritingHtml)
         {
-            WriteDeferredCSharpContent();
+            WriteCSharpContentPlaceholder();
 
             var source = token.GetSourceSpan(_source);
 
@@ -292,52 +300,69 @@ internal sealed class RazorHtmlWriter : SyntaxWalker
         {
             if (char.IsWhiteSpace(c))
             {
-                WriteDeferredCSharpContent();
+                WriteCSharpContentPlaceholder();
                 _codeWriter.Write(c.ToString());
             }
             else
             {
-                _csharpCharacterCount++;
+                _tildesToWrite++;
             }
         }
     }
 
-    private void WriteDeferredCSharpContent()
+    private void WriteCSharpContentPlaceholder()
     {
-        if (_csharpCharacterCount == 0)
+        var tildesToWrite = _tildesToWrite;
+
+        if (tildesToWrite == 0)
         {
+            // Nothing to write, so just return
             return;
         }
 
-        _codeWriter.Write(_csharpCharacterCount switch
+        _tildesToWrite = 0;
+
+        var writeComment = false;
+
+        // When writing 4 or more tildes, we write them as a comment to relieve pressure on the JS/TS compiler.
+
+        if (tildesToWrite >= 4)
         {
-            // Less than 4 chars, just use tildes. We can't do anything more fancy in a small space
-            1 => "~",
-            2 => "~~",
-            3 => "~~~",
+            // SPECIAL CASE: If the next character is a greater than symbol ('>'), we don't write a comment because
+            // the forward slash in the comment would be interpreted as the end of a tag, resulting in incorrect HTML.
+            // For example, `<div class=@className>` should not be written as `<div class=/*~~~~~*/>`.
 
-            // Special case for unquoted attributes that appear at the end of a tag. eg `<div class=@className>`
-            // Without this special handling, our replacement would result in `<div class=/*~~~~~*/>` which differs
-            // from the original meaning, as the div is now self-closing.
-            // Note that we don't actually know if we're in an attribute here, or some other construct, but false
-            // positives are totally fine in this scenario.
-            _ when NextCharacterIsGreaterThanSymbol() => new string('~', _csharpCharacterCount),
+            var nextIndex = _codeWriter.Location.AbsoluteIndex + tildesToWrite;
+            var text = _source.Text;
 
-            // All other cases, use a comment to relieve pressure on the JS/TS compiler
-            _ => "/*" + new string('~', _csharpCharacterCount - 4) + "*/",
-        });
-        _csharpCharacterCount = 0;
+            Debug.Assert(nextIndex <= text.Length, "The next index should not exceed the length of the source text.");
 
-        bool NextCharacterIsGreaterThanSymbol()
-        {
-            var sourceText = _source.Text;
-            var index = _codeWriter.Location.AbsoluteIndex + _csharpCharacterCount;
-            if (sourceText.Length <= index)
+            if (nextIndex >= text.Length || text[nextIndex] != '>')
             {
-                return false;
+                // We can write a comment
+                writeComment = true;
+                tildesToWrite -= 4; // We need to reserve 4 characters for the comment start and end
             }
+        }
 
-            return sourceText[index] == '>';
+        if (writeComment)
+        {
+            _codeWriter.Write(CommentStart);
+        }
+
+        while (tildesToWrite > 0)
+        {
+            var tildes = tildesToWrite < Tildes.Length
+                ? Tildes[..tildesToWrite]
+                : Tildes;
+
+            _codeWriter.Write(tildes);
+            tildesToWrite -= tildes.Length;
+        }
+
+        if (writeComment)
+        {
+            _codeWriter.Write(CommentEnd);
         }
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorHtmlWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorHtmlWriter.cs
@@ -326,8 +326,7 @@ internal sealed class RazorHtmlWriter : SyntaxWalker
                 whitespaceIndex = -1;
             }
 
-            // If we didn't transition from whitespace to non-whitespace, be sure to
-            // increment the C# content placeholder size so that we can write it later.
+            // Finally, be sure to increment the C# content placeholder size so that we can write it later.
             _placeholderSize++;
         }
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorHtmlWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorHtmlWriter.cs
@@ -93,7 +93,7 @@ internal sealed class RazorHtmlWriter : SyntaxWalker
 
     public override void VisitRazorCommentBlock(RazorCommentBlockSyntax node)
     {
-        using (IsNotHtml())
+        using (NonHtmlScope())
         {
             base.VisitRazorCommentBlock(node);
         }
@@ -101,7 +101,7 @@ internal sealed class RazorHtmlWriter : SyntaxWalker
 
     public override void VisitRazorMetaCode(RazorMetaCodeSyntax node)
     {
-        using (IsNotHtml())
+        using (NonHtmlScope())
         {
             base.VisitRazorMetaCode(node);
         }
@@ -109,7 +109,7 @@ internal sealed class RazorHtmlWriter : SyntaxWalker
 
     public override void VisitMarkupTransition(MarkupTransitionSyntax node)
     {
-        using (IsNotHtml())
+        using (NonHtmlScope())
         {
             base.VisitMarkupTransition(node);
         }
@@ -117,7 +117,7 @@ internal sealed class RazorHtmlWriter : SyntaxWalker
 
     public override void VisitCSharpTransition(CSharpTransitionSyntax node)
     {
-        using (IsNotHtml())
+        using (NonHtmlScope())
         {
             base.VisitCSharpTransition(node);
         }
@@ -125,7 +125,7 @@ internal sealed class RazorHtmlWriter : SyntaxWalker
 
     public override void VisitCSharpEphemeralTextLiteral(CSharpEphemeralTextLiteralSyntax node)
     {
-        using (IsNotHtml())
+        using (NonHtmlScope())
         {
             base.VisitCSharpEphemeralTextLiteral(node);
         }
@@ -133,7 +133,7 @@ internal sealed class RazorHtmlWriter : SyntaxWalker
 
     public override void VisitCSharpExpressionLiteral(CSharpExpressionLiteralSyntax node)
     {
-        using (IsNotHtml())
+        using (NonHtmlScope())
         {
             base.VisitCSharpExpressionLiteral(node);
         }
@@ -141,7 +141,7 @@ internal sealed class RazorHtmlWriter : SyntaxWalker
 
     public override void VisitCSharpStatementLiteral(CSharpStatementLiteralSyntax node)
     {
-        using (IsNotHtml())
+        using (NonHtmlScope())
         {
             base.VisitCSharpStatementLiteral(node);
         }
@@ -149,7 +149,7 @@ internal sealed class RazorHtmlWriter : SyntaxWalker
 
     public override void VisitMarkupStartTag(MarkupStartTagSyntax node)
     {
-        using (IsHtml())
+        using (HtmlScope())
         {
             base.VisitMarkupStartTag(node);
         }
@@ -157,7 +157,7 @@ internal sealed class RazorHtmlWriter : SyntaxWalker
 
     public override void VisitMarkupEndTag(MarkupEndTagSyntax node)
     {
-        using (IsHtml())
+        using (HtmlScope())
         {
             base.VisitMarkupEndTag(node);
         }
@@ -165,7 +165,7 @@ internal sealed class RazorHtmlWriter : SyntaxWalker
 
     public override void VisitMarkupTagHelperStartTag(MarkupTagHelperStartTagSyntax node)
     {
-        using (IsHtml())
+        using (HtmlScope())
         {
             base.VisitMarkupTagHelperStartTag(node);
         }
@@ -173,7 +173,7 @@ internal sealed class RazorHtmlWriter : SyntaxWalker
 
     public override void VisitMarkupTagHelperEndTag(MarkupTagHelperEndTagSyntax node)
     {
-        using (IsHtml())
+        using (HtmlScope())
         {
             base.VisitMarkupTagHelperEndTag(node);
         }
@@ -181,7 +181,7 @@ internal sealed class RazorHtmlWriter : SyntaxWalker
 
     public override void VisitMarkupEphemeralTextLiteral(MarkupEphemeralTextLiteralSyntax node)
     {
-        using (IsHtml())
+        using (HtmlScope())
         {
             base.VisitMarkupEphemeralTextLiteral(node);
         }
@@ -189,7 +189,7 @@ internal sealed class RazorHtmlWriter : SyntaxWalker
 
     public override void VisitMarkupTextLiteral(MarkupTextLiteralSyntax node)
     {
-        using (IsHtml())
+        using (HtmlScope())
         {
             base.VisitMarkupTextLiteral(node);
         }
@@ -197,7 +197,7 @@ internal sealed class RazorHtmlWriter : SyntaxWalker
 
     public override void VisitUnclassifiedTextLiteral(UnclassifiedTextLiteralSyntax node)
     {
-        using (IsHtml())
+        using (HtmlScope())
         {
             base.VisitUnclassifiedTextLiteral(node);
         }
@@ -215,12 +215,12 @@ internal sealed class RazorHtmlWriter : SyntaxWalker
         }
     }
 
-    private readonly ref struct WriterStateSaver
+    private readonly ref struct WriterScope
     {
         private readonly RazorHtmlWriter _writer;
         private readonly bool _oldIsWritingHtml;
 
-        public WriterStateSaver(RazorHtmlWriter writer, bool isWritingHtml)
+        public WriterScope(RazorHtmlWriter writer, bool isWritingHtml)
         {
             _writer = writer;
             _oldIsWritingHtml = writer._isWritingHtml;
@@ -233,11 +233,11 @@ internal sealed class RazorHtmlWriter : SyntaxWalker
         }
     }
 
-    private WriterStateSaver IsHtml()
-        => new(this, isWritingHtml: true);
-
-    private WriterStateSaver IsNotHtml()
+    private WriterScope NonHtmlScope()
         => new(this, isWritingHtml: false);
+
+    private WriterScope HtmlScope()
+        => new(this, isWritingHtml: true);
     private void WriteHtmlToken(SyntaxToken token)
     {
         var content = token.Content;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorHtmlWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorHtmlWriter.cs
@@ -16,12 +16,9 @@ namespace Microsoft.AspNetCore.Razor.Language;
 // not all characters in the document are included in the ClassifiedSpans.
 internal sealed class RazorHtmlWriter : SyntaxWalker
 {
-    // 32 '~' characters followed by comment start and end text.
-    private const string KnownText = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~/**/";
-
-    private static ReadOnlyMemory<char> Tildes => KnownText.AsMemory(0, 32);
-    private static ReadOnlyMemory<char> CommentStart => KnownText.AsMemory(32, 2);
-    private static ReadOnlyMemory<char> CommentEnd => KnownText.AsMemory(34, 2);
+    private static ReadOnlyMemory<char> Tildes => "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~".AsMemory(); // 32 '~' characters
+    private static ReadOnlyMemory<char> CommentStart => "/*".AsMemory();
+    private static ReadOnlyMemory<char> CommentEnd => "*/".AsMemory();
 
     private readonly RazorSourceDocument _source;
     private readonly CodeWriter _codeWriter;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorHtmlWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorHtmlWriter.cs
@@ -16,24 +16,9 @@ namespace Microsoft.AspNetCore.Razor.Language;
 // not all characters in the document are included in the ClassifiedSpans.
 internal class RazorHtmlWriter : SyntaxWalker, IDisposable
 {
-    private readonly Action<RazorCommentBlockSyntax> _baseVisitRazorCommentBlock;
-    private readonly Action<RazorMetaCodeSyntax> _baseVisitRazorMetaCode;
-    private readonly Action<MarkupTransitionSyntax> _baseVisitMarkupTransition;
-    private readonly Action<CSharpTransitionSyntax> _baseVisitCSharpTransition;
-    private readonly Action<CSharpEphemeralTextLiteralSyntax> _baseVisitCSharpEphemeralTextLiteral;
-    private readonly Action<CSharpExpressionLiteralSyntax> _baseVisitCSharpExpressionLiteral;
-    private readonly Action<CSharpStatementLiteralSyntax> _baseVisitCSharpStatementLiteral;
-    private readonly Action<MarkupStartTagSyntax> _baseVisitMarkupStartTag;
-    private readonly Action<MarkupEndTagSyntax> _baseVisitMarkupEndTag;
-    private readonly Action<MarkupTagHelperStartTagSyntax> _baseVisitMarkupTagHelperStartTag;
-    private readonly Action<MarkupTagHelperEndTagSyntax> _baseVisitMarkupTagHelperEndTag;
-    private readonly Action<MarkupEphemeralTextLiteralSyntax> _baseVisitMarkupEphemeralTextLiteral;
-    private readonly Action<MarkupTextLiteralSyntax> _baseVisitMarkupTextLiteral;
-    private readonly Action<UnclassifiedTextLiteralSyntax> _baseVisitUnclassifiedTextLiteral;
-
     private readonly PooledObject<ImmutableArray<SourceMapping>.Builder> _sourceMappingsBuilder;
 
-    private bool _isHtml;
+    private bool _isWritingHtml;
     private SourceSpan _lastOriginalSourceSpan = SourceSpan.Undefined;
     private SourceSpan _lastGeneratedSourceSpan = SourceSpan.Undefined;
 
@@ -53,22 +38,7 @@ internal class RazorHtmlWriter : SyntaxWalker, IDisposable
         Source = source;
         Builder = new CodeWriter();
         _sourceMappingsBuilder = ArrayBuilderPool<SourceMapping>.GetPooledObject();
-        _isHtml = true;
-
-        _baseVisitRazorCommentBlock = base.VisitRazorCommentBlock;
-        _baseVisitRazorMetaCode = base.VisitRazorMetaCode;
-        _baseVisitMarkupTransition = base.VisitMarkupTransition;
-        _baseVisitCSharpTransition = base.VisitCSharpTransition;
-        _baseVisitCSharpEphemeralTextLiteral = base.VisitCSharpEphemeralTextLiteral;
-        _baseVisitCSharpExpressionLiteral = base.VisitCSharpExpressionLiteral;
-        _baseVisitCSharpStatementLiteral = base.VisitCSharpStatementLiteral;
-        _baseVisitMarkupStartTag = base.VisitMarkupStartTag;
-        _baseVisitMarkupEndTag = base.VisitMarkupEndTag;
-        _baseVisitMarkupTagHelperStartTag = base.VisitMarkupTagHelperStartTag;
-        _baseVisitMarkupTagHelperEndTag = base.VisitMarkupTagHelperEndTag;
-        _baseVisitMarkupEphemeralTextLiteral = base.VisitMarkupEphemeralTextLiteral;
-        _baseVisitMarkupTextLiteral = base.VisitMarkupTextLiteral;
-        _baseVisitUnclassifiedTextLiteral = base.VisitUnclassifiedTextLiteral;
+        _isWritingHtml = true;
     }
 
     public RazorSourceDocument Source { get; }
@@ -114,72 +84,114 @@ internal class RazorHtmlWriter : SyntaxWalker, IDisposable
 
     public override void VisitRazorCommentBlock(RazorCommentBlockSyntax node)
     {
-        WriteNode(node, isHtml: false, _baseVisitRazorCommentBlock);
+        using (IsNotHtml())
+        {
+            base.VisitRazorCommentBlock(node);
+        }
     }
 
     public override void VisitRazorMetaCode(RazorMetaCodeSyntax node)
     {
-        WriteNode(node, isHtml: false, _baseVisitRazorMetaCode);
+        using (IsNotHtml())
+        {
+            base.VisitRazorMetaCode(node);
+        }
     }
 
     public override void VisitMarkupTransition(MarkupTransitionSyntax node)
     {
-        WriteNode(node, isHtml: false, _baseVisitMarkupTransition);
+        using (IsNotHtml())
+        {
+            base.VisitMarkupTransition(node);
+        }
     }
 
     public override void VisitCSharpTransition(CSharpTransitionSyntax node)
     {
-        WriteNode(node, isHtml: false, _baseVisitCSharpTransition);
+        using (IsNotHtml())
+        {
+            base.VisitCSharpTransition(node);
+        }
     }
 
     public override void VisitCSharpEphemeralTextLiteral(CSharpEphemeralTextLiteralSyntax node)
     {
-        WriteNode(node, isHtml: false, _baseVisitCSharpEphemeralTextLiteral);
+        using (IsNotHtml())
+        {
+            base.VisitCSharpEphemeralTextLiteral(node);
+        }
     }
 
     public override void VisitCSharpExpressionLiteral(CSharpExpressionLiteralSyntax node)
     {
-        WriteNode(node, isHtml: false, _baseVisitCSharpExpressionLiteral);
+        using (IsNotHtml())
+        {
+            base.VisitCSharpExpressionLiteral(node);
+        }
     }
 
     public override void VisitCSharpStatementLiteral(CSharpStatementLiteralSyntax node)
     {
-        WriteNode(node, isHtml: false, _baseVisitCSharpStatementLiteral);
+        using (IsNotHtml())
+        {
+            base.VisitCSharpStatementLiteral(node);
+        }
     }
 
     public override void VisitMarkupStartTag(MarkupStartTagSyntax node)
     {
-        WriteNode(node, isHtml: true, _baseVisitMarkupStartTag);
+        using (IsHtml())
+        {
+            base.VisitMarkupStartTag(node);
+        }
     }
 
     public override void VisitMarkupEndTag(MarkupEndTagSyntax node)
     {
-        WriteNode(node, isHtml: true, _baseVisitMarkupEndTag);
+        using (IsHtml())
+        {
+            base.VisitMarkupEndTag(node);
+        }
     }
 
     public override void VisitMarkupTagHelperStartTag(MarkupTagHelperStartTagSyntax node)
     {
-        WriteNode(node, isHtml: true, _baseVisitMarkupTagHelperStartTag);
+        using (IsHtml())
+        {
+            base.VisitMarkupTagHelperStartTag(node);
+        }
     }
 
     public override void VisitMarkupTagHelperEndTag(MarkupTagHelperEndTagSyntax node)
     {
-        WriteNode(node, isHtml: true, _baseVisitMarkupTagHelperEndTag);
+        using (IsHtml())
+        {
+            base.VisitMarkupTagHelperEndTag(node);
+        }
     }
 
     public override void VisitMarkupEphemeralTextLiteral(MarkupEphemeralTextLiteralSyntax node)
     {
-        WriteNode(node, isHtml: true, _baseVisitMarkupEphemeralTextLiteral);
+        using (IsHtml())
+        {
+            base.VisitMarkupEphemeralTextLiteral(node);
+        }
     }
 
     public override void VisitMarkupTextLiteral(MarkupTextLiteralSyntax node)
     {
-        WriteNode(node, isHtml: true, _baseVisitMarkupTextLiteral);
+        using (IsHtml())
+        {
+            base.VisitMarkupTextLiteral(node);
+        }
     }
 
     public override void VisitUnclassifiedTextLiteral(UnclassifiedTextLiteralSyntax node)
     {
-        WriteNode(node, isHtml: true, _baseVisitUnclassifiedTextLiteral);
+        using (IsHtml())
+        {
+            base.VisitUnclassifiedTextLiteral(node);
+        }
     }
 
     public override void VisitToken(SyntaxToken token)
@@ -188,10 +200,34 @@ internal class RazorHtmlWriter : SyntaxWalker, IDisposable
         WriteToken(token);
     }
 
+    private readonly ref struct WriterStateSaver
+    {
+        private readonly RazorHtmlWriter _writer;
+        private readonly bool _oldIsWritingHtml;
+
+        public WriterStateSaver(RazorHtmlWriter writer, bool isWritingHtml)
+        {
+            _writer = writer;
+            _oldIsWritingHtml = writer._isWritingHtml;
+            writer._isWritingHtml = isWritingHtml;
+        }
+
+        public void Dispose()
+        {
+            _writer._isWritingHtml = _oldIsWritingHtml;
+        }
+    }
+
+    private WriterStateSaver IsHtml()
+        => new(this, isWritingHtml: true);
+
+    private WriterStateSaver IsNotHtml()
+        => new(this, isWritingHtml: false);
+
     private void WriteToken(SyntaxToken token)
     {
         var content = token.Content;
-        if (_isHtml)
+        if (_isWritingHtml)
         {
             WriteDeferredCSharpContent();
 
@@ -306,14 +342,6 @@ internal class RazorHtmlWriter : SyntaxWalker, IDisposable
 
             return sourceText[index] == '>';
         }
-    }
-
-    private void WriteNode<TNode>(TNode node, bool isHtml, Action<TNode> handler) where TNode : SyntaxNode
-    {
-        var old = _isHtml;
-        _isHtml = isHtml;
-        handler(node);
-        _isHtml = old;
     }
 
     public void Dispose()

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorHtmlWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorHtmlWriter.cs
@@ -238,6 +238,7 @@ internal sealed class RazorHtmlWriter : SyntaxWalker
 
     private WriterScope HtmlScope()
         => new(this, isWritingHtml: true);
+
     private void WriteHtmlToken(SyntaxToken token)
     {
         var content = token.Content;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/SourceSpan.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/SourceSpan.cs
@@ -96,18 +96,6 @@ public struct SourceSpan : IEquatable<SourceSpan>
             FilePath);
     }
 
-    internal SourceSpan With(int length, int endCharacterIndex)
-    {
-        return new SourceSpan(
-            FilePath,
-            AbsoluteIndex,
-            LineIndex,
-            CharacterIndex,
-            length,
-            LineCount,
-            endCharacterIndex);
-    }
-
     internal readonly SourceSpan GetZeroWidthEndSpan()
     {
         return new SourceSpan(FilePath, AbsoluteIndex + Length, LineIndex, characterIndex: EndCharacterIndex, length: 0, lineCount: 0, EndCharacterIndex);


### PR DESCRIPTION
This pull request is essentially a rewrite of `RazorHtmlWriter` with the following changes:

- Simply span tracking for source mappings.
- Avoid allocating strings when writing whitespace to the `CodeWriter` and reduce the number of writes.
- Avoid allocating strings when writing C# placeholder content (i.e. `~~~` and `/*~~~~~~~*/`).
- Avoid allocating delegates to base visitor methods.
- Fix a bug this change uncovered in the `CodeWriter.Reader.Read(char[], int, int)` implementation that can cause the `SourceText` produced to be one character shorter than expected.

I recommend reviewing commit-by-commit.

----
CI Build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2736836&view=results
Test Insertion: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/646317
Toolset Run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2736837&view=results