### PR TITLE
Explicitly deny certain Roslyn formatting options

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/New/CSharpFormattingPass.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/New/CSharpFormattingPass.cs
@@ -6,10 +6,12 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
@@ -220,7 +222,30 @@ internal sealed partial class CSharpFormattingPass(IHostServicesProvider hostSer
 
         var tree = CSharpSyntaxTree.ParseText(generatedCSharpText, cancellationToken: cancellationToken);
         var csharpRoot = await tree.GetRootAsync(cancellationToken).ConfigureAwait(false);
-        var csharpChanges = RazorCSharpFormattingInteractionService.GetFormattedTextChanges(helper.HostWorkspaceServices, csharpRoot, csharpRoot.FullSpan, options.ToIndentationOptions(), options.CSharpSyntaxFormattingOptions, cancellationToken);
+        var csharpSyntaxFormattingOptions = options.CSharpSyntaxFormattingOptions.AssumeNotNull();
+
+        // Roslyn can be configured to insert a space after a method call, or a dot, but that can break Razor. eg:
+        //
+        // <div>@PrintHello()</div>
+        // @DateTime.Now.ToString()
+        //
+        // Would become:
+        //
+        // <div>@PrintHello ()</div>
+        // @DateTime. Now. ToString()
+        //
+        // In Razor, that's not a method call, its a method group (ie C# compile error) followed by Html, and
+        // the dot after DateTime is also just Html, as is the rest of the line.
+        // We're not smart enough (yet?) to ignore this change when its inline in Razor, but allow it when
+        // in a code block, so we just force these options to off.
+        csharpSyntaxFormattingOptions = csharpSyntaxFormattingOptions with
+        {
+            Spacing = csharpSyntaxFormattingOptions.Spacing
+                & ~RazorSpacePlacement.AfterMethodCallName
+                & ~RazorSpacePlacement.AfterDot
+        };
+
+        var csharpChanges = RazorCSharpFormattingInteractionService.GetFormattedTextChanges(helper.HostWorkspaceServices, csharpRoot, csharpRoot.FullSpan, options.ToIndentationOptions(), csharpSyntaxFormattingOptions, cancellationToken);
 
         return generatedCSharpText.WithChanges(csharpChanges);
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentFormattingTest.cs
@@ -29,6 +29,118 @@ public class DocumentFormattingTest(FormattingTestContext context, HtmlFormattin
             expected: "");
     }
 
+    [FormattingTestFact(SkipOldFormattingEngine = true)]
+    public async Task RoslynFormatSpaceAfterDot()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                <div>
+
+                @DateTime.Now.ToString()
+
+                </div>
+                """,
+            expected: """
+                <div>
+                
+                    @DateTime.Now.ToString()
+                
+                </div>
+                """,
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
+            {
+                Spacing = RazorSpacePlacement.AfterDot
+            });
+    }
+
+    [FormattingTestFact(SkipOldFormattingEngine = true)]
+    public async Task RoslynFormatSpaceAfterMethodCall()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                <h1>count is @counter</h1>
+
+                @GetCount()
+
+                @code {
+                private int counter;
+
+                class Goo
+                {
+                    public int GetCount()
+                    {
+                        return counter++;
+                    }
+                }
+                }
+                """,
+            expected: """
+                <h1>count is @counter</h1>
+                
+                @GetCount()
+                
+                @code {
+                    private int counter;
+                
+                    class Goo
+                    {
+                        public int GetCount()
+                        {
+                            return counter++;
+                        }
+                    }
+                }
+                """,
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
+            {
+                Spacing = RazorSpacePlacement.AfterMethodCallName
+            });
+    }
+
+    [FormattingTestFact(SkipOldFormattingEngine = true)]
+    public async Task RoslynFormatSpaceAfterMethodCallAndDecl()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                <h1>count is @counter</h1>
+
+                @GetCount()
+
+                @code {
+                private int counter;
+
+                class Goo
+                {
+                    public int GetCount()
+                    {
+                        return counter++;
+                    }
+                }
+                }
+                """,
+            expected: """
+                <h1>count is @counter</h1>
+                
+                @GetCount()
+                
+                @code {
+                    private int counter;
+                
+                    class Goo
+                    {
+                        public int GetCount ()
+                        {
+                            return counter++;
+                        }
+                    }
+                }
+                """,
+            csharpSyntaxFormattingOptions: RazorCSharpSyntaxFormattingOptions.Default with
+            {
+                Spacing = RazorSpacePlacement.AfterMethodCallName | RazorSpacePlacement.AfterMethodDeclarationName
+            });
+    }
+
     [FormattingTestFact]
     public async Task RoslynFormatBracesAsKandR()
     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/12053