### PR TITLE
Don't use `requestContext` in document closed endpoint

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Endpoints/RazorDocumentClosedEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Endpoints/RazorDocumentClosedEndpoint.cs
@@ -30,7 +30,7 @@ internal class RazorDocumentClosedEndpoint(IHtmlDocumentSynchronizer htmlDocumen
 
     protected override Task<VoidResult> HandleRequestAsync(TextDocumentIdentifier textDocument, RazorCohostRequestContext requestContext, CancellationToken cancellationToken)
     {
-        _htmlDocumentSynchronizer.DocumentRemoved(requestContext.DocumentUri.AssumeNotNull().GetRequiredParsedUri(), cancellationToken);
+        _htmlDocumentSynchronizer.DocumentRemoved(textDocument.DocumentUri.GetRequiredParsedUri(), cancellationToken);
         return SpecializedTasks.Default<VoidResult>();
     }
 }


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-dotnettools/issues/2206