### PR TITLE
Update Roslyn to consume the new WorkspaceChanged replacement

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,89 +2,89 @@
 <Dependencies>
   <Source Uri="https://github.com/dotnet/dotnet" Mapping="razor" Sha="f5705c8f4c5079bba77bae8698ba1583bde0388c" BarId="269610" />
   <ProductDependencies>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="5.0.0-1.25321.1">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="5.0.0-1.25358.11">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ad14335550de1134f0b5a59b6cd040001d0d8c8d</Sha>
+      <Sha>aae13ec39930966db0502983a4dbf8a8b1d70452</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CommonLanguageServerProtocol.Framework" Version="5.0.0-1.25321.1">
+    <Dependency Name="Microsoft.CommonLanguageServerProtocol.Framework" Version="5.0.0-1.25358.11">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ad14335550de1134f0b5a59b6cd040001d0d8c8d</Sha>
+      <Sha>aae13ec39930966db0502983a4dbf8a8b1d70452</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Common" Version="5.0.0-1.25321.1">
+    <Dependency Name="Microsoft.CodeAnalysis.Common" Version="5.0.0-1.25358.11">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ad14335550de1134f0b5a59b6cd040001d0d8c8d</Sha>
+      <Sha>aae13ec39930966db0502983a4dbf8a8b1d70452</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="5.0.0-1.25321.1">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="5.0.0-1.25358.11">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ad14335550de1134f0b5a59b6cd040001d0d8c8d</Sha>
+      <Sha>aae13ec39930966db0502983a4dbf8a8b1d70452</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.EditorFeatures" Version="5.0.0-1.25321.1">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.EditorFeatures" Version="5.0.0-1.25358.11">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ad14335550de1134f0b5a59b6cd040001d0d8c8d</Sha>
+      <Sha>aae13ec39930966db0502983a4dbf8a8b1d70452</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="5.0.0-1.25321.1">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="5.0.0-1.25358.11">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ad14335550de1134f0b5a59b6cd040001d0d8c8d</Sha>
+      <Sha>aae13ec39930966db0502983a4dbf8a8b1d70452</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0-1.25321.1">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0-1.25358.11">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ad14335550de1134f0b5a59b6cd040001d0d8c8d</Sha>
+      <Sha>aae13ec39930966db0502983a4dbf8a8b1d70452</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures" Version="5.0.0-1.25321.1">
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures" Version="5.0.0-1.25358.11">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ad14335550de1134f0b5a59b6cd040001d0d8c8d</Sha>
+      <Sha>aae13ec39930966db0502983a4dbf8a8b1d70452</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Common" Version="5.0.0-1.25321.1">
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Common" Version="5.0.0-1.25358.11">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ad14335550de1134f0b5a59b6cd040001d0d8c8d</Sha>
+      <Sha>aae13ec39930966db0502983a4dbf8a8b1d70452</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Text" Version="5.0.0-1.25321.1">
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Text" Version="5.0.0-1.25358.11">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ad14335550de1134f0b5a59b6cd040001d0d8c8d</Sha>
+      <Sha>aae13ec39930966db0502983a4dbf8a8b1d70452</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Remote.ServiceHub" Version="5.0.0-1.25321.1">
+    <Dependency Name="Microsoft.CodeAnalysis.Remote.ServiceHub" Version="5.0.0-1.25358.11">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ad14335550de1134f0b5a59b6cd040001d0d8c8d</Sha>
+      <Sha>aae13ec39930966db0502983a4dbf8a8b1d70452</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="5.0.0-1.25321.1">
+    <Dependency Name="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="5.0.0-1.25358.11">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ad14335550de1134f0b5a59b6cd040001d0d8c8d</Sha>
+      <Sha>aae13ec39930966db0502983a4dbf8a8b1d70452</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.0.0-1.25321.1">
+    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.0.0-1.25358.11">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ad14335550de1134f0b5a59b6cd040001d0d8c8d</Sha>
+      <Sha>aae13ec39930966db0502983a4dbf8a8b1d70452</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.0.0-1.25321.1">
+    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.0.0-1.25358.11">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ad14335550de1134f0b5a59b6cd040001d0d8c8d</Sha>
+      <Sha>aae13ec39930966db0502983a4dbf8a8b1d70452</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.VisualStudio.LanguageServices" Version="5.0.0-1.25321.1">
+    <Dependency Name="Microsoft.VisualStudio.LanguageServices" Version="5.0.0-1.25358.11">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ad14335550de1134f0b5a59b6cd040001d0d8c8d</Sha>
+      <Sha>aae13ec39930966db0502983a4dbf8a8b1d70452</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Test.Utilities" Version="5.0.0-1.25321.1">
+    <Dependency Name="Microsoft.CodeAnalysis.Test.Utilities" Version="5.0.0-1.25358.11">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ad14335550de1134f0b5a59b6cd040001d0d8c8d</Sha>
+      <Sha>aae13ec39930966db0502983a4dbf8a8b1d70452</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.Razor.Features" Version="5.0.0-1.25321.1">
+    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.Razor.Features" Version="5.0.0-1.25358.11">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ad14335550de1134f0b5a59b6cd040001d0d8c8d</Sha>
+      <Sha>aae13ec39930966db0502983a4dbf8a8b1d70452</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.Razor.EditorFeatures" Version="5.0.0-1.25321.1">
+    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.Razor.EditorFeatures" Version="5.0.0-1.25358.11">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ad14335550de1134f0b5a59b6cd040001d0d8c8d</Sha>
+      <Sha>aae13ec39930966db0502983a4dbf8a8b1d70452</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.LanguageServer.Protocol" Version="5.0.0-1.25321.1">
+    <Dependency Name="Microsoft.CodeAnalysis.LanguageServer.Protocol" Version="5.0.0-1.25358.11">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ad14335550de1134f0b5a59b6cd040001d0d8c8d</Sha>
+      <Sha>aae13ec39930966db0502983a4dbf8a8b1d70452</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.FSharp" Version="5.0.0-1.25321.1">
+    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.FSharp" Version="5.0.0-1.25358.11">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ad14335550de1134f0b5a59b6cd040001d0d8c8d</Sha>
+      <Sha>aae13ec39930966db0502983a4dbf8a8b1d70452</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Analyzers" Version="5.0.0-1.25321.1">
+    <Dependency Name="Microsoft.CodeAnalysis.Analyzers" Version="5.0.0-1.25358.11">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ad14335550de1134f0b5a59b6cd040001d0d8c8d</Sha>
+      <Sha>aae13ec39930966db0502983a4dbf8a8b1d70452</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Opt-in arcade features -->
   <PropertyGroup>
     <UsingToolVSSDK>true</UsingToolVSSDK>
