### PR TITLE
Allow Razor completion items on deletion

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
@@ -263,12 +263,6 @@ internal class RazorCompletionListProvider(
             return true;
         }
 
-        if (vsCompletionContext.InvokeKind == VSInternalCompletionInvokeKind.Deletion)
-        {
-            // We do not support providing completions on delete.
-            return false;
-        }
-
         return true;
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/RazorCompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/RazorCompletionListProviderTest.cs
@@ -62,7 +62,7 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
         ];
 
     [Fact]
-    public void IsApplicableTriggerContext_Deletion_ReturnsFalse()
+    public void IsApplicableTriggerContext_Deletion_ReturnsTrue()
     {
         // Arrange
         var completionContext = new VSInternalCompletionContext()
@@ -74,7 +74,7 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
         var result = RazorCompletionListProvider.IsApplicableTriggerContext(completionContext);
 
         // Assert
-        Assert.False(result);
+        Assert.True(result);
     }
 
     [Fact]


### PR DESCRIPTION
﻿### Summary of the changes

-We had old code that prevented us from even trying to return Razor completion items on deletion. It seems to work well now, so I removed that condition. 

Fixes:
https://github.com/dotnet/razor/issues/11565