### PR TITLE
Make cohost formatting honour C# formatting options

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostDocumentFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostDocumentFormattingEndpoint.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
 using Microsoft.CodeAnalysis.Razor.Cohost;
@@ -60,7 +61,13 @@ internal sealed class CohostDocumentFormattingEndpoint(
     protected override RazorTextDocumentIdentifier? GetRazorTextDocumentIdentifier(DocumentFormattingParams request)
         => request.TextDocument.ToRazorTextDocumentIdentifier();
 
-    protected override async Task<TextEdit[]?> HandleRequestAsync(DocumentFormattingParams request, TextDocument razorDocument, CancellationToken cancellationToken)
+    protected override Task<TextEdit[]?> HandleRequestAsync(DocumentFormattingParams request, TextDocument razorDocument, CancellationToken cancellationToken)
+    {
+        var csharpSyntaxFormattingOptions = RazorCSharpFormattingInteractionService.GetRazorCSharpSyntaxFormattingOptions(razorDocument.Project.Solution.Services);
+        return HandleRequestAsync(request, razorDocument, csharpSyntaxFormattingOptions, cancellationToken);
+    }
+
+    private async Task<TextEdit[]?> HandleRequestAsync(DocumentFormattingParams request, TextDocument razorDocument, RazorCSharpSyntaxFormattingOptions csharpSyntaxFormattingOptions, CancellationToken cancellationToken)
     {
         _logger.LogDebug($"Getting Html formatting changes for {razorDocument.FilePath}");
         var htmlResult = await TryGetHtmlFormattingEditsAsync(request, razorDocument, cancellationToken).ConfigureAwait(false);
@@ -75,7 +82,10 @@ internal sealed class CohostDocumentFormattingEndpoint(
         var sourceText = await razorDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
         var htmlChanges = htmlEdits.SelectAsArray(sourceText.GetTextChange);
 
-        var options = RazorFormattingOptions.From(request.Options, _clientSettingsManager.GetClientSettings().AdvancedSettings.CodeBlockBraceOnNextLine);
+        var options = RazorFormattingOptions.From(
+            request.Options,
+            _clientSettingsManager.GetClientSettings().AdvancedSettings.CodeBlockBraceOnNextLine,
+            csharpSyntaxFormattingOptions);
 
         _logger.LogDebug($"Calling OOP with the {htmlChanges.Length} html edits, so it can fill in the rest");
         var remoteResult = await _remoteServiceInvoker.TryInvokeAsync<IRemoteFormattingService, ImmutableArray<TextChange>>(
@@ -114,8 +124,7 @@ internal sealed class CohostDocumentFormattingEndpoint(
 
     internal readonly struct TestAccessor(CohostDocumentFormattingEndpoint instance)
     {
-        public Task<TextEdit[]?> HandleRequestAsync(DocumentFormattingParams request, TextDocument razorDocument, CancellationToken cancellationToken)
-            => instance.HandleRequestAsync(request, razorDocument, cancellationToken);
+        public Task<TextEdit[]?> HandleRequestAsync(DocumentFormattingParams request, TextDocument razorDocument, RazorCSharpSyntaxFormattingOptions csharpSyntaxFormattingOptions, CancellationToken cancellationToken)
+            => instance.HandleRequestAsync(request, razorDocument, csharpSyntaxFormattingOptions, cancellationToken);
     }
 }
-

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostOnTypeFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostOnTypeFormattingEndpoint.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
 using Microsoft.CodeAnalysis.Razor.Cohost;
@@ -111,7 +112,8 @@ internal sealed class CohostOnTypeFormattingEndpoint(
             htmlChanges = htmlEdits.SelectAsArray(sourceText.GetTextChange);
         }
 
-        var options = RazorFormattingOptions.From(request.Options, clientSettings.AdvancedSettings.CodeBlockBraceOnNextLine);
+        var csharpSyntaxFormattingOptions = RazorCSharpFormattingInteractionService.GetRazorCSharpSyntaxFormattingOptions(razorDocument.Project.Solution.Services);
+        var options = RazorFormattingOptions.From(request.Options, clientSettings.AdvancedSettings.CodeBlockBraceOnNextLine, csharpSyntaxFormattingOptions);
 
         _logger.LogDebug($"Calling OOP with the {htmlChanges.Length} html edits, so it can fill in the rest");
         var remoteResult = await _remoteServiceInvoker.TryInvokeAsync<IRemoteFormattingService, ImmutableArray<TextChange>>(
@@ -154,4 +156,3 @@ internal sealed class CohostOnTypeFormattingEndpoint(
             => instance.HandleRequestAsync(request, razorDocument, cancellationToken);
     }
 }
-

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPass.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPass.cs
@@ -87,7 +87,7 @@ internal sealed class CSharpFormattingPass(
             // These should already be remapped.
             var spanToFormat = sourceText.GetLinePositionSpan(span);
 
-            var changes = await _csharpFormatter.FormatAsync(hostWorkspaceServices, csharpDocument, context, spanToFormat, _csharpSyntaxFormattingOptionsOverride, cancellationToken).ConfigureAwait(false);
+            var changes = await _csharpFormatter.FormatAsync(hostWorkspaceServices, csharpDocument, context, spanToFormat, cancellationToken).ConfigureAwait(false);
             csharpChanges.AddRange(changes.Where(e => spanToFormat.Contains(sourceText.GetLinePositionSpan(e.Span))));
         }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPassBase.cs
@@ -13,7 +13,6 @@ using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.PooledObjects;
-using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.Logging;
@@ -28,8 +27,6 @@ internal abstract partial class CSharpFormattingPassBase(IDocumentMappingService
     private readonly bool _isFormatOnType = isFormatOnType;
 
     protected IDocumentMappingService DocumentMappingService { get; } = documentMappingService;
-
-    protected RazorCSharpSyntaxFormattingOptions? _csharpSyntaxFormattingOptionsOverride;
 
     public async Task<ImmutableArray<TextChange>> ExecuteAsync(FormattingContext context, ImmutableArray<TextChange> changes, CancellationToken cancellationToken)
     {
@@ -167,7 +164,7 @@ internal abstract partial class CSharpFormattingPassBase(IDocumentMappingService
         }
 
         // Now, invoke the C# formatter to obtain the CSharpDesiredIndentation for all significant locations.
-        var significantLocationIndentation = await CSharpFormatter.GetCSharpIndentationAsync(context, significantLocations, hostWorkspaceServices, _csharpSyntaxFormattingOptionsOverride, cancellationToken).ConfigureAwait(false);
+        var significantLocationIndentation = await CSharpFormatter.GetCSharpIndentationAsync(context, significantLocations, hostWorkspaceServices, cancellationToken).ConfigureAwait(false);
 
         // Build source mapping indentation scopes.
         var sourceMappingIndentations = new SortedDictionary<int, IndentationData>();
@@ -696,16 +693,6 @@ internal abstract partial class CSharpFormattingPassBase(IDocumentMappingService
             }
 
             return _indentation;
-        }
-    }
-
-    internal TestAccessor GetTestAccessor() => new(this);
-
-    internal readonly struct TestAccessor(CSharpFormattingPassBase instance)
-    {
-        public void SetCSharpSyntaxFormattingOptionsOverride(RazorCSharpSyntaxFormattingOptions? optionsOverride)
-        {
-            instance._csharpSyntaxFormattingOptionsOverride = optionsOverride;
         }
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
@@ -58,7 +58,7 @@ internal sealed class CSharpOnTypeFormattingPass(
                 context.Options.ToIndentationOptions(),
                 autoFormattingOptions,
                 indentStyle: CodeAnalysis.Formatting.FormattingOptions.IndentStyle.Smart,
-                _csharpSyntaxFormattingOptionsOverride,
+                context.Options.CSharpSyntaxFormattingOptions,
                 cancellationToken).ConfigureAwait(false);
 
             if (formattingChanges.IsEmpty)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/RazorFormattingOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/RazorFormattingOptions.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.Serialization;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
 
 namespace Microsoft.CodeAnalysis.Razor.Formatting;
 
@@ -15,6 +16,8 @@ internal readonly record struct RazorFormattingOptions
     public int TabSize { get; init; } = 4;
     [DataMember(Order = 2)]
     public bool CodeBlockBraceOnNextLine { get; init; } = false;
+    [DataMember(Order = 3)]
+    public RazorCSharpSyntaxFormattingOptions? CSharpSyntaxFormattingOptions { get; init; }
 
     public RazorFormattingOptions()
     {
@@ -26,6 +29,15 @@ internal readonly record struct RazorFormattingOptions
             InsertSpaces = options.InsertSpaces,
             TabSize = options.TabSize,
             CodeBlockBraceOnNextLine = codeBlockBraceOnNextLine
+        };
+
+    public static RazorFormattingOptions From(FormattingOptions options, bool codeBlockBraceOnNextLine, RazorCSharpSyntaxFormattingOptions csharpSyntaxFormattingOptions)
+        => new()
+        {
+            InsertSpaces = options.InsertSpaces,
+            TabSize = options.TabSize,
+            CodeBlockBraceOnNextLine = codeBlockBraceOnNextLine,
+            CSharpSyntaxFormattingOptions = csharpSyntaxFormattingOptions
         };
 
     public RazorIndentationOptions ToIndentationOptions()

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/RazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/RazorFormattingService.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -395,24 +394,6 @@ internal class RazorFormattingService : IRazorFormattingService
         {
             var contentValidationPass = service._validationPasses.OfType<FormattingContentValidationPass>().Single();
             contentValidationPass.DebugAssertsEnabled = debugAssertsEnabled;
-        }
-
-        public void SetCSharpSyntaxFormattingOptionsOverride(RazorCSharpSyntaxFormattingOptions? optionsOverride)
-        {
-            if (service._documentFormattingPasses.OfType<CSharpFormattingPass>().SingleOrDefault() is { } pass)
-            {
-                pass.GetTestAccessor().SetCSharpSyntaxFormattingOptionsOverride(optionsOverride);
-            }
-
-            if (service._documentFormattingPasses.OfType<CSharpOnTypeFormattingPass>().SingleOrDefault() is { } onTypePass)
-            {
-                onTypePass.GetTestAccessor().SetCSharpSyntaxFormattingOptionsOverride(optionsOverride);
-            }
-
-            if (service._documentFormattingPasses.OfType<New.CSharpFormattingPass>().SingleOrDefault() is { } newPass)
-            {
-                newPass.GetTestAccessor().SetCSharpSyntaxFormattingOptionsOverride(optionsOverride);
-            }
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentFormattingTest.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Test.Common;
@@ -66,7 +65,7 @@ public class DocumentFormattingTest(FormattingTestContext context, HtmlFormattin
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.None
             });
@@ -106,7 +105,7 @@ public class DocumentFormattingTest(FormattingTestContext context, HtmlFormattin
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.None
             });
@@ -134,7 +133,7 @@ public class DocumentFormattingTest(FormattingTestContext context, HtmlFormattin
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeOpenBraceInMethods
             });
@@ -164,7 +163,7 @@ public class DocumentFormattingTest(FormattingTestContext context, HtmlFormattin
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeOpenBraceInMethods
             });
@@ -194,7 +193,7 @@ public class DocumentFormattingTest(FormattingTestContext context, HtmlFormattin
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeOpenBraceInMethods
             });
@@ -228,7 +227,7 @@ public class DocumentFormattingTest(FormattingTestContext context, HtmlFormattin
                     }
                 </div>
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeOpenBraceInMethods
             });
