### PR TITLE
Reduce work done in FormNameTagHelperDescriptorProvider.Execute

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/FormNameTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/FormNameTagHelperDescriptorProvider.cs
@@ -19,7 +19,8 @@ internal sealed class FormNameTagHelperDescriptorProvider() : TagHelperDescripto
     {
         ArgHelper.ThrowIfNull(context);
 
-        if (context.TargetSymbol is not { } targetSymbol || targetSymbol.Name != ComponentsApi.AssemblyName)
+        var targetSymbol = context.TargetSymbol;
+        if (targetSymbol is not null && targetSymbol.Name != ComponentsApi.AssemblyName)
         {
             return;
         }
@@ -35,7 +36,7 @@ internal sealed class FormNameTagHelperDescriptorProvider() : TagHelperDescripto
             return;
         }
 
-        if (!SymbolEqualityComparer.Default.Equals(targetSymbol, renderTreeBuilder.ContainingAssembly))
+        if (targetSymbol is not null && !SymbolEqualityComparer.Default.Equals(targetSymbol, renderTreeBuilder.ContainingAssembly))
         {
             return;
         }


### PR DESCRIPTION
Currently, the code finds the RenderTreeBuilder type in the compilation and checks to see if the executing context is for that asembly. Instead, as the name of the assembly is known, we can just verify against that.

*** Allocations ***
<img width="1260" height="367" alt="image" src="https://github.com/user-attachments/assets/a6a76686-481e-428c-8679-0da5499097ca" />

*** CPU usage ***
<img width="1314" height="526" alt="image" src="https://github.com/user-attachments/assets/a131f44d-e8a9-47bb-8b59-e6d591ed01cf" />