### PR TITLE
Fix logging

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Diagnostics/CohostDocumentPullDiagnosticsEndpointBase.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Diagnostics/CohostDocumentPullDiagnosticsEndpointBase.cs
@@ -25,7 +25,7 @@ internal abstract class CohostDocumentPullDiagnosticsEndpointBase<TRequest, TRes
     IHtmlRequestInvoker requestInvoker,
     IClientCapabilitiesService clientCapabilitiesService,
     ITelemetryReporter telemetryReporter,
-    ILoggerFactory loggerFactory)
+    ILogger logger)
     : AbstractCohostDocumentEndpoint<TRequest, TResponse>(incompatibleProjectService)
     where TRequest : notnull
 {
@@ -33,7 +33,7 @@ internal abstract class CohostDocumentPullDiagnosticsEndpointBase<TRequest, TRes
     private readonly IHtmlRequestInvoker _requestInvoker = requestInvoker;
     private readonly IClientCapabilitiesService _clientCapabilitiesService = clientCapabilitiesService;
     private readonly ITelemetryReporter _telemetryReporter = telemetryReporter;
-    private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<CohostDocumentPullDiagnosticsEndpointBase<TRequest, TResponse>>();
+    private readonly ILogger _logger = logger;
 
     protected override bool MutatesSolutionState => false;
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentPullDiagnosticsEndpoint.cs
@@ -33,7 +33,13 @@ internal sealed class CohostDocumentPullDiagnosticsEndpoint(
     IClientCapabilitiesService clientCapabilitiesService,
     ITelemetryReporter telemetryReporter,
     ILoggerFactory loggerFactory)
-    : CohostDocumentPullDiagnosticsEndpointBase<VSInternalDocumentDiagnosticsParams, VSInternalDiagnosticReport[]>(incompatibleProjectService, remoteServiceInvoker, requestInvoker, clientCapabilitiesService, telemetryReporter, loggerFactory), IDynamicRegistrationProvider
+    : CohostDocumentPullDiagnosticsEndpointBase<VSInternalDocumentDiagnosticsParams, VSInternalDiagnosticReport[]>(
+        incompatibleProjectService,
+        remoteServiceInvoker,
+        requestInvoker,
+        clientCapabilitiesService,
+        telemetryReporter,
+        loggerFactory.GetOrCreateLogger<CohostDocumentPullDiagnosticsEndpoint>()), IDynamicRegistrationProvider
 {
     private readonly IRemoteServiceInvoker _remoteServiceInvoker = remoteServiceInvoker;
     private readonly IClientSettingsManager _clientSettingsManager = clientSettingsManager;

--- a/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Endpoints/DocumentPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Endpoints/DocumentPullDiagnosticsEndpoint.cs
@@ -31,7 +31,13 @@ internal sealed class DocumentPullDiagnosticsEndpoint(
     IClientCapabilitiesService clientCapabilitiesService,
     ITelemetryReporter telemetryReporter,
     ILoggerFactory loggerFactory)
-    : CohostDocumentPullDiagnosticsEndpointBase<DocumentDiagnosticParams, FullDocumentDiagnosticReport?>(incompatibleProjectService, remoteServiceInvoker, requestInvoker, clientCapabilitiesService, telemetryReporter, loggerFactory), IDynamicRegistrationProvider
+    : CohostDocumentPullDiagnosticsEndpointBase<DocumentDiagnosticParams, FullDocumentDiagnosticReport?>(
+        incompatibleProjectService,
+        remoteServiceInvoker,
+        requestInvoker,
+        clientCapabilitiesService,
+        telemetryReporter,
+        loggerFactory.GetOrCreateLogger<DocumentPullDiagnosticsEndpoint>()), IDynamicRegistrationProvider
 {
     protected override string LspMethodName => Methods.TextDocumentDiagnosticName;
     protected override bool SupportsHtmlDiagnostics => false;


### PR DESCRIPTION
Noticed diagnostics logging looks like this:
```
2025-08-08 10:55:38.751 [trace] [Razor.LanguageClient.Cohost.CohostDocumentPullDiagnosticsEndpointBase`2[[Roslyn.LanguageServer.Protocol.DocumentDiagnosticParams, Microsoft.CodeAnalysis.LanguageServer.Protocol, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35],[Roslyn.LanguageServer.Protocol.FullDocumentDiagnosticReport, Microsoft.CodeAnalysis.LanguageServer.Protocol, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]] Reporting 1 diagnostics back to the client
```

I think that category name is a little long :)