@@ -255,7 +254,7 @@ public class DocumentFormattingTest(FormattingTestContext context, HtmlFormattin
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.None
             });

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingTestBase.cs
@@ -66,13 +66,15 @@ public abstract class FormattingTestBase : RazorToolingIntegrationTestBase
         bool codeBlockBraceOnNextLine = false,
         bool inGlobalNamespace = false,
         bool debugAssertsEnabled = true,
-        RazorCSharpSyntaxFormattingOptions? formattingOptionsOverride = null)
+        RazorCSharpSyntaxFormattingOptions? csharpSyntaxFormattingOptions = null)
     {
         (input, expected) = ProcessFormattingContext(input, expected);
 
         var razorLSPOptions = RazorLSPOptions.Default with { CodeBlockBraceOnNextLine = codeBlockBraceOnNextLine };
 
-        await RunFormattingTestInternalAsync(input, expected, tabSize, insertSpaces, fileKind, tagHelpers, allowDiagnostics, razorLSPOptions, inGlobalNamespace, debugAssertsEnabled, formattingOptionsOverride);
+        csharpSyntaxFormattingOptions ??= RazorCSharpSyntaxFormattingOptions.Default;
+
+        await RunFormattingTestInternalAsync(input, expected, tabSize, insertSpaces, fileKind, tagHelpers, allowDiagnostics, razorLSPOptions, inGlobalNamespace, debugAssertsEnabled, csharpSyntaxFormattingOptions);
     }
 
     private async Task RunFormattingTestInternalAsync(
@@ -86,7 +88,7 @@ public abstract class FormattingTestBase : RazorToolingIntegrationTestBase
         RazorLSPOptions? razorLSPOptions,
         bool inGlobalNamespace,
         bool debugAssertsEnabled,
-        RazorCSharpSyntaxFormattingOptions? formattingOptionsOverride)
+        RazorCSharpSyntaxFormattingOptions csharpSyntaxFormattingOptions)
     {
         // Arrange
         var fileKindValue = fileKind ?? RazorFileKind.Component;
@@ -109,11 +111,11 @@ public abstract class FormattingTestBase : RazorToolingIntegrationTestBase
             TabSize = tabSize,
             InsertSpaces = insertSpaces,
         };
