### PR TITLE
Fix completion of hyphenated items

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionTriggerAndCommitCharacters.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionTriggerAndCommitCharacters.cs
@@ -15,7 +15,7 @@ internal class CompletionTriggerAndCommitCharacters
     private const char TransitionCharacter = '@';
 
     private static readonly char[] s_vsHtmlTriggerCharacters = [':', '#', '.', '!', '*', ',', '(', '[', '-', '<', '&', '\\', '/', '\'', '"', '=', ':', ' ', '`'];
-    private static readonly char[] s_vsCodeHtmlTriggerCharacters = ['#', '.', '!', ',', '-', '<'];
+    private static readonly char[] s_vsCodeHtmlTriggerCharacters = ['#', '.', '!', ',', '<'];
     private static readonly char[] s_razorTriggerCharacters = ['<', ':', ' '];
     private static readonly char[] s_csharpTriggerCharacters = [' ', '(', '=', '#', '.', '<', '[', '{', '"', '/', ':', '~'];
     private static readonly ImmutableArray<string> s_commitCharacters = [" ", ">", ";", "="];


### PR DESCRIPTION
﻿### Summary of the changes
VSCode dismisses and re-invokes completion and when a trigger character is typed, even if completion list is up while typing it. That's different from how VS client handles trigger characters. Removing hyphen from trigger characters for VSCode fixes this behavior and allowed proper filtering and completion of such items. Same goes double-completion of "asp-" if trying to complete after the "-". If "-" is a trigger character, VSCode doesn't include it or text before it in "applicable to" span when completing, resulting in text like asp-asp-xxx getting inserted.

Fixes:
Two internally filed issues:
- There are two "asp" when type code "<form asp-ant" in  _layout.cshtml and press "Enter"
- There is no intellisense when type "asp-" in cshtml file