### PR TITLE
Refactor OptionsStorage to use async service provider

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Options/OptionsStorage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Options/OptionsStorage.cs
@@ -99,7 +99,7 @@ internal class OptionsStorage : IAdvancedSettingsStorage, IDisposable
         Lazy<ITelemetryReporter> telemetryReporter,
         JoinableTaskContext joinableTaskContext)
     {
-        var shellSettingsManager = new ShellSettingsManager(synchronousServiceProvider);
+        var shellSettingsManager = new ShellSettingsManager(serviceProvider);
         _writableSettingsStore = shellSettingsManager.GetWritableSettingsStore(SettingsScope.UserSettings);
 
         _writableSettingsStore.CreateCollection(SettingsNames.LegacyCollection);
@@ -115,11 +115,11 @@ internal class OptionsStorage : IAdvancedSettingsStorage, IDisposable
         });
     }
 
-    private async Task GetTaskListDescriptorsAsync(JoinableTaskFactory jtf, SVsServiceProvider synchronousServiceProvider)
+    private async Task GetTaskListDescriptorsAsync(JoinableTaskFactory jtf, IAsyncServiceProvider synchronousServiceProvider)
     {
         await jtf.SwitchToMainThreadAsync();
 
-        var taskListService = synchronousServiceProvider.GetService<IVsTaskList, IVsCommentTaskInfo>();
+        var taskListService = await synchronousServiceProvider.GetServiceAsync<IVsTaskList, IVsCommentTaskInfo>();
         if (taskListService is null)
         {
             return;


### PR DESCRIPTION
Updated OptionsStorage to use IAsyncServiceProvider for service retrieval.

RPS Regression in Visual Studio where intellicode is not longer loading the ErrorList before Razor does

﻿### Summary of the changes

-

Fixes:
