### PR TITLE
Ignore missing classname error from C# in style block

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Diagnostics/CSSErrorCodes.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Diagnostics/CSSErrorCodes.cs
@@ -7,6 +7,7 @@ namespace Microsoft.CodeAnalysis.Razor.Diagnostics;
 internal static class CSSErrorCodes
 {
     public const string UnrecognizedBlockType = "CSS002";
+    public const string MissingClassNameAfterDot = "CSS008";
     public const string MissingOpeningBrace = "CSS023";
     public const string MissingSelectorAfterCombinator = "CSS029";
     public const string MissingSelectorBeforeCombinatorCode = "CSS031";

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Diagnostics/RazorTranslateDiagnosticsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Diagnostics/RazorTranslateDiagnosticsService.cs
@@ -241,6 +241,7 @@ internal class RazorTranslateDiagnosticsService(IDocumentMappingService document
         {
             CSSErrorCodes.UnrecognizedBlockType => IsEscapedAtSign(diagnostic, sourceText),
             CSSErrorCodes.MissingOpeningBrace => IsCSharpInStyleBlock(diagnostic, sourceText, syntaxTree),
+            CSSErrorCodes.MissingClassNameAfterDot => IsCSharpInStyleBlock(diagnostic, sourceText, syntaxTree),
             CSSErrorCodes.MissingSelectorAfterCombinator => IsCSharpInStyleBlock(diagnostic, sourceText, syntaxTree),
             CSSErrorCodes.MissingSelectorBeforeCombinatorCode => IsCSharpInStyleBlock(diagnostic, sourceText, syntaxTree),
             HtmlErrorCodes.UnexpectedEndTagErrorCode => IsHtmlWithBangAndMatchingTags(diagnostic, sourceText, syntaxTree),

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentPullDiagnosticsTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentPullDiagnosticsTest.cs
@@ -164,6 +164,40 @@ public class CohostDocumentPullDiagnosticsTest(ITestOutputHelper testOutputHelpe
     }
 
     [Fact]
+    public Task FilterMissingClassNameInCss()
+    {
+        TestCode input = """
+            <div>
+
+            <style>
+              .@(className)
+                background-color: lightblue;
+              }
+            </style>
+
+            </div>
+
+            @code
+            {
+                private string className = "foo";
+            }
+            """;
+
+        return VerifyDiagnosticsAsync(input,
+            htmlResponse: [new VSInternalDiagnosticReport
+            {
+                Diagnostics =
+                [
+                    new Diagnostic
+                    {
+                        Code = CSSErrorCodes.MissingClassNameAfterDot,
+                        Range = SourceText.From(input.Text).GetRange(new TextSpan(input.Text.IndexOf("@"), 1))
+                    },
+                ]
+            }]);
+    }
+
+    [Fact]
     public Task CombinedAndNestedDiagnostics()
         => VerifyDiagnosticsAsync("""
             @using System.Threading.Tasks;


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/12052