### PR TITLE
Remove intermediate strings from hint name calculation

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/TextDocumentExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/TextDocumentExtensions.cs
@@ -26,12 +26,8 @@ internal static class TextDocumentExtensions
         }
 
         var filePath = razorDocument.Project.FilePath.AsSpanOrDefault();
-        var projectBasePath = PathUtilities.GetDirectoryName(filePath);
-        var relativeDocumentPath = filePath[projectBasePath.Length..];
-        while (relativeDocumentPath[0] is '/' or '\\')
-        {
-            relativeDocumentPath = relativeDocumentPath[1..];
-        }
+        var containingPath = PathUtilities.GetDirectoryName(filePath);
+        var relativeDocumentPath = filePath[containingPath.Length..].TrimStart(['/', '\\']);
 
         hintName = RazorSourceGenerator.GetIdentifierFromPath(relativeDocumentPath);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/TextDocumentExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/TextDocumentExtensions.cs
@@ -25,9 +25,17 @@ internal static class TextDocumentExtensions
             return false;
         }
 
-        var filePath = razorDocument.Project.FilePath.AsSpanOrDefault();
-        var containingPath = PathUtilities.GetDirectoryName(filePath);
-        var relativeDocumentPath = filePath[containingPath.Length..].TrimStart(['/', '\\']);
+        var filePath = razorDocument.FilePath.AsSpanOrDefault();
+        var projectFilePath = razorDocument.Project.FilePath.AsSpanOrDefault();
+        var projectBasePath = PathUtilities.GetDirectoryName(projectFilePath);
+        if (filePath.Length <= projectBasePath.Length)
+        {
+            // File must be from outside the project directory
+            hintName = null;
+            return false;
+        }
+
+        var relativeDocumentPath = filePath[projectBasePath.Length..].TrimStart(['/', '\\']);
 
         hintName = RazorSourceGenerator.GetIdentifierFromPath(relativeDocumentPath);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/TextDocumentExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/TextDocumentExtensions.cs
@@ -1,8 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
 using Microsoft.AspNetCore.Razor;
 using Microsoft.NET.Sdk.Razor.SourceGenerators;
 
@@ -25,8 +25,14 @@ internal static class TextDocumentExtensions
             return false;
         }
 
-        var projectBasePath = Path.GetDirectoryName(razorDocument.Project.FilePath).AssumeNotNull();
-        var relativeDocumentPath = razorDocument.FilePath[projectBasePath.Length..].TrimStart('/', '\\');
+        var filePath = razorDocument.Project.FilePath.AsSpanOrDefault();
+        var projectBasePath = PathUtilities.GetDirectoryName(filePath);
+        var relativeDocumentPath = filePath[projectBasePath.Length..];
+        while (relativeDocumentPath[0] is '/' or '\\')
+        {
+            relativeDocumentPath = relativeDocumentPath[1..];
+        }
+
         hintName = RazorSourceGenerator.GetIdentifierFromPath(relativeDocumentPath);
 
         return hintName is not null;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/XunitDisposeHook.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/XunitDisposeHook.cs
@@ -63,7 +63,10 @@ internal sealed class XunitDisposeHook : MarshalByRefObject
                     // ret
                     Marshal.WriteByte(functionPointer, 0xC3);
                     break;
-
+                case Architecture.Arm64:
+                    // This place is not a place of honor. No highly esteemed deed is commemorated here.
+                    Marshal.WriteInt64(functionPointer, 0xD65F03C0);
+                    break;
                 default:
                     throw new NotSupportedException();
             }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/TextDocumentExtensionsTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/TextDocumentExtensionsTest.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.AspNetCore.Razor.Test.Common.VisualStudio;
+using Microsoft.CodeAnalysis;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor.Test.Cohost;
+
+public class TextDocumentExtensionsTest(ITestOutputHelper testOutput) : VisualStudioWorkspaceTestBase(testOutput)
+{
+    [Theory]
+    [InlineData(@"Pages\Index.razor")]
+    [InlineData(@"Pages/Index.razor")]
+    [InlineData(@"Pages.Index.razor")]
+    public void TryComputeHintNameFromRazorDocument(string razorFilePath)
+    {
+        var projectId = ProjectId.CreateNewId();
+        var projectInfo = ProjectInfo
+            .Create(
+                projectId,
+                VersionStamp.Create(),
+                name: "Project",
+                assemblyName: "Project",
+                LanguageNames.CSharp,
+                TestProjectData.SomeProject.FilePath);
+
+        var documentId = DocumentId.CreateNewId(projectId);
+        var solution = Workspace.CurrentSolution
+            .AddProject(projectInfo)
+            .AddAdditionalDocument(documentId, "File.razor", "", filePath: Path.Combine(TestProjectData.SomeProjectPath, razorFilePath));
+
+        var document = solution.GetAdditionalDocument(documentId);
+
+        Assert.NotNull(document);
+        Assert.True(document.TryComputeHintNameFromRazorDocument(out var hintName));
+        // This tests TryComputeHintNameFromRazorDocument and also neatly demonstrates a bug: https://github.com/dotnet/razor/issues/11578
+        Assert.Equal("Pages_Index_razor.g.cs", hintName);
+    }
+}


### PR DESCRIPTION
Got a new ARM laptop, thought I'd try a little item from my TODO list (https://github.com/dotnet/razor/pull/11788#discussion_r2064001002), ended up worse than I ever expected.