### PR TITLE
Don't show HTML snippets in style, script, or html comment blocks

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
@@ -230,6 +230,14 @@ internal static class DelegatedCompletionHelper
 
         if (startOrEndTag is null)
         {
+            if (RazorSyntaxFacts.IsInStyleBlock(node)
+                || RazorSyntaxFacts.IsInScriptBlock(node)
+                || RazorSyntaxFacts.IsInMarkupCommentBlock(node))
+            {
+                // If we're in a style, script, or HTML comment block, we don't want to include HTML snippets.
+                return false;
+            }
+
             return token.Kind is not (SyntaxKind.OpenAngle or SyntaxKind.CloseAngle);
         }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorSyntaxFacts.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorSyntaxFacts.cs
@@ -207,4 +207,28 @@ internal static class RazorSyntaxFacts
 
         return false;
     }
+
+    internal static bool IsInElementWithName(RazorSyntaxNode? node, string name)
+    {
+        var element = node?.FirstAncestorOrSelf<MarkupElementSyntax>();
+
+        return string.Equals(element?.StartTag.Name.Content, name, StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal static bool IsInMarkupCommentBlock(RazorSyntaxNode? node)
+    {
+        var element = node?.FirstAncestorOrSelf<MarkupCommentBlockSyntax>();
+
+        return element is not null;
+    }
+
+    internal static bool IsInStyleBlock(RazorSyntaxNode? node)
+    {
+        return IsInElementWithName(node, "style");
+    }
+
+    internal static bool IsInScriptBlock(RazorSyntaxNode? node)
+    {
+        return IsInElementWithName(node, "script");
+    }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/CompletionIntegrationTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/CompletionIntegrationTests.cs
@@ -438,14 +438,28 @@ public class CompletionIntegrationTests(ITestOutputHelper testOutputHelper) : Ab
     [InlineData("</PageTitle")]
     [InlineData("<div")]
     [InlineData("</div")]
+    [InlineData("// script block ")]
+    [InlineData("/* style block ")]
+    [InlineData("<!-- comment block ")]
     [WorkItem("https://github.com/dotnet/razor/issues/9427")]
-    public async Task Snippets_DoNotTrigger_InsideTag(string tag)
+    // Do not trigger snippets in start tags, end tags, script blocks, style blocks, or comments
+    public async Task Snippets_DoNotTrigger_InDisallowedContext(string tag)
     {
         await TestServices.SolutionExplorer.AddFileAsync(
             RazorProjectConstants.BlazorProjectName,
             "Test.razor",
             """
-            @page "Test"
+            @page "/Test"
+
+            <script>
+                // script block 
+            </script>
+
+            <style>
+                /* style block  */
+            </style>
+
+            <!-- comment block  -->
 
             <PageTitle>Test</PageTitle>
 


### PR DESCRIPTION
﻿### Summary of the changes

- Don't add html snippets to completion inside of style, script, and HTML comment blocks
- Ideally HTML snippets should be added by HTML LSP server to the returned completion items rather than Razor is doing it

Fixes:
https://developercommunity.visualstudio.com/t/Snippets-are-way-too-agressive-in-Razor-/10676182