### PR TITLE
Fix edit mapping for Html documents

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/AbstractEditMappingService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/AbstractEditMappingService.cs
@@ -55,6 +55,13 @@ internal abstract class AbstractEditMappingService(
         {
             var generatedDocumentUri = new Uri(uriString);
 
+            // For Html we just map the Uri, the range will be the same
+            if (_filePathService.IsVirtualHtmlFile(generatedDocumentUri))
+            {
+                var razorUri = _filePathService.GetRazorDocumentUri(generatedDocumentUri);
+                remappedChanges[razorUri.AbsoluteUri] = edits;
+            }
+
             // Check if the edit is actually for a generated document, because if not we don't need to do anything
             if (!_filePathService.IsVirtualCSharpFile(generatedDocumentUri))
             {
@@ -110,6 +117,18 @@ internal abstract class AbstractEditMappingService(
         foreach (var entry in documentEdits)
         {
             var generatedDocumentUri = entry.TextDocument.DocumentUri.GetRequiredParsedUri();
+
+            // For Html we just map the Uri, the range will be the same
+            if (_filePathService.IsVirtualHtmlFile(generatedDocumentUri))
+            {
+                var razorUri = _filePathService.GetRazorDocumentUri(generatedDocumentUri);
+                entry.TextDocument = new OptionalVersionedTextDocumentIdentifier()
+                {
+                    DocumentUri = new(razorUri),
+                };
+                remappedDocumentEdits.Add(entry);
+                continue;
+            }
 
             // Check if the edit is actually for a generated document, because if not we don't need to do anything
             if (!_filePathService.IsVirtualCSharpFile(generatedDocumentUri))

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_CodeActions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_CodeActions.cs
@@ -54,33 +54,20 @@ internal partial class RazorCustomMessageTarget
 
         codeActionParams.CodeActionParams.TextDocument.DocumentUri = new(virtualDocumentSnapshot.Uri);
 
-        var textBuffer = virtualDocumentSnapshot.Snapshot.TextBuffer;
         var lspMethodName = Methods.TextDocumentCodeActionName;
         using var _ = _telemetryReporter.TrackLspRequest(lspMethodName, languageServerName, TelemetryThresholds.CodeActionSubLSPTelemetryThreshold, codeActionParams.CorrelationId);
-        var requests = _requestInvoker.ReinvokeRequestOnMultipleServersAsync<VSCodeActionParams, IReadOnlyList<VSInternalCodeAction>>(
-            textBuffer,
+        var response = await _requestInvoker.ReinvokeRequestOnServerAsync<VSCodeActionParams, IReadOnlyList<VSInternalCodeAction>>(
             lspMethodName,
+            languageServerName,
             codeActionParams.CodeActionParams,
             cancellationToken).ConfigureAwait(false);
 
-        var codeActions = new List<VSInternalCodeAction>();
-        await foreach (var response in requests.WithCancellation(cancellationToken).ConfigureAwait(false))
+        if (response.Result is { } codeActions)
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                break;
-            }
-
-            if (response.Response != null)
-            {
-                foreach (var codeAction in response.Response)
-                {
-                    codeActions.Add(codeAction);
-                }
-            }
+            return codeActions;
         }
 
-        return codeActions;
+        return [];
     }
 
     // Called by the Razor Language Server to resolve code actions from the platform.
@@ -94,12 +81,14 @@ internal partial class RazorCustomMessageTarget
 
         bool synchronized;
         VirtualDocumentSnapshot virtualDocumentSnapshot;
+        string languageServerName;
         if (resolveCodeActionParams.LanguageKind == RazorLanguageKind.Html)
         {
             (synchronized, virtualDocumentSnapshot) = await TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(
                 resolveCodeActionParams.HostDocumentVersion,
                 resolveCodeActionParams.Identifier,
                 cancellationToken).ConfigureAwait(false);
+            languageServerName = RazorLSPConstants.HtmlLanguageServerName;
         }
         else if (resolveCodeActionParams.LanguageKind == RazorLanguageKind.CSharp)
         {
@@ -107,6 +96,7 @@ internal partial class RazorCustomMessageTarget
                 resolveCodeActionParams.HostDocumentVersion,
                 resolveCodeActionParams.Identifier,
                 cancellationToken).ConfigureAwait(false);
+            languageServerName = RazorLSPConstants.RazorCSharpLanguageServerName;
         }
         else
         {
@@ -120,22 +110,17 @@ internal partial class RazorCustomMessageTarget
             return null;
         }
 
-        var textBuffer = virtualDocumentSnapshot.Snapshot.TextBuffer;
         var codeAction = resolveCodeActionParams.CodeAction;
 
-        var requests = _requestInvoker.ReinvokeRequestOnMultipleServersAsync<CodeAction, VSInternalCodeAction?>(
-            textBuffer,
+        var response = await _requestInvoker.ReinvokeRequestOnServerAsync<CodeAction, VSInternalCodeAction?>(
             Methods.CodeActionResolveName,
+            languageServerName,
             codeAction,
             cancellationToken).ConfigureAwait(false);
 
-        await foreach (var response in requests.WithCancellation(cancellationToken).ConfigureAwait(false))
+        if (response.Result is { } resolvedCodeAction)
         {
-            if (response.Response is not null)
-            {
-                // Only take the first response from a resolution
-                return response.Response;
-            }
+            return resolvedCodeAction;
         }
 
         return null;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_DocumentColor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_DocumentColor.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Protocol.ColorPresentation;
-using Microsoft.VisualStudio.Threading;
 using StreamJsonRpc;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient.Endpoints;
@@ -26,27 +25,17 @@ internal partial class RazorCustomMessageTarget
         var (synchronized, htmlDoc) = await TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(documentColorParams.HostDocumentVersion, documentColorParams.TextDocument, cancellationToken);
         if (!synchronized || htmlDoc is null)
         {
-            return new List<ColorInformation>();
+            return [];
         }
 
         documentColorParams.TextDocument.DocumentUri = new(htmlDoc.Uri);
-        var htmlTextBuffer = htmlDoc.Snapshot.TextBuffer;
-        var requests = _requestInvoker.ReinvokeRequestOnMultipleServersAsync<DocumentColorParams, ColorInformation[]>(
-            htmlTextBuffer,
+        var response = await _requestInvoker.ReinvokeRequestOnServerAsync<DocumentColorParams, ColorInformation[]>(
             Methods.TextDocumentDocumentColor.Name,
+            RazorLSPConstants.HtmlLanguageServerName,
             documentColorParams,
             cancellationToken).ConfigureAwait(false);
 
-        var colorInformation = new List<ColorInformation>();
-        await foreach (var response in requests)
-        {
-            if (response.Response is not null)
-            {
-                colorInformation.AddRange(response.Response);
-            }
-        }
-
-        return colorInformation;
+        return response.Result;
     }
 
     // Called by the Razor Language Server to provide color presentation from the platform.
@@ -61,26 +50,16 @@ internal partial class RazorCustomMessageTarget
         var (synchronized, htmlDoc) = await TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(colorPresentationParams.RequiredHostDocumentVersion, colorPresentationParams.TextDocument, cancellationToken);
         if (!synchronized || htmlDoc is null)
         {
-            return new List<ColorPresentation>();
+            return [];
         }
 
         colorPresentationParams.TextDocument.DocumentUri = new(htmlDoc.Uri);
-        var htmlTextBuffer = htmlDoc.Snapshot.TextBuffer;
-        var requests = _requestInvoker.ReinvokeRequestOnMultipleServersAsync<ColorPresentationParams, ColorPresentation[]>(
-            htmlTextBuffer,
+        var response = await _requestInvoker.ReinvokeRequestOnServerAsync<ColorPresentationParams, ColorPresentation[]>(
             Methods.TextDocumentColorPresentationName,
+            RazorLSPConstants.HtmlLanguageServerName,
             colorPresentationParams,
             cancellationToken).ConfigureAwait(false);
 
-        var colorPresentation = new List<ColorPresentation>();
-        await foreach (var response in requests)
-        {
-            if (response.Response is not null)
-            {
-                colorPresentation.AddRange(response.Response);
-            }
-        }
-
-        return colorPresentation;
+        return response.Result;
     }
 }


### PR DESCRIPTION
Fixes the integration tests that I broke when I removed Html source mappings.

Also simplified the code actions and document color code, because they were the only two requesting from multiple language servers, which made debugging annoying, and is wasteful because we were getting empty responses from the ESLint server. We only work with the Html server in VS, and there is no point pretending otherwise.