-        var razorOptions = RazorFormattingOptions.From(options, codeBlockBraceOnNextLine: razorLSPOptions?.CodeBlockBraceOnNextLine ?? false);
+        var razorOptions = RazorFormattingOptions.From(options, codeBlockBraceOnNextLine: razorLSPOptions?.CodeBlockBraceOnNextLine ?? false, csharpSyntaxFormattingOptions);
 
         var languageServerFeatureOptions = new TestLanguageServerFeatureOptions(useNewFormattingEngine: _context.UseNewFormattingEngine);
 
-        var formattingService = await TestRazorFormattingService.CreateWithFullSupportAsync(LoggerFactory, codeDocument, razorLSPOptions, languageServerFeatureOptions, debugAssertsEnabled, formattingOptionsOverride);
+        var formattingService = await TestRazorFormattingService.CreateWithFullSupportAsync(LoggerFactory, codeDocument, razorLSPOptions, languageServerFeatureOptions, debugAssertsEnabled);
         var documentContext = new DocumentContext(uri, documentSnapshot, projectContext: null);
 
         var client = new FormattingLanguageServerClient(_htmlFormattingService, LoggerFactory);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/TestRazorFormattingService.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/TestRazorFormattingService.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
-using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
 using Microsoft.CodeAnalysis.Razor.Formatting;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
