### PR TITLE
Fix exception in tests

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestRazorProjectInfoDriver.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestRazorProjectInfoDriver.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+
+internal class TestRazorProjectInfoDriver : IRazorProjectInfoDriver
+{
+    public static readonly TestRazorProjectInfoDriver Instance = new();
+
+    public void AddListener(IRazorProjectInfoListener listener)
+    {
+    }
+
+    public ImmutableArray<RazorProjectInfo> GetLatestProjectInfo()
+    {
+        return [];
+    }
+
+    public Task WaitForInitializationAsync()
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestRazorProjectInfoDriver.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestRazorProjectInfoDriver.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 
-internal class TestRazorProjectInfoDriver : IRazorProjectInfoDriver
+internal sealed class TestRazorProjectInfoDriver : IRazorProjectInfoDriver
 {
     public static readonly TestRazorProjectInfoDriver Instance = new();
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestRazorProjectService.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestRazorProjectService.cs
@@ -5,12 +5,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
-using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Serialization;
 using Microsoft.CodeAnalysis.Razor.Utilities;
-using Moq;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 
@@ -20,23 +18,11 @@ internal class TestRazorProjectService(
     ILoggerFactory loggerFactory)
     : RazorProjectService(
         projectManager,
-        CreateProjectInfoDriver(),
+        TestRazorProjectInfoDriver.Instance,
         remoteTextLoaderFactory,
         loggerFactory)
 {
     private readonly ProjectSnapshotManager _projectManager = projectManager;
-
-    private static IRazorProjectInfoDriver CreateProjectInfoDriver()
-    {
-        var mock = new StrictMock<IRazorProjectInfoDriver>();
-
-        mock.Setup(x => x.GetLatestProjectInfo())
-            .Returns([]);
-
-        mock.Setup(x => x.AddListener(It.IsAny<IRazorProjectInfoListener>()));
-
-        return mock.Object;
-    }
 
     public async Task AddDocumentToPotentialProjectsAsync(string filePath, CancellationToken cancellationToken)
     {


### PR DESCRIPTION
Going through our tests trying to find the source of the flakiness. This isn't it, but it does throw an exception during language server shut down (method not mocked) so its not exactly helping.