@@ -47,27 +47,27 @@
 
   -->
   <PropertyGroup Label="Automated">
-    <MicrosoftCodeAnalysisAnalyzersPackageVersion>5.0.0-1.25321.1</MicrosoftCodeAnalysisAnalyzersPackageVersion>
-    <MicrosoftNetCompilersToolsetPackageVersion>5.0.0-1.25321.1</MicrosoftNetCompilersToolsetPackageVersion>
-    <MicrosoftCodeAnalysisExternalAccessFSharpPackageVersion>5.0.0-1.25321.1</MicrosoftCodeAnalysisExternalAccessFSharpPackageVersion>
-    <MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>5.0.0-1.25321.1</MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>
-    <MicrosoftCodeAnalysisExternalAccessRazorEditorFeaturesPackageVersion>5.0.0-1.25321.1</MicrosoftCodeAnalysisExternalAccessRazorEditorFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisExternalAccessRazorFeaturesPackageVersion>5.0.0-1.25321.1</MicrosoftCodeAnalysisExternalAccessRazorFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisCommonPackageVersion>5.0.0-1.25321.1</MicrosoftCodeAnalysisCommonPackageVersion>
-    <MicrosoftCodeAnalysisCSharpPackageVersion>5.0.0-1.25321.1</MicrosoftCodeAnalysisCSharpPackageVersion>
-    <MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>5.0.0-1.25321.1</MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>5.0.0-1.25321.1</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>5.0.0-1.25321.1</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesPackageVersion>5.0.0-1.25321.1</MicrosoftCodeAnalysisEditorFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>5.0.0-1.25321.1</MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>5.0.0-1.25321.1</MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>
-    <MicrosoftCodeAnalysisLanguageServerProtocolPackageVersion>5.0.0-1.25321.1</MicrosoftCodeAnalysisLanguageServerProtocolPackageVersion>
-    <MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>5.0.0-1.25321.1</MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>
-    <MicrosoftCodeAnalysisTestUtilitiesPackageVersion>5.0.0-1.25321.1</MicrosoftCodeAnalysisTestUtilitiesPackageVersion>
-    <MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>5.0.0-1.25321.1</MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>5.0.0-1.25321.1</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>5.0.0-1.25321.1</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
-    <MicrosoftVisualStudioLanguageServicesPackageVersion>5.0.0-1.25321.1</MicrosoftVisualStudioLanguageServicesPackageVersion>
+    <MicrosoftCodeAnalysisAnalyzersPackageVersion>5.0.0-1.25358.11</MicrosoftCodeAnalysisAnalyzersPackageVersion>
+    <MicrosoftNetCompilersToolsetPackageVersion>5.0.0-1.25358.11</MicrosoftNetCompilersToolsetPackageVersion>
+    <MicrosoftCodeAnalysisExternalAccessFSharpPackageVersion>5.0.0-1.25358.11</MicrosoftCodeAnalysisExternalAccessFSharpPackageVersion>
+    <MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>5.0.0-1.25358.11</MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>
+    <MicrosoftCodeAnalysisExternalAccessRazorEditorFeaturesPackageVersion>5.0.0-1.25358.11</MicrosoftCodeAnalysisExternalAccessRazorEditorFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisExternalAccessRazorFeaturesPackageVersion>5.0.0-1.25358.11</MicrosoftCodeAnalysisExternalAccessRazorFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisCommonPackageVersion>5.0.0-1.25358.11</MicrosoftCodeAnalysisCommonPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>5.0.0-1.25358.11</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>5.0.0-1.25358.11</MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>5.0.0-1.25358.11</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>5.0.0-1.25358.11</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesPackageVersion>5.0.0-1.25358.11</MicrosoftCodeAnalysisEditorFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>5.0.0-1.25358.11</MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>5.0.0-1.25358.11</MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>
+    <MicrosoftCodeAnalysisLanguageServerProtocolPackageVersion>5.0.0-1.25358.11</MicrosoftCodeAnalysisLanguageServerProtocolPackageVersion>
+    <MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>5.0.0-1.25358.11</MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>
+    <MicrosoftCodeAnalysisTestUtilitiesPackageVersion>5.0.0-1.25358.11</MicrosoftCodeAnalysisTestUtilitiesPackageVersion>
+    <MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>5.0.0-1.25358.11</MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>5.0.0-1.25358.11</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>5.0.0-1.25358.11</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
+    <MicrosoftVisualStudioLanguageServicesPackageVersion>5.0.0-1.25358.11</MicrosoftVisualStudioLanguageServicesPackageVersion>
     <!--
       Exception - Microsoft.Extensions.ObjectPool and System.Collections.Immutable packages are not updated by automation,
       but are present in Version.Details.xml for source-build PVP flow. See the comment in Version.Details.xml for more information.

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Discovery/ProjectStateChangeDetector.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Discovery/ProjectStateChangeDetector.TestAccessor.cs
@@ -39,7 +39,7 @@ internal partial class ProjectStateChangeDetector
 
         public void WorkspaceChanged(WorkspaceChangeEventArgs e)
         {
-            instance.Workspace_WorkspaceChanged(instance, e);
+            instance.OnWorkspaceChanged(e);
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/WorkspaceTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/WorkspaceTestBase.cs
@@ -126,7 +126,7 @@ public abstract class WorkspaceTestBase(ITestOutputHelper testOutput) : ToolingT
             {
                 var currentCount = 0;
 
-                Workspace.WorkspaceChanged += OnWorkspaceChanged;
+                using var _ = Workspace.RegisterWorkspaceChangedHandler(OnWorkspaceChanged);
 
                 if (!Workspace.TryApplyChanges(solution))
                 {
@@ -142,10 +142,9 @@ public abstract class WorkspaceTestBase(ITestOutputHelper testOutput) : ToolingT
                 }
                 while (lastCount != currentCount);
 
-                Workspace.WorkspaceChanged -= OnWorkspaceChanged;
                 return true;
 
-                void OnWorkspaceChanged(object? sender, WorkspaceChangeEventArgs e)
+                void OnWorkspaceChanged(WorkspaceChangeEventArgs e)
                 {
                     currentCount++;
                 }


### PR DESCRIPTION
This moves to the replacement for WorkspaceChanged that doesn't invoke on the UI thread. The code is believed to already be safe to invoke on any thread, so there's no deeper changes.