@@ -23,8 +22,7 @@ internal static class TestRazorFormattingService
         RazorCodeDocument? codeDocument = null,
         RazorLSPOptions? razorLSPOptions = null,
         LanguageServerFeatureOptions? languageServerFeatureOptions = null,
-        bool debugAssertsEnabled = false,
-        RazorCSharpSyntaxFormattingOptions? formattingOptionsOverride = null)
+        bool debugAssertsEnabled = false)
     {
         codeDocument ??= TestRazorCodeDocument.CreateEmpty();
 
@@ -50,7 +48,6 @@ internal static class TestRazorFormattingService
         var service = new RazorFormattingService(mappingService, hostServicesProvider, languageServerFeatureOptions, loggerFactory);
         var accessor = service.GetTestAccessor();
         accessor.SetDebugAssertsEnabled(debugAssertsEnabled);
-        accessor.SetCSharpSyntaxFormattingOptionsOverride(formattingOptionsOverride);
 
         return service;
     }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/Formatting/CSharpSyntaxFormattingOptionsTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/Formatting/CSharpSyntaxFormattingOptionsTest.cs
@@ -39,7 +39,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -71,7 +71,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -103,7 +103,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -135,7 +135,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -167,7 +167,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -199,7 +199,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -231,7 +231,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -263,7 +263,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -295,7 +295,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -327,7 +327,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -359,7 +359,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -391,7 +391,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -423,7 +423,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -455,7 +455,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -487,7 +487,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -519,7 +519,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -551,7 +551,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -583,7 +583,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -615,7 +615,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -647,7 +647,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -679,7 +679,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -711,7 +711,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -743,7 +743,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -775,7 +775,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -807,7 +807,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -839,7 +839,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -871,7 +871,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -903,7 +903,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -935,7 +935,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -967,7 +967,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -999,7 +999,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -1031,7 +1031,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -1063,7 +1063,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -1095,7 +1095,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -1127,7 +1127,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -1159,7 +1159,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -1190,7 +1190,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -1221,7 +1221,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -1252,7 +1252,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -1283,7 +1283,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -1315,7 +1315,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -1347,7 +1347,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -1379,7 +1379,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -1411,7 +1411,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -1443,7 +1443,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -1475,7 +1475,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -1507,7 +1507,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -1539,7 +1539,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -1571,7 +1571,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -1603,7 +1603,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -1635,7 +1635,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -1667,7 +1667,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -1699,7 +1699,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -1731,7 +1731,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -1763,7 +1763,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -1795,7 +1795,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BetweenQueryExpressionClauses,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -1827,7 +1827,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -1859,7 +1859,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks,
                 WrappingKeepStatementsOnSingleLine = true,
