### PR TITLE
Refactor GetTaskListDescriptorsAsync to use async provider

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Options/OptionsStorage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Options/OptionsStorage.cs
@@ -111,15 +111,15 @@ internal class OptionsStorage : IAdvancedSettingsStorage, IDisposable
             _unifiedSettingsReader = unifiedSettingsManager.GetReader();
             _unifiedSettingsSubscription = _unifiedSettingsReader.SubscribeToChanges(OnUnifiedSettingsChanged, SettingsNames.AllSettings.Select(s => s.UnifiedName).ToArray());
 
-            await GetTaskListDescriptorsAsync(joinableTaskContext.Factory, synchronousServiceProvider);
+            await GetTaskListDescriptorsAsync(joinableTaskContext.Factory, serviceProvider);
         });
     }
 
-    private async Task GetTaskListDescriptorsAsync(JoinableTaskFactory jtf, SVsServiceProvider synchronousServiceProvider)
+    private async Task GetTaskListDescriptorsAsync(JoinableTaskFactory jtf, IAsyncServiceProvider serviceProvider)
     {
         await jtf.SwitchToMainThreadAsync();
 
-        var taskListService = synchronousServiceProvider.GetService<IVsTaskList, IVsCommentTaskInfo>();
+        var taskListService = await serviceProvider.GetServiceAsync<IVsTaskList, IVsCommentTaskInfo>();
         if (taskListService is null)
         {
             return;


### PR DESCRIPTION
Updated OptionsStorage to use IAsyncServiceProvider for service retrieval.

RPS Regression in Visual Studio where intellicode is not longer loading the ErrorList before Razor loads the errorlist

This uses the Async service provider instead of the sync service provider
