### PR TITLE
Reduce TextDiffer allocations, including LOH

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TextDifferencing/TextDiffer.DiffEdit.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TextDifferencing/TextDiffer.DiffEdit.cs
@@ -14,7 +14,7 @@ internal abstract partial class TextDiffer
         public int? NewTextPosition { get; }
         public int Length { get; }
 
-        private DiffEdit(DiffEditKind kind, int position, int? newTextPosition, int length)
+        public DiffEdit(DiffEditKind kind, int position, int? newTextPosition, int length)
         {
             Kind = kind;
             Position = position;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TextDifferencing/TextDiffer.IntArray.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TextDifferencing/TextDiffer.IntArray.cs
@@ -28,7 +28,7 @@ internal abstract partial class TextDiffer
                 => (array, start, length) = (Array, Start, Length);
         }
 
-        private const int PageSize = 1024 * 80 / sizeof(int);
+        private const int PageSize = 1024 * 64 / sizeof(int);
 
         private Page _page;
         private readonly Page[] _pages;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TextDifferencing/TextDiffer.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TextDifferencing/TextDiffer.cs
@@ -18,6 +18,9 @@ internal abstract partial class TextDiffer
     protected abstract int OldSourceLength { get; }
     protected abstract int NewSourceLength { get; }
 
+    private int _oldSourceOffset;
+    private int _newSourceOffset;
+
     protected abstract bool SourceEqual(int oldSourceIndex, int newSourceIndex);
 
     protected List<DiffEdit> ComputeDiff()
@@ -25,31 +28,43 @@ internal abstract partial class TextDiffer
         var edits = new List<DiffEdit>(capacity: 4);
         var builder = new DiffEditBuilder(edits);
 
+        var lowA = 0;
+        var highA = OldSourceLength;
+        var lowB = 0;
+        var highB = NewSourceLength;
+
+        // Determine the extent of the changes in both texts, as this will allow us
+        // to limit the amount of memory needed in the vf/vr arrays. By doing this though,
+        // we will need to adjust SourceEqual requests to use an appropriate offset.
+        FindChangeExtent(ref lowA, ref highA, ref lowB, ref highB);
+
+        _oldSourceOffset = lowA;
+        _newSourceOffset = lowB;
+
+        var oldSourceLength = highA - lowA;
+        var newSourceLength = highB - lowB;
+
         // Initialize the vectors to use for forward and reverse searches.
-        var max = NewSourceLength + OldSourceLength;
+        var max = newSourceLength + oldSourceLength;
         using var vf = new IntArray((2 * max) + 1);
         using var vr = new IntArray((2 * max) + 1);
 
-        ComputeDiffRecursive(builder, 0, OldSourceLength, 0, NewSourceLength, vf, vr);
+        ComputeDiffRecursive(builder, 0, oldSourceLength, 0, newSourceLength, vf, vr);
+
+        // Update the resultant edits with the appropriate offsets
+        for (var i = 0; i < edits.Count; i++)
+        {
+            var edit = edits[i];
+
+            edits[i] = new DiffEdit(edit.Kind, _oldSourceOffset + edit.Position, _newSourceOffset + edit.NewTextPosition, edit.Length);
+        }
 
         return edits;
     }
 
     private void ComputeDiffRecursive(DiffEditBuilder edits, int lowA, int highA, int lowB, int highB, IntArray vf, IntArray vr)
     {
-        while (lowA < highA && lowB < highB && SourceEqual(lowA, lowB))
-        {
-            // Skip equal text at the start.
-            lowA++;
-            lowB++;
-        }
-
-        while (lowA < highA && lowB < highB && SourceEqual(highA - 1, highB - 1))
-        {
-            // Skip equal text at the end.
-            highA--;
-            highB--;
-        }
+        FindChangeExtent(ref lowA, ref highA, ref lowB, ref highB);
 
         if (lowA == highA)
         {
@@ -79,6 +94,23 @@ internal abstract partial class TextDiffer
 
             // Recursively find the midpoint of the right half.
             ComputeDiffRecursive(edits, middleX, highA, middleY, highB, vf, vr);
+        }
+    }
+
+    private void FindChangeExtent(ref int lowA, ref int highA, ref int lowB, ref int highB)
+    {
+        while (lowA < highA && lowB < highB && SourceEqualUsingOffset(lowA, lowB))
+        {
+            // Skip equal text at the start.
+            lowA++;
+            lowB++;
+        }
+
+        while (lowA < highA && lowB < highB && SourceEqualUsingOffset(highA - 1, highB - 1))
+        {
+            // Skip equal text at the end.
+            highA--;
+            highB--;
         }
     }
 
@@ -126,7 +158,7 @@ internal abstract partial class TextDiffer
                 var y = x - k;
 
                 // Traverse diagonal if possible.
-                while (x < highA && y < highB && SourceEqual(x, y))
+                while (x < highA && y < highB && SourceEqualUsingOffset(x, y))
                 {
                     x++;
                     y++;
@@ -169,7 +201,7 @@ internal abstract partial class TextDiffer
                 var y = x - k;
 
                 // Traverse diagonal if possible.
-                while (x > lowA && y > lowB && SourceEqual(x - 1, y - 1))
+                while (x > lowA && y > lowB && SourceEqualUsingOffset(x - 1, y - 1))
                 {
                     x--;
                     y--;
@@ -195,4 +227,7 @@ internal abstract partial class TextDiffer
 
         throw Assumes.NotReachable();
     }
+
+    private bool SourceEqualUsingOffset(int oldSourceIndex, int newSourceIndex)
+        => SourceEqual(oldSourceIndex + _sourceOffsetA, newSourceIndex + _newSourceOffset);
 }


### PR DESCRIPTION
TextDiffer.ComputeDiff shows as 1.3% of allocations in the razor speedometer scrolling and typing test. There are two issues:

1) The IntArray class was using too large a page size when used in conjunction with System.Buffers.ArrayPool. It was indicating it wanted an 80KB buffer, and ArrayPool allocates it's pool entries on powers of 2, so it was giving back an 128KB array, which goes to the LOH. The fix is to request a 64 KB buffer.

2) The IntArrays were being constructed over unnecessarilly large ranges. If we instead prime the pump by detemining an initial changed extent, we can request significantly less allocated space during the typing scenario (reduces the requested array size from the buffer size to just the changed range, tyipcally only a couple characters)

Reducing the size of the vf/vr arrays did require a redirection to the SourceEqual method in the derived classes, as they don't know of that concept.

![image](https://github.com/user-attachments/assets/17a5aff7-29d2-4f4f-838c-c36ba640853c)