### PR TITLE
Use snippet InsertText in directive attributes to insert equals and quotes

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
@@ -123,6 +123,7 @@ internal class DirectiveAttributeCompletionItemProvider : DirectiveAttributeComp
         foreach (var (displayText, (attributeDescriptions, commitCharacters)) in attributeCompletions)
         {
             var insertTextSpan = displayText.AsSpan();
+            var originalInsertTextSpan = insertTextSpan;
 
             // Strip off the @ from the insertion text. This change is here to align the insertion text with the
             // completion hooks into VS and VSCode. Basically, completion triggers when `@` is typed so we don't
@@ -148,6 +149,9 @@ internal class DirectiveAttributeCompletionItemProvider : DirectiveAttributeComp
                 }
             }
 
+            // Don't create another string annecessarily, even thouth ReadOnlySpan.ToString() special-cases the string to avoid allocation
+            var insertText = insertTextSpan == originalInsertTextSpan ? displayText : insertTextSpan.ToString();
+
             using var razorCommitCharacters = new PooledArrayBuilder<RazorCommitCharacter>(capacity: commitCharacters.Count);
 
             foreach (var c in commitCharacters)
@@ -157,7 +161,7 @@ internal class DirectiveAttributeCompletionItemProvider : DirectiveAttributeComp
 
             var razorCompletionItem = RazorCompletionItem.CreateDirectiveAttribute(
                 displayText,
-                insertTextSpan.ToString(),
+                insertText,
                 descriptionInfo: new([.. attributeDescriptions]),
                 commitCharacters: razorCommitCharacters.ToImmutableAndClear(),
                 isSnippet);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
