### PR TITLE
Avoid concurrent generation of the html document within a razor code document.

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocument.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocument.cs
@@ -24,6 +24,7 @@ public sealed partial class RazorCodeDocument
     public RazorFileKind FileKind => ParserOptions.FileKind;
 
     private readonly PropertyTable _properties = new();
+    private readonly object _htmlDocumentLock = new();
 
     private RazorCodeDocument(
         RazorSourceDocument source,
@@ -182,8 +183,14 @@ public sealed partial class RazorCodeDocument
             return result;
         }
 
-        result = RazorHtmlWriter.GetHtmlDocument(this);
-        _properties.HtmlDocument.SetValue(result);
+        lock (_htmlDocumentLock)
+        {
+            if (!_properties.HtmlDocument.TryGetValue(out result))
+            {
+                result = RazorHtmlWriter.GetHtmlDocument(this);
+                _properties.HtmlDocument.SetValue(result);
+            }
+        }
 
         return result;
     }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocument.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocument.cs
@@ -183,6 +183,7 @@ public sealed partial class RazorCodeDocument
             return result;
         }
 
+        // Perf: Avoid concurrent requests generating the same html document
         lock (_htmlDocumentLock)
         {
             if (!_properties.HtmlDocument.TryGetValue(out result))

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocument.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocument.cs
@@ -24,7 +24,7 @@ public sealed partial class RazorCodeDocument
     public RazorFileKind FileKind => ParserOptions.FileKind;
 
     private readonly PropertyTable _properties = new();
-    private readonly object _htmlDocumentLock = new();
+    private readonly Lazy<RazorHtmlDocument> _lazyHtmlDocument;
 
     private RazorCodeDocument(
         RazorSourceDocument source,
@@ -40,6 +40,7 @@ public sealed partial class RazorCodeDocument
         CodeGenerationOptions = codeGenerationOptions ?? RazorCodeGenerationOptions.Default;
 
         _properties = properties ?? new();
+        _lazyHtmlDocument = new(() => CreateHtmlDocument());
     }
 
     public static RazorCodeDocument Create(
@@ -177,20 +178,17 @@ public sealed partial class RazorCodeDocument
     }
 
     internal RazorHtmlDocument GetHtmlDocument()
+        => _lazyHtmlDocument.Value;
+
+    private RazorHtmlDocument CreateHtmlDocument()
     {
         if (_properties.HtmlDocument.TryGetValue(out var result))
         {
             return result;
         }
 
-        lock (_htmlDocumentLock)
-        {
-            if (!_properties.HtmlDocument.TryGetValue(out result))
-            {
-                result = RazorHtmlWriter.GetHtmlDocument(this);
-                _properties.HtmlDocument.SetValue(result);
-            }
-        }
+        result = RazorHtmlWriter.GetHtmlDocument(this);
+        _properties.HtmlDocument.SetValue(result);
 
         return result;
     }


### PR DESCRIPTION
I see about 40% of edits within an html scope generate the html document multiple times, primarily due to concurrent RazorCodeCode.GetHtmlDocument requests from the callstacks below (measured on release bits without a debugger attached). As these requests are on the same code document, they can be collapsed into a single request.

*** callstack 1 ***
RazorCodeDocument.GetHtmlDocument
RazorCodeDocumentExtensions.GetHtmlSourceText
GeneratedDocumentSynchronizer.DocumentProcessed
OpenDocumentGenerator.ProcessBatchAsync

*** callstack 2 ***
RazorCodeDocument.GetHtmlDocument
IDocumentMappingServiceExtensions.GetPositionInfo
DelegatedCompletionListProvider.GetCompletionListAsync CompletionListProvider.GetCompletionListCoreAsync