### PR TITLE
Ensure unique file paths for non-file Uris

### DIFF
--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/UriExtensionsTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/UriExtensionsTest.cs
@@ -60,6 +60,7 @@ public class UriExtensionsTest : ToolingTestBase
     [InlineData(@"git:/c%3A/path/to/dir/Index.cshtml", @"c:/_git_/path/to/dir/Index.cshtml")]
     [InlineData(@"git:/c:/path%2Fto/dir/Index.cshtml?%7B%22p", @"c:/_git_/path/to/dir/Index.cshtml")]
     [InlineData(@"git:/c:/path/to/dir/Index.cshtml", @"c:/_git_/path/to/dir/Index.cshtml")]
+    [InlineData(@"chat-editing-text-model:/c:/path/to/dir/Index.cshtml", @"c:/_chat-editing-text-model_/path/to/dir/Index.cshtml")]
     public void GetAbsoluteOrUNCPath_AbsolutePath_HandlesGitScheme(string filePath, string expected)
     {
         // Arrange


### PR DESCRIPTION
Bug: https://github.com/microsoft/vscode-dotnettools/issues/2151
(deliberately not marking this PR as a fix due to DevKit process)

When an active agent chat session is open, VS Code will send LSP requests for files with the `chat-editing-text-model://` scheme, similar to how the left hand side of a diff view uses `git://`. This causes problems during editing because we end up getting didChange messages for Uris with that scheme, and Uris with the file scheme, which means we end up with two didChanges for the same physical file.

This PR expands the fix we previously had specifically for `git://` Uris, to apply to any non-file Uri. It essentially ensures these documents are always in the misc files project, so we'll still be able to generally deal with them, we just won't get confused by them.