### PR TITLE
Apply post-merge feedback from https://github.com/dotnet/razor/pull/11983

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TextDifferencing/TextDiffer.DiffEdit.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TextDifferencing/TextDiffer.DiffEdit.cs
@@ -14,7 +14,7 @@ internal abstract partial class TextDiffer
         public int? NewTextPosition { get; }
         public int Length { get; }
 
-        public DiffEdit(DiffEditKind kind, int position, int? newTextPosition, int length)
+        private DiffEdit(DiffEditKind kind, int position, int? newTextPosition, int length)
         {
             Kind = kind;
             Position = position;
@@ -46,5 +46,8 @@ internal abstract partial class TextDiffer
 
         public static DiffEdit Delete(int position, int length = 1)
             => new(DiffEditKind.Delete, position, newTextPosition: null, length);
+
+        public DiffEdit Offset(int positionOffset, int newTextPositionOffset)
+            => new(Kind, positionOffset + Position, newTextPositionOffset + NewTextPosition, Length);
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TextDifferencing/TextDiffer.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TextDifferencing/TextDiffer.cs
@@ -54,9 +54,7 @@ internal abstract partial class TextDiffer
         // Update the resultant edits with the appropriate offsets
         for (var i = 0; i < edits.Count; i++)
         {
-            var edit = edits[i];
-
-            edits[i] = new DiffEdit(edit.Kind, _oldSourceOffset + edit.Position, _newSourceOffset + edit.NewTextPosition, edit.Length);
+            edits[i] = edits[i].Offset(_oldSourceOffset, _newSourceOffset);
         }
 
         return edits;


### PR DESCRIPTION
Specifically, provide a factory method for offseting a DiffEdit instead of exposing the DiffEdit ctor