@@ -16,6 +16,9 @@ namespace Microsoft.CodeAnalysis.Razor.Completion;
 
 internal class DirectiveAttributeCompletionItemProvider : DirectiveAttributeCompletionItemProviderBase
 {
+    private static ReadOnlyMemory<char> QuotedAttributeValueSnippet => "=\"$0\"".AsMemory();
+    private static ReadOnlyMemory<char> UnquotedAttributeValueSnippet => "=$0".AsMemory();
+
     public override ImmutableArray<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context)
     {
         if (!context.SyntaxTree.Options.FileKind.IsComponent())
@@ -176,11 +179,11 @@ internal class DirectiveAttributeCompletionItemProvider : DirectiveAttributeComp
                 && containingAttribute is not (MarkupTagHelperDirectiveAttributeSyntax or MarkupAttributeBlockSyntax)
                 && containingAttribute.Parent is not (MarkupTagHelperDirectiveAttributeSyntax or MarkupAttributeBlockSyntax))
             {
-                var suffixTextSpan = razorCompletionOptions.AutoInsertAttributeQuotes ? "=\"$0\"".AsSpan() : "=$0".AsSpan();
+                var suffixTextSpan = razorCompletionOptions.AutoInsertAttributeQuotes ? QuotedAttributeValueSnippet : UnquotedAttributeValueSnippet;
 
                 var buffer = new char[baseTextSpan.Length + suffixTextSpan.Length];
                 baseTextSpan.CopyTo(buffer);
-                suffixTextSpan.CopyTo(buffer.AsSpan(baseTextSpan.Length));
+                suffixTextSpan.CopyTo(buffer.AsMemory().Slice(baseTextSpan.Length));
 
                 snippetTextSpan = buffer.AsSpan();
                 return true;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
@@ -171,7 +171,7 @@ internal class DirectiveAttributeCompletionItemProvider : DirectiveAttributeComp
 
         return completionItems.ToImmutableAndClear();
 
-        bool TryGetSnippetText(
+        static bool TryGetSnippetText(
             RazorSyntaxNode owner,
             ReadOnlySpan<char> baseTextSpan,
             RazorCompletionOptions razorCompletionOptions,
@@ -180,8 +180,8 @@ internal class DirectiveAttributeCompletionItemProvider : DirectiveAttributeComp
             if (razorCompletionOptions.SnippetsSupported
                 // Don't create snippet text when attribute is already in the tag and we are trying to replace it
                 // Otherwise you could have something like @onabort=""=""
-                && containingAttribute is not (MarkupTagHelperDirectiveAttributeSyntax or MarkupAttributeBlockSyntax)
-                && containingAttribute.Parent is not (MarkupTagHelperDirectiveAttributeSyntax or MarkupAttributeBlockSyntax))
+                && owner is not (MarkupTagHelperDirectiveAttributeSyntax or MarkupAttributeBlockSyntax)
+                && owner.Parent is not (MarkupTagHelperDirectiveAttributeSyntax or MarkupAttributeBlockSyntax))
             {
                 var suffixTextSpan = razorCompletionOptions.AutoInsertAttributeQuotes ? QuotedAttributeValueSnippet : UnquotedAttributeValueSnippet;
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
@@ -187,7 +187,7 @@ internal class DirectiveAttributeCompletionItemProvider : DirectiveAttributeComp
 
                 var buffer = new char[baseTextSpan.Length + suffixTextSpan.Length];
                 baseTextSpan.CopyTo(buffer);
-                suffixTextSpan.CopyTo(buffer.AsMemory().Slice(baseTextSpan.Length));
+                suffixTextSpan.CopyTo(buffer.AsMemory()[baseTextSpan.Length..]);
 
                 snippetTextSpan = buffer.AsSpan();
                 return true;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItem.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItem.cs
@@ -65,7 +65,7 @@ internal sealed class RazorCompletionItem
         string displayText, string insertText,
         AggregateBoundAttributeDescription descriptionInfo,
         ImmutableArray<RazorCommitCharacter> commitCharacters,
-        bool isSnippet = false)
+        bool isSnippet)
         => new(RazorCompletionItemKind.DirectiveAttribute, displayText, insertText, sortText: null, descriptionInfo, commitCharacters, isSnippet);
 
     public static RazorCompletionItem CreateDirectiveAttributeParameter(

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItem.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItem.cs
@@ -64,8 +64,9 @@ internal sealed class RazorCompletionItem
     public static RazorCompletionItem CreateDirectiveAttribute(
         string displayText, string insertText,
         AggregateBoundAttributeDescription descriptionInfo,
-        ImmutableArray<RazorCommitCharacter> commitCharacters)
-        => new(RazorCompletionItemKind.DirectiveAttribute, displayText, insertText, sortText: null, descriptionInfo, commitCharacters, isSnippet: false);
+        ImmutableArray<RazorCommitCharacter> commitCharacters,
+        bool isSnippet = false)
+        => new(RazorCompletionItemKind.DirectiveAttribute, displayText, insertText, sortText: null, descriptionInfo, commitCharacters, isSnippet);
 
     public static RazorCompletionItem CreateDirectiveAttributeParameter(
         string displayText, string insertText,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionItemResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionItemResolverTest.cs
@@ -123,7 +123,8 @@ public class RazorCompletionItemResolverTest : LanguageServerTestBase
             displayText: "TestItem",
             insertText: "TestItem",
             _attributeDescription,
-            commitCharacters: []);
+            commitCharacters: [],
+            isSnippet: false);
         var completionList = CreateLSPCompletionList(razorCompletionItem);
         var completionItem = (VSInternalCompletionItem)completionList.Items.Single();
 
@@ -212,7 +213,8 @@ public class RazorCompletionItemResolverTest : LanguageServerTestBase
         var razorCompletionItem = RazorCompletionItem.CreateDirectiveAttribute(
             displayText: "TestItem",
             insertText: "TestItem", _attributeDescription,
-            commitCharacters: []);
+            commitCharacters: [],
+            isSnippet: false);
         var completionList = CreateLSPCompletionList(razorCompletionItem);
         var completionItem = (VSInternalCompletionItem)completionList.Items.Single();
 

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
@@ -8,8 +8,10 @@ using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.IntegrationTests;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.AspNetCore.Razor.Test.Common;
 using Xunit;
 using Xunit.Abstractions;
+using RazorSyntaxNode = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion;
 
