### PR TITLE
Compiler: Reduce allocations and do less work when visiting intermediate nodes

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Components/ComponentWhitespacePassTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Components/ComponentWhitespacePassTest.cs
@@ -54,6 +54,8 @@ public class ComponentWhitespacePassTest
 
         // Assert
         var method = documentNode.FindPrimaryMethod();
+        Assert.NotNull(method);
+
         var child = Assert.IsType<MarkupElementIntermediateNode>(Assert.Single(method.Children));
         Assert.Equal("span", child.TagName);
     }
@@ -74,7 +76,10 @@ public class ComponentWhitespacePassTest
         Pass.Execute(document, documentNode);
 
         // Assert
-        var parentElement = Assert.IsType<MarkupElementIntermediateNode>(Assert.Single(documentNode.FindPrimaryMethod().Children));
+        var method = documentNode.FindPrimaryMethod();
+        Assert.NotNull(method);
+
+        var parentElement = Assert.IsType<MarkupElementIntermediateNode>(Assert.Single(method.Children));
         var childElement = Assert.IsType<MarkupElementIntermediateNode>(Assert.Single(parentElement.Children));
         Assert.Equal("child", childElement.TagName);
         Assert.Collection(childElement.Children,
@@ -102,7 +107,10 @@ public class ComponentWhitespacePassTest
         Pass.Execute(document, documentNode);
 
         // Assert
-        Assert.Collection(documentNode.FindPrimaryMethod().Children,
+        var method = documentNode.FindPrimaryMethod();
+        Assert.NotNull(method);
+
+        Assert.Collection(method.Children,
             node => Assert.IsType<MarkupElementIntermediateNode>(node),
             node => Assert.IsType<HtmlContentIntermediateNode>(node),
             node => Assert.IsType<MarkupElementIntermediateNode>(node));
@@ -128,7 +136,10 @@ public class ComponentWhitespacePassTest
         Pass.Execute(document, documentNode);
 
         // Assert
-        var parentElement = Assert.IsType<MarkupElementIntermediateNode>(Assert.Single(documentNode.FindPrimaryMethod().Children));
+        var method = documentNode.FindPrimaryMethod();
+        Assert.NotNull(method);
+
+        var parentElement = Assert.IsType<MarkupElementIntermediateNode>(Assert.Single(method.Children));
         Assert.Collection(parentElement.Children,
             node =>
             {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Extensions/DefaultTagHelperOptimizationPassTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Extensions/DefaultTagHelperOptimizationPassTest.cs
@@ -44,6 +44,8 @@ public class DefaultTagHelperOptimizationPassTest : RazorProjectEngineTestBase
         var documentNode = processor.GetDocumentNode();
 
         var @class = documentNode.FindPrimaryClass();
+        Assert.NotNull(@class);
+
         Assert.IsType<DefaultTagHelperRuntimeIntermediateNode>(@class.Children[0]);
 
         var fieldDeclaration = Assert.IsType<FieldDeclarationIntermediateNode>(@class.Children[1]);

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentBindLoweringPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentBindLoweringPass.cs
@@ -42,17 +42,18 @@ internal class ComponentBindLoweringPass : ComponentIntermediateNodePassBase, IR
         }
 
         // For each @bind *usage* we need to rewrite the tag helper node to map to basic constructs.
+        using var _ = ReferenceEqualityHashSetPool<IntermediateNode>.GetPooledObject(out var parents);
         var references = documentNode.FindDescendantReferences<TagHelperDirectiveAttributeIntermediateNode>();
         var parameterReferences = documentNode.FindDescendantReferences<TagHelperDirectiveAttributeParameterIntermediateNode>();
 
-        var parents = new HashSet<IntermediateNode>();
-        for (var i = 0; i < references.Count; i++)
+        foreach (var reference in references)
         {
-            parents.Add(references[i].Parent);
+            parents.Add(reference.Parent);
         }
-        for (var i = 0; i < parameterReferences.Count; i++)
+
+        foreach (var parameterReference in parameterReferences)
         {
-            parents.Add(parameterReferences[i].Parent);
+            parents.Add(parameterReference.Parent);
         }
 
         foreach (var parent in parents)
@@ -65,9 +66,9 @@ internal class ComponentBindLoweringPass : ComponentIntermediateNodePassBase, IR
         // We don't have to worry about duplicate bound attributes in the same element
         // like, <Foo @bind="bar" @bind="bar" />, because IR lowering takes care of that.
         var bindEntries = new Dictionary<(IntermediateNode, string), BindEntry>();
-        for (var i = 0; i < references.Count; i++)
+
+        foreach (var reference in references)
         {
-            var reference = references[i];
             var parent = reference.Parent;
             var node = (TagHelperDirectiveAttributeIntermediateNode)reference.Node;
 
@@ -85,11 +86,10 @@ internal class ComponentBindLoweringPass : ComponentIntermediateNodePassBase, IR
 
         // Do a pass to look for (@bind:get, @bind:set) pairs as this alternative form might have been used
         // to define the binding.
-        for (var i = 0; i < parameterReferences.Count; i++)
+        foreach (var parameterReference in parameterReferences)
         {
-            var reference = parameterReferences[i];
-            var parent = reference.Parent;
-            var node = (TagHelperDirectiveAttributeParameterIntermediateNode)reference.Node;
+            var parent = parameterReference.Parent;
+            var node = (TagHelperDirectiveAttributeParameterIntermediateNode)parameterReference.Node;
 
             if (!parent.Children.Contains(node))
             {
@@ -105,9 +105,9 @@ internal class ComponentBindLoweringPass : ComponentIntermediateNodePassBase, IR
                         node.Source,
                         node.AttributeName));
                 }
-                if (!bindEntries.TryGetValue((reference.Parent, node.AttributeNameWithoutParameter), out var existingEntry))
+                if (!bindEntries.TryGetValue((parameterReference.Parent, node.AttributeNameWithoutParameter), out var existingEntry))
                 {
-                    bindEntries[(reference.Parent, node.AttributeNameWithoutParameter)] = new BindEntry(reference);
+                    bindEntries[(parameterReference.Parent, node.AttributeNameWithoutParameter)] = new BindEntry(parameterReference);
                 }
                 else
                 {
@@ -119,9 +119,8 @@ internal class ComponentBindLoweringPass : ComponentIntermediateNodePassBase, IR
         }
 
         // Now collect all the parameterized attributes and store them along with their corresponding @bind or @bind-* attributes.
-        for (var i = 0; i < parameterReferences.Count; i++)
+        foreach (var parameterReference in parameterReferences)
         {
-            var parameterReference = parameterReferences[i];
             var parent = parameterReference.Parent;
             var node = (TagHelperDirectiveAttributeParameterIntermediateNode)parameterReference.Node;
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentBindLoweringPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentBindLoweringPass.cs
@@ -1097,12 +1097,12 @@ internal class ComponentBindLoweringPass : ComponentIntermediateNodePassBase, IR
     private static IntermediateToken GetAttributeContent(IntermediateNode node)
     {
         var nodes = node.FindDescendantNodes<TemplateIntermediateNode>();
-        var template = nodes.Count > 0 ? nodes[0] : default;
+        var template = nodes.Length > 0 ? nodes[0] : default;
         if (template != null)
         {
             // See comments in TemplateDiagnosticPass
             node.AddDiagnostic(ComponentDiagnosticFactory.Create_TemplateInvalidLocation(template.Source));
-            return new IntermediateToken() { Kind = TokenKind.CSharp, Content = string.Empty, };
+            return new IntermediateToken() { Kind = TokenKind.CSharp, Content = string.Empty };
         }
 
         if (node.Children[0] is HtmlContentIntermediateNode htmlContentNode)

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentChildContentDiagnosticPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentChildContentDiagnosticPass.cs
@@ -50,19 +50,16 @@ internal class ComponentChildContentDiagnosticPass : ComponentIntermediateNodePa
             if (node.IsParameterized)
             {
                 var ancestors = Ancestors;
-
                 var parentComponent = (ComponentIntermediateNode)ancestors[0];
-                ancestors = ancestors[1..];
 
-                while (!ancestors.IsEmpty)
+                // Skip the immediate parent component as we've already validated against it.
+                // Loop to ancestors.Length - 1 because we're always checking pairs.
+
+                for (var i = 1; i < ancestors.Length - 1; i++)
                 {
-                    if (ancestors is
-                        [
-                            ComponentChildContentIntermediateNode { IsParameterized: true } ancestor,
-                            ComponentIntermediateNode ancestorParentComponent,
-                            ..
-                        ]
-                        && ancestor.ParameterName == node.ParameterName)
+                    if (ancestors[i] is ComponentChildContentIntermediateNode { IsParameterized: true } ancestor &&
+                        ancestor.ParameterName == node.ParameterName &&
+                        ancestors[i + 1] is ComponentIntermediateNode ancestorParentComponent)
                     {
                         // Duplicate name. We report an error because this will almost certainly also lead to an error
                         // from the C# compiler that's way less clear.
@@ -73,8 +70,6 @@ internal class ComponentChildContentDiagnosticPass : ComponentIntermediateNodePa
                             childContent2: ancestor,
                             component2: ancestorParentComponent));
                     }
-
-                    ancestors = ancestors[1..];
                 }
             }
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentComplexAttributeContentPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentComplexAttributeContentPass.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
@@ -25,10 +23,9 @@ internal class ComponentComplexAttributeContentPass : ComponentIntermediateNodeP
             return;
         }
 
-        var nodes = documentNode.FindDescendantNodes<TagHelperIntermediateNode>();
-        for (var i = 0; i < nodes.Count; i++)
+        foreach (var node in documentNode.FindDescendantNodes<TagHelperIntermediateNode>())
         {
-            ProcessAttributes(nodes[i]);
+            ProcessAttributes(node);
         }
     }
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentCssScopePass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentCssScopePass.cs
@@ -24,21 +24,15 @@ internal class ComponentCssScopePass : ComponentIntermediateNodePassBase, IRazor
             return;
         }
 