@@ -1891,7 +1891,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks,
                 WrappingKeepStatementsOnSingleLine = false,
@@ -1923,7 +1923,7 @@ public class CSharpSyntaxFormattingOptionsTest(FormattingTestContext context, Ht
                     }
                 }
                 """,
-            formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
             {
                 NewLines = RazorNewLinePlacement.BeforeMembersInObjectInitializers | RazorNewLinePlacement.BeforeMembersInAnonymousTypes | RazorNewLinePlacement.BeforeElse | RazorNewLinePlacement.BeforeCatch | RazorNewLinePlacement.BeforeFinally | RazorNewLinePlacement.BeforeOpenBraceInTypes | RazorNewLinePlacement.BeforeOpenBraceInAnonymousTypes | RazorNewLinePlacement.BeforeOpenBraceInObjectCollectionArrayInitializers | RazorNewLinePlacement.BeforeOpenBraceInProperties | RazorNewLinePlacement.BeforeOpenBraceInMethods | RazorNewLinePlacement.BeforeOpenBraceInAccessors | RazorNewLinePlacement.BeforeOpenBraceInAnonymousMethods | RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody | RazorNewLinePlacement.BeforeOpenBraceInControlBlocks,
                 WrappingKeepStatementsOnSingleLine = false,

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/Formatting/CSharpSyntaxFormattingOptionsTest_Generator.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/Formatting/CSharpSyntaxFormattingOptionsTest_Generator.cs
@@ -76,7 +76,7 @@ public class CSharpSyntaxFormattingOptionsTest_Generator
                             }
                         }
                         """,
-                    formattingOptionsOverride: RazorCSharpSyntaxFormattingOptions.Default with
+                    csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
                     {
                         NewLines = {RazorNewLinePlacement},
                         WrappingKeepStatementsOnSingleLine = {WrappingKeepStatementsOnSingleLine},


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/11839
Needs https://github.com/dotnet/roslyn/pull/79458 before it will compile

This just tweaks the "override C# settings for tests" system we had into a formal "can specify C# settings before formatting" option, and then in cohosting we grab the options from Roslyn (via new EA API) before jumping to OOP.