@@ -17,7 +19,7 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
 {
     private readonly DirectiveAttributeCompletionItemProvider _provider;
     private readonly TagHelperDocumentContext _defaultTagHelperContext;
-
+    private readonly RazorCompletionOptions _defaultRazorCompletionOptions;
     internal override RazorFileKind? FileKind => RazorFileKind.Component;
     internal override bool UseTwoPhaseCompilation => true;
 
@@ -33,6 +35,7 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
 
         var codeDocument = GetCodeDocument(string.Empty);
         _defaultTagHelperContext = codeDocument.GetRequiredTagHelperContext();
+        _defaultRazorCompletionOptions = new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true);
     }
 
     private RazorCodeDocument GetCodeDocument(string content)
@@ -45,7 +48,7 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
     public void GetCompletionItems_OnNonAttributeArea_ReturnsEmptyCollection()
     {
         // Arrange
-        var context = CreateRazorCompletionContext(absoluteIndex: 3, "<input @  />");
+        var context = CreateRazorCompletionContext("<in$$put @  />");
 
         // Act
         var completions = _provider.GetCompletionItems(context);
@@ -58,7 +61,7 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
     public void GetCompletionItems_OnDirectiveAttributeParameter_ReturnsEmptyCollection()
     {
         // Arrange
-        var context = CreateRazorCompletionContext(absoluteIndex: 14, "<input @bind:fo  />");
+        var context = CreateRazorCompletionContext("<input @bind:f$$o  />");
 
         // Act
         var completions = _provider.GetCompletionItems(context);
@@ -71,7 +74,7 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
     public void GetCompletionItems_OnDirectiveAttributeName_bind_ReturnsCompletions()
     {
         // Arrange
-        var context = CreateRazorCompletionContext(absoluteIndex: 8, "<input @  />");
+        var context = CreateRazorCompletionContext("<input @$$  />");
 
         // Act
         var completions = _provider.GetCompletionItems(context);
@@ -84,7 +87,7 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
     public void GetCompletionItems_OnDirectiveAttributeName_attributes_ReturnsCompletions()
     {
         // Arrange
-        var context = CreateRazorCompletionContext(absoluteIndex: 8, "<input @  />");
+        var context = CreateRazorCompletionContext("<input @$$  />");
 
         // Act
         var completions = _provider.GetCompletionItems(context);
@@ -97,7 +100,7 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
     public void GetCompletionItems_AttributeAreaEndOfSelfClosingTag_ReturnsEmptyCollection()
     {
         // Arrange
-        var context = CreateRazorCompletionContext(absoluteIndex: 16, "<input @bind:fo  />");
+        var context = CreateRazorCompletionContext("<input @bind:fo $$ />");
 
         // Act
         var completions = _provider.GetCompletionItems(context);
@@ -110,7 +113,7 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
     public void GetCompletionItems_AttributeAreaEndOfOpeningTag_ReturnsEmptyCollection()
     {
         // Arrange
-        var context = CreateRazorCompletionContext(absoluteIndex: 16, "<input @bind:fo   ></input>");
+        var context = CreateRazorCompletionContext("<input @bind:fo $$  ></input>");
 
         // Act
         var completions = _provider.GetCompletionItems(context);
@@ -123,7 +126,7 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
     public void GetCompletionItems_ExistingAttribute_LeadingEdge_ReturnsEmptyCollection()
     {
         // Arrange
-        var context = CreateRazorCompletionContext(absoluteIndex: 7, "<input src=\"xyz\" />");
+        var context = CreateRazorCompletionContext("<input $$src=\"xyz\" />");
 
         // Act
         var completions = _provider.GetCompletionItems(context);
@@ -136,7 +139,7 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
     public void GetCompletionItems_ExistingAttribute_TrailingEdge_ReturnsEmptyCollection()
     {
         // Arrange
-        var context = CreateRazorCompletionContext(absoluteIndex: 16, "<input src=\"xyz\" />");
+        var context = CreateRazorCompletionContext("<input src=\"xyz$$\" />");
 
         // Act
         var completions = _provider.GetCompletionItems(context);
@@ -149,7 +152,7 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
     public void GetCompletionItems_ExistingAttribute_Partial_ReturnsEmptyCollection()
     {
         // Arrange
-        var context = CreateRazorCompletionContext(absoluteIndex: 9, "<svg xml: ></svg>");
+        var context = CreateRazorCompletionContext("<svg xml:$$ ></svg>");
 
         // Act
         var completions = _provider.GetCompletionItems(context);
@@ -162,10 +165,11 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
     public void GetAttributeCompletions_NoDescriptorsForTag_ReturnsEmptyCollection()
     {
         // Arrange
+        var owner = GetOwner("<foobarbaz @bin$$></foobarbar>");
         var documentContext = TagHelperDocumentContext.Create(string.Empty, tagHelpers: []);
 
         // Act
-        var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions("@bin", "foobarbaz", [], documentContext);
+        var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions(owner!, "@bin", "foobarbaz", [], documentContext, _defaultRazorCompletionOptions);
 
         // Assert
         Assert.Empty(completions);
@@ -179,9 +183,10 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
         descriptor.BoundAttributeDescriptor(boundAttribute => boundAttribute.Name = "Test");
         descriptor.TagMatchingRule(rule => rule.RequireTagName("*"));
         var documentContext = TagHelperDocumentContext.Create(string.Empty, [descriptor.Build()]);
+        var owner = GetOwner("<input @bin$$></input>");
 
         // Act
-        var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions("@bin", "input", [], documentContext);
+        var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions(owner, "@bin", "input", [], documentContext, _defaultRazorCompletionOptions);
 
         // Assert
         Assert.Empty(completions);
@@ -192,21 +197,65 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
     {
         // Arrange
         var attributeNames = ImmutableArray.Create("@bind");
+        var owner = GetOwner("<input @bind$$></input>");
 
         // Act
-        var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions("@bind", "input", attributeNames, _defaultTagHelperContext);
+        var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions(owner, "@bind", "input", attributeNames, _defaultTagHelperContext, _defaultRazorCompletionOptions);
 
         // Assert
-        AssertContains(completions, "bind", "@bind", ["=", ":"]);
+        AssertContains(completions, "bind=\"$0\"", "@bind", ["=", ":"]);
     }
 
     [Fact]
     public void GetAttributeCompletions_NonIndexer_ReturnsCompletion()
     {
         // Arrange
+        var owner = GetOwner("<input @$$></input>");
 
         // Act
-        var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions("@", "input", [], _defaultTagHelperContext);
+        var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions(owner, "@", "input", [], _defaultTagHelperContext, _defaultRazorCompletionOptions);
+
+        // Assert
+        AssertContains(completions, "bind=\"$0\"", "@bind", ["=", ":"]);
+    }
+
+    [Fact]
+    public void GetAttributeCompletions_WithNoAutoQuotesOption_ReturnsNonQuotedSnippet()
+    {
+        // Arrange
+        var owner = GetOwner("<input @$$></input>");
+        var noAutoQuotesRazorCompletionOptions = new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: false, CommitElementsWithSpace: true);
+
+        // Act
+        var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions(owner, "@", "input", [], _defaultTagHelperContext, noAutoQuotesRazorCompletionOptions);
+
+        // Assert
+        AssertContains(completions, "bind=$0", "@bind", ["=", ":"]);
+    }
+
+    [Fact]
+    public void GetAttributeCompletions_WithNoSnippetsOption_ReturnsNoSnippets()
+    {
+        // Arrange
+        var owner = GetOwner("<input @$$></input>");
+        var noAutoQuotesRazorCompletionOptions = new RazorCompletionOptions(SnippetsSupported: false, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true);
+
+        // Act
+        var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions(owner, "@", "input", [], _defaultTagHelperContext, noAutoQuotesRazorCompletionOptions);
+
+        // Assert
+        AssertContains(completions, "bind", "@bind", ["=", ":"]);
+    }
+
+    [Fact]
+    public void GetAttributeCompletions_ExistingAttrubteWithValue_ReturnsNoSnippets()
+    {
+        // Arrange
+        var owner = GetOwner("<input @bi$$nd=\"foo\"></input>");
+        var noAutoQuotesRazorCompletionOptions = new RazorCompletionOptions(SnippetsSupported: false, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true);
+
+        // Act
+        var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions(owner, "@", "input", [], _defaultTagHelperContext, noAutoQuotesRazorCompletionOptions);
 
         // Assert
         AssertContains(completions, "bind", "@bind", ["=", ":"]);
@@ -216,9 +265,10 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
     public void GetAttributeCompletions_Indexer_ReturnsCompletion()
     {
         // Arrange
+        var owner = GetOwner("<input @$$></input>");
 
         // Act
-        var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions("@", "input", [], _defaultTagHelperContext);
+        var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions(owner, "@", "input", [], _defaultTagHelperContext, _defaultRazorCompletionOptions);
 
         // Assert
         AssertContains(completions, "bind-", "@bind-...", []);
@@ -229,12 +279,13 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
     {
         // Arrange
         var attributeNames = ImmutableArray.Create("@bind", "@");
+        var owner = GetOwner("<input @$$></input>");
 
         // Act
-        var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions("@", "input", attributeNames, _defaultTagHelperContext);
+        var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions(owner, "@", "input", attributeNames, _defaultTagHelperContext, _defaultRazorCompletionOptions);
 
         // Assert
-        AssertContains(completions, "bind", "@bind", ["=", ":"]);
+        AssertContains(completions, "bind=\"$0\"", "@bind", ["=", ":"]);
     }
 
     [Fact]
@@ -250,9 +301,10 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
             "@bind:set",
             "@bind:after",
             "@");
+        var owner = GetOwner("<input @$$></input>");
 
         // Act
-        var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions("@", "input", attributeNames, _defaultTagHelperContext);
+        var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions(owner, "@", "input", attributeNames, _defaultTagHelperContext, _defaultRazorCompletionOptions);
 
         // Assert
         AssertDoesNotContain(completions, "bind", "@bind");
@@ -278,15 +330,21 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
                RazorCompletionItemKind.DirectiveAttribute == completion.Kind);
     }
 
-    private RazorCompletionContext CreateRazorCompletionContext(int absoluteIndex, string documentContent)
+    private RazorCompletionContext CreateRazorCompletionContext(string testCodeText)
     {
-        var codeDocument = GetCodeDocument(documentContent);
+        var testCode = new TestCode(testCodeText);
+        var codeDocument = GetCodeDocument(testCode.Text);
         var syntaxTree = codeDocument.GetRequiredSyntaxTree();
         var tagHelperContext = codeDocument.GetRequiredTagHelperContext();
 
-        var owner = syntaxTree.Root.FindInnermostNode(absoluteIndex, includeWhitespace: true, walkMarkersBack: true);
-        owner = AbstractRazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, absoluteIndex);
+        var owner = syntaxTree.Root.FindInnermostNode(testCode.Position, includeWhitespace: true, walkMarkersBack: true);
+        owner = AbstractRazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, testCode.Position);
 
-        return new RazorCompletionContext(absoluteIndex, owner, syntaxTree, tagHelperContext);
+        return new RazorCompletionContext(testCode.Position, owner, syntaxTree, tagHelperContext);
+    }
+
+    private RazorSyntaxNode GetOwner(string testCodeText)
+    {
+        return CreateRazorCompletionContext(testCodeText).Owner!;
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
@@ -330,9 +330,8 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
                RazorCompletionItemKind.DirectiveAttribute == completion.Kind);
     }
 
-    private RazorCompletionContext CreateRazorCompletionContext(string testCodeText)
+    private RazorCompletionContext CreateRazorCompletionContext(TestCode testCode)
     {
-        var testCode = new TestCode(testCodeText);
         var codeDocument = GetCodeDocument(testCode.Text);
         var syntaxTree = codeDocument.GetRequiredSyntaxTree();
         var tagHelperContext = codeDocument.GetRequiredTagHelperContext();

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/RazorCompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/RazorCompletionListProviderTest.cs
@@ -174,7 +174,8 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
             displayText: "@testDisplay",
             insertText: "testInsert",
             descriptionInfo: null!,
-            commitCharacters: RazorCommitCharacter.CreateArray(["=", ":"]));
+            commitCharacters: RazorCommitCharacter.CreateArray(["=", ":"]),
+            isSnippet: false);
 
         // Act
         Assert.True(RazorCompletionListProvider.TryConvert(completionItem, _clientCapabilities, out var converted));


### PR DESCRIPTION
﻿### Summary of the changes

- Using snippet insert text will ensure that equals and quotes are added on attribute commit, and cursor is moved to the correct position between double quotes.

Fixes:
https://github.com/dotnet/razor/issues/11395