-        var nodes = documentNode.FindDescendantNodes<MarkupElementIntermediateNode>();
-        for (var i = 0; i < nodes.Count; i++)
+        foreach (var node in documentNode.FindDescendantNodes<MarkupElementIntermediateNode>())
         {
-            ProcessElement(nodes[i], cssScope);
+            // Add a minimized attribute whose name is simply the CSS scope
+            node.Children.Add(new HtmlAttributeIntermediateNode
+            {
+                AttributeName = cssScope,
+                Prefix = cssScope,
+                Suffix = string.Empty,
+            });
         }
-    }
-
-    private void ProcessElement(MarkupElementIntermediateNode node, string cssScope)
-    {
-        // Add a minimized attribute whose name is simply the CSS scope
-        node.Children.Add(new HtmlAttributeIntermediateNode
-        {
-            AttributeName = cssScope,
-            Prefix = cssScope,
-            Suffix = string.Empty,
-        });
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentDesignTimeNodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentDesignTimeNodeWriter.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -104,7 +102,7 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
         WriteCSharpExpressionInnards(context, node);
     }
 
-    private void WriteCSharpExpressionInnards(CodeRenderingContext context, CSharpExpressionIntermediateNode node, string type = null)
+    private void WriteCSharpExpressionInnards(CodeRenderingContext context, CSharpExpressionIntermediateNode node, string? type = null)
     {
         if (node.Children.Count == 0)
         {
@@ -191,7 +189,7 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
             }
         }
 
-        IDisposable linePragmaScope = null;
+        IDisposable? linePragmaScope = null;
         if (node.Source != null)
         {
             if (!isWhitespaceStatement)
@@ -372,7 +370,7 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
 
         // We might need a scope for inferring types,
         CodeWriterExtensions.CSharpCodeWritingScope? typeInferenceCaptureScope = null;
-        string typeInferenceLocalName = null;
+        string? typeInferenceLocalName = null;
 
         var suppressTypeInference = ShouldSuppressTypeInferenceCall(node);
         if (suppressTypeInference)
@@ -563,7 +561,7 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
         // the "usings directive is unnecessary" message.
         // Looks like:
         // __o = typeof(SomeNamespace.SomeComponent);
-        using (context.CodeWriter.BuildLinePragma(node.Source.Value, context))
+        using (context.CodeWriter.BuildLinePragma(node.Source.AssumeNotNull(), context))
         {
             context.CodeWriter.Write(DesignTimeVariable);
             context.CodeWriter.Write(" = ");
@@ -677,7 +675,7 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
         context.CodeWriter.WriteLine();
     }
 
-    private void WritePropertyAccess(CodeRenderingContext context, ComponentAttributeIntermediateNode node, ComponentIntermediateNode componentNode, string typeInferenceLocalName, bool shouldWriteBL0005Disable, out bool wrotePropertyAccess)
+    private void WritePropertyAccess(CodeRenderingContext context, ComponentAttributeIntermediateNode node, ComponentIntermediateNode componentNode, string? typeInferenceLocalName, bool shouldWriteBL0005Disable, out bool wrotePropertyAccess)
     {
         wrotePropertyAccess = false;
         if (node?.TagHelper?.Name is null || node.OriginalAttributeSpan is null)

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentDocumentClassifierPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentDocumentClassifierPass.cs
@@ -1,9 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
@@ -117,10 +116,10 @@ internal class ComponentDocumentClassifierPass : DocumentClassifierPassBase
             var directiveType = razorLanguageVersion >= RazorLanguageVersion.Version_6_0
                 ? ComponentConstrainedTypeParamDirective.Directive
                 : ComponentTypeParamDirective.Directive;
-            var typeParamReferences = documentNode.FindDirectiveReferences(directiveType);
-            for (var i = 0; i < typeParamReferences.Count; i++)
+
+            foreach (var typeParamReference in documentNode.FindDirectiveReferences(directiveType))
             {
-                var typeParamNode = (DirectiveIntermediateNode)typeParamReferences[i].Node;
+                var typeParamNode = (DirectiveIntermediateNode)typeParamReference.Node;
                 if (typeParamNode.HasDiagnostics)
                 {
                     continue;
@@ -154,7 +153,7 @@ internal class ComponentDocumentClassifierPass : DocumentClassifierPassBase
         }
     }
 
-    private bool TryComputeClassName(RazorCodeDocument codeDocument, out string className)
+    private static bool TryComputeClassName(RazorCodeDocument codeDocument, [NotNullWhen(true)] out string? className)
     {
         className = null;
         if (codeDocument.Source.FilePath == null || codeDocument.Source.RelativePath == null)

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentEventHandlerLoweringPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentEventHandlerLoweringPass.cs
@@ -172,8 +172,7 @@ internal class ComponentEventHandlerLoweringPass : ComponentIntermediateNodePass
         // correct context for intellisense when typing in the attribute.
         var eventArgsType = node.TagHelper.GetEventArgsType();
 
-        using var tokens = new PooledArrayBuilder<IntermediateToken>(original.Length + 2);
-        tokens.SetCapacityIfLarger(original.Length + 2);
+        using var tokens = new PooledArrayBuilder<IntermediateToken>(capacity: original.Length + 2);
 
         tokens.Add(
             new IntermediateToken()

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentEventHandlerLoweringPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentEventHandlerLoweringPass.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
@@ -33,19 +31,20 @@ internal class ComponentEventHandlerLoweringPass : ComponentIntermediateNodePass
         // For each event handler *usage* we need to rewrite the tag helper node to map to basic constructs.
         // Each usage will be represented by a tag helper property that is a descendant of either
         // a component or element.
-        var references = documentNode.FindDescendantReferences<TagHelperDirectiveAttributeIntermediateNode>();
         using var _ = ReferenceEqualityHashSetPool<IntermediateNode>.GetPooledObject(out var parents);
+        var references = documentNode.FindDescendantReferences<TagHelperDirectiveAttributeIntermediateNode>();
 
-        for (var i = 0; i < references.Count; i++)
+        foreach (var reference in references)
         {
-            parents.Add(references[i].Parent);
+            parents.Add(reference.Parent);
         }
 
         // We need to do something similar for directive attribute parameters like @onclick:preventDefault.
         var parameterReferences = documentNode.FindDescendantReferences<TagHelperDirectiveAttributeParameterIntermediateNode>();
-        for (var i = 0; i < parameterReferences.Count; i++)
+
+        foreach (var parameterReference in parameterReferences)
         {
-            parents.Add(parameterReferences[i].Parent);
+            parents.Add(parameterReference.Parent);
         }
 
         foreach (var parent in parents)
@@ -53,9 +52,8 @@ internal class ComponentEventHandlerLoweringPass : ComponentIntermediateNodePass
             ProcessDuplicates(parent);
         }
 
-        for (var i = 0; i < references.Count; i++)
+        foreach (var reference in references)
         {
-            var reference = references[i];
             var node = (TagHelperDirectiveAttributeIntermediateNode)reference.Node;
 
             if (!reference.Parent.Children.Contains(node))
@@ -70,12 +68,11 @@ internal class ComponentEventHandlerLoweringPass : ComponentIntermediateNodePass
             }
         }
 
-        for (var i = 0; i < parameterReferences.Count; i++)
+        foreach (var parameterReference in parameterReferences)
         {
-            var reference = parameterReferences[i];
-            var node = (TagHelperDirectiveAttributeParameterIntermediateNode)reference.Node;
+            var node = (TagHelperDirectiveAttributeParameterIntermediateNode)parameterReference.Node;
 
-            if (!reference.Parent.Children.Contains(node))
+            if (!parameterReference.Parent.Children.Contains(node))
             {
                 // This node was removed as a duplicate, skip it.
                 continue;
@@ -83,7 +80,7 @@ internal class ComponentEventHandlerLoweringPass : ComponentIntermediateNodePass
 
             if (node.TagHelper.IsEventHandlerTagHelper())
             {
-                reference.Replace(RewriteParameterUsage(node));
+                parameterReference.Replace(RewriteParameterUsage(node));
             }
         }
     }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentGenericTypePass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentGenericTypePass.cs
@@ -413,9 +413,9 @@ internal class ComponentGenericTypePass : ComponentIntermediateNodePassBase, IRa
 
         private void CreateTypeInferenceMethod(DocumentIntermediateNode documentNode, ComponentIntermediateNode node, List<CascadingGenericTypeParameter>? receivesCascadingGenericTypes)
         {
-            var @namespace = documentNode.FindPrimaryNamespace().Content;
+            var @namespace = documentNode.FindPrimaryNamespace().AssumeNotNull().Content;
             @namespace = string.IsNullOrEmpty(@namespace) ? "__Blazor" : "__Blazor." + @namespace;
-            @namespace += "." + documentNode.FindPrimaryClass().ClassName;
+            @namespace += "." + documentNode.FindPrimaryClass().AssumeNotNull().ClassName;
 
             var genericTypeConstraints = node.Component.BoundAttributes
                 .Where(t => t.Metadata.ContainsKey(ComponentMetadata.Component.TypeParameterConstraintsKey))

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentGenericTypePass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentGenericTypePass.cs
@@ -175,8 +175,13 @@ internal class ComponentGenericTypePass : ComponentIntermediateNodePassBase, IRa
             List<CascadingGenericTypeParameter>? receivesCascadingGenericTypes = null;
             foreach (var uncoveredBindingKey in bindings.Keys.ToList())
             {
-                foreach (var candidateAncestor in Ancestors.OfType<ComponentIntermediateNode>())
+                foreach (var ancestor in Ancestors)
                 {
+                    if (ancestor is not ComponentIntermediateNode candidateAncestor)
+                    {
+                        continue;
+                    }
+
                     if (candidateAncestor.ProvidesCascadingGenericTypes != null
                         && candidateAncestor.ProvidesCascadingGenericTypes.TryGetValue(uncoveredBindingKey, out var genericTypeProvider))
                     {
@@ -247,7 +252,7 @@ internal class ComponentGenericTypePass : ComponentIntermediateNodePassBase, IRa
             // Next we need to generate a type inference 'method' node. This represents a method that we will codegen that
             // contains all of the operations on the render tree building. Calling a method to operate on the builder
             // will allow the C# compiler to perform type inference.
-            var documentNode = (DocumentIntermediateNode)Ancestors[Ancestors.Count - 1];
+            var documentNode = (DocumentIntermediateNode)Ancestors[^1];
             CreateTypeInferenceMethod(documentNode, node, receivesCascadingGenericTypes);
         }
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentKeyLoweringPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentKeyLoweringPass.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
 namespace Microsoft.AspNetCore.Razor.Language.Components;
@@ -28,9 +26,9 @@ internal class ComponentKeyLoweringPass : ComponentIntermediateNodePassBase, IRa
         }
 
         var references = documentNode.FindDescendantReferences<TagHelperDirectiveAttributeIntermediateNode>();
-        for (var i = 0; i < references.Count; i++)
+
+        foreach (var reference in references)
         {
-            var reference = references[i];
             var node = (TagHelperDirectiveAttributeIntermediateNode)reference.Node;
 
             if (node.TagHelper.IsKeyTagHelper())
@@ -53,9 +51,9 @@ internal class ComponentKeyLoweringPass : ComponentIntermediateNodePassBase, IRa
         return new SetKeyIntermediateNode(keyValueToken);
     }
 
-    private IntermediateToken DetermineKeyValueToken(TagHelperDirectiveAttributeIntermediateNode attributeNode)
+    private IntermediateToken? DetermineKeyValueToken(TagHelperDirectiveAttributeIntermediateNode attributeNode)
     {
-        IntermediateToken foundToken = null;
+        IntermediateToken? foundToken = null;
 
         if (attributeNode.Children.Count == 1)
         {

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentLayoutDirectivePass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentLayoutDirectivePass.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
-using System;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
@@ -21,7 +18,7 @@ internal class ComponentLayoutDirectivePass : IntermediateNodePassBase, IRazorDi
         }
 
         var directives = documentNode.FindDirectiveReferences(ComponentLayoutDirective.Directive);
-        if (directives.Count == 0)
+        if (directives.Length == 0)
         {
             return;
         }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentLoweringPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentLoweringPass.cs
@@ -34,9 +34,9 @@ internal class ComponentLoweringPass : ComponentIntermediateNodePassBase, IRazor
         // APIs.
         var usings = documentNode.FindDescendantNodes<UsingDirectiveIntermediateNode>();
         var references = documentNode.FindDescendantReferences<TagHelperIntermediateNode>();
-        for (var i = 0; i < references.Count; i++)
+
+        foreach (var reference in references)
         {
-            var reference = references[i];
             var node = (TagHelperIntermediateNode)reference.Node;
             if (node.TagHelpers.Any(t => t.IsChildContentTagHelper))
             {
@@ -46,9 +46,9 @@ internal class ComponentLoweringPass : ComponentIntermediateNodePassBase, IRazor
 
             // The element didn't match any child content descriptors. Look for any matching component descriptors.
             var count = 0;
-            for (var j = 0; j < node.TagHelpers.Count; j++)
+            foreach (var tagHelper in node.TagHelpers)
             {
-                if (node.TagHelpers[j].IsComponentTagHelper)
+                if (tagHelper.IsComponentTagHelper)
                 {
                     // Only allow a single component tag helper per element. If there are multiple, we'll just consider
                     // the first one and ignore the others.

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentPageDirectivePass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentPageDirectivePass.cs
@@ -29,15 +29,14 @@ internal class ComponentPageDirectivePass : IntermediateNodePassBase, IRazorDire
         }
 
         var directives = documentNode.FindDirectiveReferences(ComponentPageDirective.Directive);
-        if (directives.Count == 0)
+        if (directives.Length == 0)
         {
             return;
         }
 
         // We don't allow @page directives in imports
-        for (var i = 0; i < directives.Count; i++)
+        foreach (var directive in directives)
         {
-            var directive = directives[i];
             if (codeDocument.FileKind.IsComponentImport() || directive.Node.IsImported)
             {
                 directive.Node.AddDiagnostic(ComponentDiagnosticFactory.CreatePageDirective_CannotBeImported(directive.Node.Source.GetValueOrDefault()));
@@ -54,9 +53,9 @@ internal class ComponentPageDirectivePass : IntermediateNodePassBase, IRazorDire
             }
         }
 
-        for (var i = 0; i < directives.Count; i++)
+        foreach (var directive in directives)
         {
-            var pageDirective = (DirectiveIntermediateNode)directives[i].Node;
+            var pageDirective = (DirectiveIntermediateNode)directive.Node;
 
             // The parser also adds errors for invalid syntax, we just need to not crash.
             var routeToken = pageDirective.Tokens.First();

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentReferenceCaptureLoweringPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentReferenceCaptureLoweringPass.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
 namespace Microsoft.AspNetCore.Razor.Language.Components;
@@ -28,9 +26,9 @@ internal class ComponentReferenceCaptureLoweringPass : ComponentIntermediateNode
         }
 
         var references = documentNode.FindDescendantReferences<TagHelperDirectiveAttributeIntermediateNode>();
-        for (var i = 0; i < references.Count; i++)
+
+        foreach (var reference in references)
         {
-            var reference = references[i];
             var node = (TagHelperDirectiveAttributeIntermediateNode)reference.Node;
 
             if (node.TagHelper.IsRefTagHelper())
@@ -63,9 +61,9 @@ internal class ComponentReferenceCaptureLoweringPass : ComponentIntermediateNode
         }
     }
 
-    private IntermediateToken DetermineIdentifierToken(TagHelperDirectiveAttributeIntermediateNode attributeNode)
+    private IntermediateToken? DetermineIdentifierToken(TagHelperDirectiveAttributeIntermediateNode attributeNode)
     {
-        IntermediateToken foundToken = null;
+        IntermediateToken? foundToken = null;
 
         if (attributeNode.Children.Count == 1)
         {

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentRenderModeDirectivePass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentRenderModeDirectivePass.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-#nullable enable
 
 using System.Diagnostics;
 using System.Linq;
@@ -22,13 +21,13 @@ internal sealed class ComponentRenderModeDirectivePass : IntermediateNodePassBas
         }
 
         var directives = documentNode.FindDirectiveReferences(ComponentRenderModeDirective.Directive);
-        if (directives.Count == 0)
+        if (directives.Length == 0)
         {
             return;
         }
 
         // We don't need to worry about duplicate attributes as we have already replaced any multiples with MalformedDirective
-        Debug.Assert(directives.Count == 1);
+        Debug.Assert(directives.Length == 1);
 
         var child = ((DirectiveIntermediateNode)directives[0].Node).Children.FirstOrDefault();
         if (child == null)

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentRuntimeNodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentRuntimeNodeWriter.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentSplatLoweringPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentSplatLoweringPass.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
@@ -22,15 +19,9 @@ internal class ComponentSplatLoweringPass : ComponentIntermediateNodePassBase, I
         }
 
         var references = documentNode.FindDescendantReferences<TagHelperDirectiveAttributeIntermediateNode>();
-        var parents = new HashSet<IntermediateNode>();
-        for (var i = 0; i < references.Count; i++)
-        {
-            parents.Add(references[i].Parent);
-        }
 
-        for (var i = 0; i < references.Count; i++)
+        foreach (var reference in references)
         {
-            var reference = references[i];
             var node = (TagHelperDirectiveAttributeIntermediateNode)reference.Node;
             if (node.TagHelper.IsSplatTagHelper())
             {

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentSplatLoweringPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentSplatLoweringPass.cs
@@ -18,9 +18,7 @@ internal class ComponentSplatLoweringPass : ComponentIntermediateNodePassBase, I
             return;
         }
 
-        var references = documentNode.FindDescendantReferences<TagHelperDirectiveAttributeIntermediateNode>();
-
-        foreach (var reference in references)
+        foreach (var reference in documentNode.FindDescendantReferences<TagHelperDirectiveAttributeIntermediateNode>())
         {
             var node = (TagHelperDirectiveAttributeIntermediateNode)reference.Node;
             if (node.TagHelper.IsSplatTagHelper())

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentTemplateDiagnosticPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentTemplateDiagnosticPass.cs
@@ -54,6 +54,9 @@ internal class ComponentTemplateDiagnosticPass : ComponentIntermediateNodePassBa
                                 TagHelperDirectiveAttributeIntermediateNode) // Inside a directive attribute
                 {
                     _candidates.Add(new IntermediateNodeReference(Parent, node));
+
+                    // We found a candidate and can stop looking. There's no need to report multiple diagnostics for the same node.
+                    break;
                 }
             }
         }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentTemplateDiagnosticPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentTemplateDiagnosticPass.cs
@@ -1,11 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
+using Microsoft.AspNetCore.Razor.PooledObjects;
 
 namespace Microsoft.AspNetCore.Razor.Language.Components;
 
@@ -22,13 +21,16 @@ internal class ComponentTemplateDiagnosticPass : ComponentIntermediateNodePassBa
             return;
         }
 
-        var visitor = new Visitor();
+        using var _ = ListPool<IntermediateNodeReference>.GetPooledObject(out var candidates);
+
+        var visitor = new Visitor(candidates);
         visitor.Visit(documentNode);
 
-        for (var i = 0; i < visitor.Candidates.Count; i++)
+        foreach (var candidate in candidates)
         {
-            var candidate = visitor.Candidates[i];
-            candidate.Parent.AddDiagnostic(ComponentDiagnosticFactory.Create_TemplateInvalidLocation(candidate.Node.Source));
+            var (parent, node) = candidate;
+
+            parent.AddDiagnostic(ComponentDiagnosticFactory.Create_TemplateInvalidLocation(node.Source));
 
             // Remove the offending node since we don't know how to render it. This means that the user won't get C#
             // completion at this location, which is fine because it's inside an HTML attribute.
@@ -36,31 +38,22 @@ internal class ComponentTemplateDiagnosticPass : ComponentIntermediateNodePassBa
         }
     }
 
-    private class Visitor : IntermediateNodeWalker, IExtensionIntermediateNodeVisitor<TemplateIntermediateNode>
+    private sealed class Visitor(List<IntermediateNodeReference> candidates)
+        : IntermediateNodeWalker, IExtensionIntermediateNodeVisitor<TemplateIntermediateNode>
     {
-        public List<IntermediateNodeReference> Candidates { get; } = new List<IntermediateNodeReference>();
+        private readonly List<IntermediateNodeReference> _candidates = candidates;
 
         public void VisitExtension(TemplateIntermediateNode node)
         {
             // We found a template, let's check where it's located.
-            for (var i = 0; i < Ancestors.Count; i++)
+            foreach (var ancestor in Ancestors)
             {
-                var ancestor = Ancestors[i];
-
-                if (
-                    // Inside markup attribute
-                    ancestor is HtmlAttributeIntermediateNode ||
-
-                    // Inside component attribute
-                    ancestor is ComponentAttributeIntermediateNode ||
-
-                    // Inside malformed ref attribute
-                    ancestor is TagHelperPropertyIntermediateNode ||
-
-                    // Inside a directive attribute
-                    ancestor is TagHelperDirectiveAttributeIntermediateNode)
+                if (ancestor is HtmlAttributeIntermediateNode or // Inside markup attribute
+                                ComponentAttributeIntermediateNode or // Inside component attribute
+                                TagHelperPropertyIntermediateNode or // Inside malformed ref attribute
+                                TagHelperDirectiveAttributeIntermediateNode) // Inside a directive attribute
                 {
-                    Candidates.Add(new IntermediateNodeReference(Parent, node));
+                    _candidates.Add(new IntermediateNodeReference(Parent, node));
                 }
             }
         }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentWhitespacePass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentWhitespacePass.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultRazorIntermediateNodeLoweringPhase.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultRazorIntermediateNodeLoweringPhase.cs
@@ -187,9 +187,10 @@ internal class DefaultRazorIntermediateNodeLoweringPhase : RazorEnginePhaseBase,
 
     private static void PostProcessImportedDirectives(DocumentIntermediateNode document)
     {
+        using var _ = ReferenceEqualityHashSetPool<DirectiveDescriptor>.GetPooledObject(out var seenDirectives);
         var directives = document.FindDescendantReferences<DirectiveIntermediateNode>();
-        using var _ = HashSetPool<DirectiveDescriptor>.GetPooledObject(out var seenDirectives);
-        for (var i = directives.Count - 1; i >= 0; i--)
+
+        for (var i = directives.Length - 1; i >= 0; i--)
         {
             var reference = directives[i];
             var directive = (DirectiveIntermediateNode)reference.Node;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DirectiveRemovalOptimizationPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DirectiveRemovalOptimizationPass.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
-using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
 namespace Microsoft.AspNetCore.Razor.Language;
@@ -14,25 +11,12 @@ internal class DirectiveRemovalOptimizationPass : IntermediateNodePassBase, IRaz
 
     protected override void ExecuteCore(RazorCodeDocument codeDocument, DocumentIntermediateNode documentNode)
     {
-        var visitor = new Visitor();
-        visitor.VisitDocument(documentNode);
-
-        foreach (var nodeReference in visitor.DirectiveNodes)
+        foreach (var nodeReference in documentNode.FindDescendantReferences<DirectiveIntermediateNode>())
         {
             // Lift the diagnostics in the directive node up to the document node.
             documentNode.AddDiagnosticsFromNode(nodeReference.Node);
 
             nodeReference.Remove();
-        }
-    }
-
-    private class Visitor : IntermediateNodeWalker
-    {
-        public IList<IntermediateNodeReference> DirectiveNodes { get; } = new List<IntermediateNodeReference>();
-
-        public override void VisitDirective(DirectiveIntermediateNode node)
-        {
-            DirectiveNodes.Add(new IntermediateNodeReference(Parent, node));
         }
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/AttributeDirectivePass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/AttributeDirectivePass.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/DefaultTagHelperOptimizationPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/DefaultTagHelperOptimizationPass.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/FunctionsDirectivePass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/FunctionsDirectivePass.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 using Microsoft.AspNetCore.Razor.PooledObjects;
@@ -9,6 +10,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions;
 
 public sealed class FunctionsDirectivePass : IntermediateNodePassBase, IRazorDirectiveClassifierPass
 {
+    private static readonly Comparer<int?> s_nullableIntComparer = Comparer<int?>.Default;
+
     protected override void ExecuteCore(RazorCodeDocument codeDocument, DocumentIntermediateNode documentNode)
     {
         var @class = documentNode.FindPrimaryClass();
@@ -27,19 +30,22 @@ public sealed class FunctionsDirectivePass : IntermediateNodePassBase, IRazorDir
         }
 
         // Now we have all the directive nodes, we want to add them to the end of the class node in document order.
-        var orderedDirectives = directiveNodes.ToImmutableOrderedByAndClear(n => n.Node.Source?.AbsoluteIndex);
+        // So, we sort them by their absolute index.
+        directiveNodes.Sort(CompareAbsoluteIndices);
 
-        foreach (var directiveReference in orderedDirectives)
+        foreach (var directiveReference in directiveNodes)
         {
             var node = directiveReference.Node;
-            for (var i = 0; i < node.Children.Count; i++)
-            {
-                @class.Children.Add(node.Children[i]);
-            }
+            @class.Children.AddRange(node.Children);
 
             // We don't want to keep the original directive node around anymore.
             // Otherwise this can cause unintended side effects in the subsequent passes.
             directiveReference.Remove();
+        }
+
+        static int CompareAbsoluteIndices(IntermediateNodeReference n1, IntermediateNodeReference n2)
+        {
+            return s_nullableIntComparer.Compare(n1.Node.Source?.AbsoluteIndex, n2.Node.Source?.AbsoluteIndex);
         }
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/SectionDirectivePass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/SectionDirectivePass.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
-#nullable disable
-
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/IntermediateNodeVisitor.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/IntermediateNodeVisitor.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 namespace Microsoft.AspNetCore.Razor.Language.Intermediate;
 
 public abstract class IntermediateNodeVisitor

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/IntermediateNodeWalker.Stack.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/IntermediateNodeWalker.Stack.cs
@@ -1,0 +1,75 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.AspNetCore.Razor.Language.Intermediate;
+
+public abstract partial class IntermediateNodeWalker
+{
+    /// <summary>
+    ///  Simple stack implementation that fills an array from end-to-start
+    ///  to keep the items in the reverse order they were pushed. This ensures
+    ///  that they are in the correct order to implement the <see cref="Ancestors"/>
+    ///  property.
+    /// </summary>
+    private struct Stack
+    {
+        private const int InitialStackSize = 4;
+
+        private IntermediateNode[]? _stack;
+        private int _stackPointer;
+
+        [MemberNotNullWhen(false, nameof(_stack))]
+        public readonly bool IsEmpty
+            => _stack is null || _stackPointer == _stack.Length;
+
+        public readonly ReadOnlySpan<IntermediateNode> Span
+            => IsEmpty
+                ? ReadOnlySpan<IntermediateNode>.Empty
+                : _stack.AsSpan()[_stackPointer..];
+
+        public void Push(IntermediateNode node)
+        {
+            if (_stack is null || _stackPointer == 0)
+            {
+                Grow();
+            }
+
+            _stack[--_stackPointer] = node;
+        }
+
+        public void Pop()
+        {
+            Debug.Assert(!IsEmpty);
+
+            _stack[_stackPointer++] = null!;
+        }
+
+        [MemberNotNull(nameof(_stack))]
+        private void Grow()
+        {
+            // If we haven't initialized the stack, do so and set the stack pointer.
+            if (_stack == null)
+            {
+                _stack = new IntermediateNode[InitialStackSize];
+                _stackPointer = _stack.Length;
+                return;
+            }
+
+            // Otherwise, double the size of the stack and copy the contents over.
+
+            Debug.Assert(_stackPointer == 0, "We should only grow the ancestor stack when the stack pointer reaches 0.");
+
+            var length = _stack.Length;
+            var newStack = new IntermediateNode[length * 2];
+
+            _stack.CopyTo(newStack, length);
+
+            _stackPointer = length;
+            _stack = newStack;
+        }
+    }
+}

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxRewriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/SyntaxRewriter.cs
@@ -47,7 +47,7 @@ internal abstract partial class SyntaxRewriter : SyntaxVisitor<SyntaxNode>
             return list;
         }
 
-        using PooledArrayBuilder<TNode> builder = [];
+        using var builder = new PooledArrayBuilder<TNode>(capacity: count);
 
         var isUpdating = false;
 
@@ -61,8 +61,6 @@ internal abstract partial class SyntaxRewriter : SyntaxVisitor<SyntaxNode>
             {
                 // The list is being updated, so we need to initialize the builder
                 // add the items we've seen so far.
-                builder.SetCapacityIfLarger(count);
-
                 builder.AddRange(list, startIndex: 0, count: i);
 
                 isUpdating = true;
@@ -93,7 +91,7 @@ internal abstract partial class SyntaxRewriter : SyntaxVisitor<SyntaxNode>
             return list;
         }
 
-        using PooledArrayBuilder<SyntaxToken> builder = [];
+        using var builder =  new PooledArrayBuilder<SyntaxToken>(count);
 
         var isUpdating = false;
 
@@ -107,8 +105,6 @@ internal abstract partial class SyntaxRewriter : SyntaxVisitor<SyntaxNode>
             {
                 // The list is being updated, so we need to initialize the builder
                 // add the items we've seen so far.
-                builder.SetCapacityIfLarger(count);
-
                 builder.AddRange(list, startIndex: 0, count: i);
 
                 isUpdating = true;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Mvc/ViewComponentTagHelperPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Mvc/ViewComponentTagHelperPass.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
@@ -36,10 +34,8 @@ public class ViewComponentTagHelperPass : IntermediateNodePassBase, IRazorOptimi
 
         // For each VCTH *usage* we need to rewrite the tag helper node to use the tag helper runtime to construct
         // and set properties on the the correct field, and using the name of the type we will generate.
-        var nodes = documentNode.FindDescendantNodes<TagHelperIntermediateNode>();
-        for (var i = 0; i < nodes.Count; i++)
+        foreach (var node in documentNode.FindDescendantNodes<TagHelperIntermediateNode>())
         {
-            var node = nodes[i];
             foreach (var tagHelper in node.TagHelpers)
             {
                 RewriteUsage(context, node, tagHelper);

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledArrayBuilder`1.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledArrayBuilder`1.cs
@@ -92,6 +92,20 @@ internal partial struct PooledArrayBuilder<T> : IDisposable
     }
 
     /// <summary>
+    ///  Retrieves the inner <see cref="_builder"/>, moving any inline elements to it if necessary.
+    /// </summary>
+    private ImmutableArray<T>.Builder GetBuilder()
+    {
+        if (!TryGetBuilder(out var builder))
+        {
+            MoveInlineItemsToBuilder();
+            builder = _builder;
+        }
+
+        return builder;
+    }
+
+    /// <summary>
     ///  Retrieves the inner <see cref="_builder"/>.
     /// </summary>
     /// <returns>
@@ -1609,6 +1623,33 @@ internal partial struct PooledArrayBuilder<T> : IDisposable
         {
             SetInlineElement(i + offset, GetInlineElement(i));
         }
+    }
+
+    /// <summary>
+    ///  Sorts the contents of this builder.
+    /// </summary>
+    public void Sort()
+    {
+        var builder = GetBuilder();
+        builder.Sort();
+    }
+
+    /// <summary>
+    ///  Sorts the contents of this builder using the provided <see cref="IComparer{T}"/>.
+    /// </summary>
+    public void Sort(IComparer<T> comparer)
+    {
+        var builder = GetBuilder();
+        builder.Sort(comparer);
+    }
+
+    /// <summary>
+    ///  Sorts the contents of this builder using the provided <see cref="Comparison{T}"/>.
+    /// </summary>
+    public void Sort(Comparison<T> comparison)
+    {
+        var builder = GetBuilder();
+        builder.Sort(comparison);
     }
 
     public readonly ImmutableArray<T> ToImmutableOrdered()

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledArrayBuilder`1.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledArrayBuilder`1.cs
@@ -255,15 +255,19 @@ internal partial struct PooledArrayBuilder<T> : IDisposable
     {
         if (value > Capacity)
         {
+            // For pooled arrays, we prefer exponential growth minimize the number of times
+            // the internal array has to be resized.
+            var newCapacity = Math.Max(value, Capacity * 2);
+
             if (TryGetBuilder(out var builder))
             {
-                Debug.Assert(value > builder.Capacity);
-                builder.Capacity = value;
+                Debug.Assert(newCapacity > builder.Capacity);
+                builder.Capacity = newCapacity;
             }
             else
             {
-                Debug.Assert(value > (_capacity ?? InlineCapacity));
-                _capacity = value;
+                Debug.Assert(newCapacity > (_capacity ?? InlineCapacity));
+                _capacity = newCapacity;
             }
         }
     }


### PR DESCRIPTION
This represents a handful of changes that improve the efficiency of `IntermediateNodeWalker` and extension method helpers that visit intermediate node trees.

The key commits are below. The remaining commits represent updates that react to the changes in these commits and general clean up. Reviewing commit-by-commit should be pretty straighforward.

- Improve `IntermediateNodeWalker` efficiency (cbc5cc2ad905468db30c195f70f21627985b78b7)
- Improve `FindDescendantReferences` extension method (f6812e82ef2aa785439a2def2087c759fdd4ffe9)
- Improve `FindDirectiveReferences` extension method (728716228bfb80602c11b3d5a80ac73af5232423)
- Improve `FindDirectiveNodes` extension method (5604593185d7d1e091e2a642734f30c062871ab7)

----
CI Build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2741969&view=results
Test Insertion: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/648672
Toolset Run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2741970&view=results