### PR TITLE
Compiler: Avoid allocating strings for various variable and parameter names during code generation

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.WriteInterpolatedStringHandler.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.WriteInterpolatedStringHandler.cs
@@ -65,6 +65,18 @@ public sealed partial class CodeWriter
                     name.WriteTo(_writer);
                     break;
 
+                case ComponentNodeWriter.SeqName name:
+                    name.WriteTo(_writer);
+                    break;
+
+                case ComponentNodeWriter.ParameterName name:
+                    name.WriteTo(_writer);
+                    break;
+
+                case ComponentNodeWriter.TypeInferenceArgName name:
+                    name.WriteTo(_writer);
+                    break;
+
                 case IWriteableValue writeableValue:
                     Debug.Assert(!typeof(T).IsValueType, $"Handle {typeof(T).FullName} to avoid boxing to {nameof(IWriteableValue)}");
                     writeableValue.WriteTo(_writer);

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.WriteInterpolatedStringHandler.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.WriteInterpolatedStringHandler.cs
@@ -1,10 +1,11 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Razor.Language.Components;
 
 namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 
@@ -50,6 +51,10 @@ public sealed partial class CodeWriter
 
                 case string s:
                     _writer.Write(s);
+                    break;
+
+                case BuilderName builderName:
+                    builderName.WriteTo(_writer);
                     break;
 
                 case IWriteableValue writeableValue:

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.WriteInterpolatedStringHandler.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.WriteInterpolatedStringHandler.cs
@@ -53,8 +53,16 @@ public sealed partial class CodeWriter
                     _writer.Write(s);
                     break;
 
-                case BuilderName builderName:
-                    builderName.WriteTo(_writer);
+                case BuilderVariableName name:
+                    name.WriteTo(_writer);
+                    break;
+
+                case RenderModeVariableName name:
+                    name.WriteTo(_writer);
+                    break;
+
+                case FormNameVariableName name:
+                    name.WriteTo(_writer);
                     break;
 
                 case IWriteableValue writeableValue:

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.WriteInterpolatedStringHandler.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.WriteInterpolatedStringHandler.cs
@@ -1,8 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration;
@@ -49,6 +50,11 @@ public sealed partial class CodeWriter
 
                 case string s:
                     _writer.Write(s);
+                    break;
+
+                case IWriteableValue writeableValue:
+                    Debug.Assert(!typeof(T).IsValueType, $"Handle {typeof(T).FullName} to avoid boxing to {nameof(IWriteableValue)}");
+                    writeableValue.WriteTo(_writer);
                     break;
 
                 default:

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.cs
@@ -244,6 +244,14 @@ public sealed partial class CodeWriter : IDisposable
         return WriteCore(value.AsMemory(startIndex, count));
     }
 
+    internal CodeWriter Write<T>(T value)
+        where T : IWriteableValue
+    {
+        value.WriteTo(this);
+
+        return this;
+    }
+
     public CodeWriter Write([InterpolatedStringHandlerArgument("")] ref WriteInterpolatedStringHandler handler)
         => this;
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriterExtensions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriterExtensions.cs
@@ -971,6 +971,11 @@ internal static class CodeWriterExtensions
 
         public void Dispose()
         {
+            if (_writer is null)
+            {
+                return;
+            }
+
             WriteEndScope();
         }
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriterExtensions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriterExtensions.cs
@@ -9,6 +9,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 using Microsoft.AspNetCore.Razor.Utilities;
@@ -67,7 +68,6 @@ internal static class CodeWriterExtensions
 
         return ImmutableCollectionsMarshal.AsImmutableArray(array);
     }
-
 
     public static bool IsAtBeginningOfLine(this CodeWriter writer)
     {
@@ -362,6 +362,15 @@ internal static class CodeWriterExtensions
         return writer.Write("(");
     }
 
+    public static CodeWriter WriteStartMethodInvocation(
+        this CodeWriter writer,
+        [InterpolatedStringHandlerArgument(nameof(writer))] ref CodeWriter.WriteInterpolatedStringHandler handler)
+    {
+        writer.Write(ref handler);
+        
+        return writer.Write("(");
+    }
+
     public static CodeWriter WriteEndMethodInvocation(this CodeWriter writer)
     {
         return WriteEndMethodInvocation(writer, endLine: true);
@@ -586,28 +595,56 @@ internal static class CodeWriterExtensions
         return new CSharpCodeWritingScope(writer);
     }
 
-    public static CSharpCodeWritingScope BuildLambda(this CodeWriter writer, params string[] parameterNames)
+    public static CSharpCodeWritingScope BuildLambda(this CodeWriter writer)
+        => writer.WriteLambdaHeader().BuildScope();
+
+    public static CSharpCodeWritingScope BuildLambda(this CodeWriter writer, string parameterName)
+        => writer.WriteLambdaHeader(parameterName).BuildScope();
+
+    public static CSharpCodeWritingScope BuildLambda<T>(this CodeWriter writer, T parameterName)
+        where T : IWriteableValue
+        => writer.WriteLambdaHeader(parameterName).BuildScope();
+
+    public static CSharpCodeWritingScope BuildAsyncLambda(this CodeWriter writer)
+        => writer.WriteAsyncLambdaHeader().BuildScope();
+
+    public static CSharpCodeWritingScope BuildAsyncLambda(this CodeWriter writer, string parameterName)
+        => writer.WriteAsyncLambdaHeader(parameterName).BuildScope();
+
+    public static CSharpCodeWritingScope BuildAsyncLambda<T>(this CodeWriter writer, T parameterName)
+        where T : IWriteableValue
+        => writer.WriteAsyncLambdaHeader(parameterName).BuildScope();
+
+    public static CodeWriter WriteLambdaHeader(this CodeWriter writer)
+        => writer.Write("() => ");
+
+    public static CodeWriter WriteLambdaHeader(this CodeWriter writer, string parameterName)
+        => writer.Write($"({parameterName}) => ");
+
+    public static CodeWriter WriteLambdaHeader<T>(this CodeWriter writer, T parameterName)
+        where T : IWriteableValue
     {
-        return BuildLambda(writer, async: false, parameterNames: parameterNames);
+        writer.Write("(");
+        parameterName.WriteTo(writer);
+        writer.Write(") => ");
+
+        return writer;
     }
 
-    public static CSharpCodeWritingScope BuildAsyncLambda(this CodeWriter writer, params string[] parameterNames)
+    public static CodeWriter WriteAsyncLambdaHeader(this CodeWriter writer)
+        => writer.Write($"async() => ");
+
+    public static CodeWriter WriteAsyncLambdaHeader(this CodeWriter writer, string parameterName)
+        => writer.Write($"async({parameterName}) => ");
+
+    public static CodeWriter WriteAsyncLambdaHeader<T>(this CodeWriter writer, T parameterName)
+        where T : IWriteableValue
     {
-        return BuildLambda(writer, async: true, parameterNames: parameterNames);
-    }
+        writer.Write("async(");
+        parameterName.WriteTo(writer);
+        writer.Write(") => ");
 
-    private static CSharpCodeWritingScope BuildLambda(CodeWriter writer, bool async, string[] parameterNames)
-    {
-        if (async)
-        {
-            writer.Write("async");
-        }
-
-        writer.Write("(").Write(string.Join(", ", parameterNames)).Write(") => ");
-
-        var scope = new CSharpCodeWritingScope(writer);
-
-        return scope;
+        return writer;
     }
 
 #nullable enable

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/IWriteableValue.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/IWriteableValue.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration;
+
+/// <summary>
+///  A type that can write itself to a <see cref="CodeWriter"/>.
+/// </summary>
+internal interface IWriteableValue
+{
+    void WriteTo(CodeWriter writer);
+}

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/BuilderName.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/BuilderName.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
+
+namespace Microsoft.AspNetCore.Razor.Language.Components;
+
+internal readonly struct BuilderName(int index) : IWriteableValue
+{
+    public static BuilderName Default => new(1);
+
+    public int Index { get; } = index;
+
+    public int Length => Index switch
+    {
+        1 => ComponentsApi.RenderTreeBuilder.BuilderParameter.Length,
+        _ => ComponentsApi.RenderTreeBuilder.BuilderParameter.Length + Index.CountDigits()
+    };
+
+    public void WriteTo(CodeWriter writer)
+    {
+        if (Index == 1)
+        {
+            writer.Write(ComponentsApi.RenderTreeBuilder.BuilderParameter);
+        }
+        else
+        {
+            writer.Write(ComponentsApi.RenderTreeBuilder.BuilderParameter);
+            writer.WriteIntegerLiteral(Index);
+        }
+    }
+}

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/BuilderVariableName.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/BuilderVariableName.cs
@@ -6,9 +6,9 @@ using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 
 namespace Microsoft.AspNetCore.Razor.Language.Components;
 
-internal readonly struct BuilderName(int index) : IWriteableValue
+internal readonly struct BuilderVariableName(int index) : IWriteableValue
 {
-    public static BuilderName Default => new(1);
+    public static BuilderVariableName Default => new(1);
 
     public int Index { get; } = index;
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/BuilderVariableName.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/BuilderVariableName.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
 using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 
 namespace Microsoft.AspNetCore.Razor.Language.Components;
 
+[DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
 internal readonly struct BuilderVariableName(int index) : IWriteableValue
 {
     public static BuilderVariableName Default => new(1);
@@ -30,4 +32,9 @@ internal readonly struct BuilderVariableName(int index) : IWriteableValue
             writer.WriteIntegerLiteral(Index);
         }
     }
+
+    internal string GetDebuggerDisplay()
+        => Index == 1
+            ? ComponentsApi.RenderTreeBuilder.BuilderParameter
+            : $"{ComponentsApi.RenderTreeBuilder.BuilderParameter}{Index}";
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentDesignTimeNodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentDesignTimeNodeWriter.cs
@@ -1157,19 +1157,15 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
     {
         // Looks like:
         // __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(expression);
+        context.CodeWriter.Write($"{DesignTimeVariable} = (global::{ComponentsApi.IComponentRenderMode.FullTypeName})(");
+
         WriteCSharpCode(context, new CSharpCodeIntermediateNode
         {
-            Children =
-            {
-                IntermediateNodeFactory.CSharpToken($"{DesignTimeVariable} = (global::{ComponentsApi.IComponentRenderMode.FullTypeName})("),
-                new CSharpCodeIntermediateNode
-                {
-                    Source = node.Source,
-                    Children = { node.Children[0] }
-                },
-                IntermediateNodeFactory.CSharpToken(");")
-            }
+            Source = node.Source,
+            Children = { node.Children[0] }
         });
+
+        context.CodeWriter.WriteLine(");");
     }
 
     private static void WriteCSharpTokens(CodeRenderingContext context, ImmutableArray<CSharpIntermediateToken> tokens)

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentDesignTimeNodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentDesignTimeNodeWriter.cs
@@ -1014,8 +1014,7 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
 
         var codeWriter = context.CodeWriter;
 
-        codeWriter
-            .WriteStartMethodInvocation($"{_scopeStack.BuilderVarName}.{ComponentsApi.RenderTreeBuilder.SetKey}");
+        codeWriter.WriteStartMethodInvocation($"{_scopeStack.BuilderVarName}.{ComponentsApi.RenderTreeBuilder.SetKey}");
         WriteSetKeyInnards(context, node);
         codeWriter.WriteEndMethodInvocation();
     }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentDesignTimeNodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentDesignTimeNodeWriter.cs
@@ -452,7 +452,7 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
                     WriteTypeInferenceMethodParameterInnards(context, parameter);
                     context.CodeWriter.Write(", out var ");
 
-                    var variableName = $"__typeInferenceArg_{ScopeStack.Depth}_{parameter.ParameterName}";
+                    var variableName = new TypeInferenceArgName(ScopeStack.Depth, parameter.ParameterName);
                     context.CodeWriter.Write(variableName);
 
                     UseCapturedCascadingGenericParameterVariable(node, parameter, variableName);
@@ -492,7 +492,7 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
             {
                 context.CodeWriter.Write(", ");
 
-                if (!string.IsNullOrEmpty(parameter.SeqName))
+                if (parameter.SeqName != null)
                 {
                     context.CodeWriter.Write("-1");
                     context.CodeWriter.Write(", ");
@@ -606,13 +606,23 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
                 // The value should be populated before we use it, because we emit code for creating ancestors
                 // first, and that's where it's populated. However if this goes wrong somehow, we don't want to
                 // throw, so use a fallback
-                var valueExpression = syntheticArg.ValueExpression ?? "default";
-                context.CodeWriter.Write(valueExpression);
-                if (!context.Options.SuppressNullabilityEnforcement && IsDefaultExpression(valueExpression))
+                if (syntheticArg.ValueExpression is IWriteableValue writeableValue)
                 {
-                    context.CodeWriter.Write("!");
+                    writeableValue.WriteTo(context.CodeWriter);
                 }
+                else
+                {
+                    var valueExpression = syntheticArg.ValueExpression as string ?? "default";
+                    context.CodeWriter.Write(valueExpression);
+
+                    if (!context.Options.SuppressNullabilityEnforcement && IsDefaultExpression(valueExpression))
+                    {
+                        context.CodeWriter.Write("!");
+                    }
+                }
+
                 break;
+
             case TypeInferenceCapturedVariable capturedVariable:
                 context.CodeWriter.Write(capturedVariable.VariableName);
                 break;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentDesignTimeNodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentDesignTimeNodeWriter.cs
@@ -322,7 +322,7 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
         }
 
         context.CodeWriter
-            .WriteStartMethodInvocation($"{_scopeStack.BuilderVarName}.{nameof(ComponentsApi.RenderTreeBuilder.AddAttribute)}")
+            .WriteStartMethodInvocation($"{_scopeStack.BuilderVariableName}.{nameof(ComponentsApi.RenderTreeBuilder.AddAttribute)}")
             .Write("-1")
             .WriteParameterSeparator()
             .WriteStringLiteral(key);
@@ -330,7 +330,7 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
 
     protected override void BeginWriteAttribute(CodeRenderingContext context, IntermediateNode expression)
     {
-        context.CodeWriter.WriteStartMethodInvocation($"{_scopeStack.BuilderVarName}.{ComponentsApi.RenderTreeBuilder.AddAttribute}");
+        context.CodeWriter.WriteStartMethodInvocation($"{_scopeStack.BuilderVariableName}.{ComponentsApi.RenderTreeBuilder.AddAttribute}");
         context.CodeWriter.Write("-1");
         context.CodeWriter.WriteParameterSeparator();
 
@@ -485,7 +485,7 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
             context.CodeWriter.Write(node.TypeInferenceNode.MethodName);
             context.CodeWriter.Write("(");
 
-            context.CodeWriter.Write(_scopeStack.BuilderVarName);
+            context.CodeWriter.Write(_scopeStack.BuilderVariableName);
             context.CodeWriter.Write(", ");
 
             context.CodeWriter.Write("-1");
@@ -940,15 +940,15 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
         // ((__builder73) => { ... })
         // OR
         // ((person) => (__builder73) => { })
-        _scopeStack.OpenComponentScope(
-            context,
-            node.AttributeName,
-            node.IsParameterized ? node.ParameterName : null);
-        for (var i = 0; i < node.Children.Count; i++)
+        var parameterName = node.IsParameterized ? node.ParameterName : null;
+
+        using (_scopeStack.OpenComponentScope(context,  parameterName))
         {
-            context.RenderNode(node.Children[i]);
+            foreach (var child in node.Children)
+            {
+                context.RenderNode(child);
+            }
         }
-        _scopeStack.CloseScope(context);
     }
 
     public override void WriteComponentTypeArgument(CodeRenderingContext context, ComponentTypeArgumentIntermediateNode node)
@@ -991,9 +991,10 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
         // Looks like:
         //
         // (__builder73) => { ... }
-        _scopeStack.OpenTemplateScope(context);
-        context.RenderChildren(node);
-        _scopeStack.CloseScope(context);
+        using (_scopeStack.OpenTemplateScope(context))
+        {
+            context.RenderChildren(node);
+        }
     }
 
     public override void WriteSetKey(CodeRenderingContext context, SetKeyIntermediateNode node)
@@ -1014,7 +1015,7 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
 
         var codeWriter = context.CodeWriter;
 
-        codeWriter.WriteStartMethodInvocation($"{_scopeStack.BuilderVarName}.{ComponentsApi.RenderTreeBuilder.SetKey}");
+        codeWriter.WriteStartMethodInvocation($"{_scopeStack.BuilderVariableName}.{ComponentsApi.RenderTreeBuilder.SetKey}");
         WriteSetKeyInnards(context, node);
         codeWriter.WriteEndMethodInvocation();
     }
@@ -1046,7 +1047,7 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
         // Looks like:
         //
         // __builder.AddMultipleAttributes(2, ...);
-        context.CodeWriter.WriteStartMethodInvocation($"{_scopeStack.BuilderVarName}.{ComponentsApi.RenderTreeBuilder.AddMultipleAttributes}");
+        context.CodeWriter.WriteStartMethodInvocation($"{_scopeStack.BuilderVariableName}.{ComponentsApi.RenderTreeBuilder.AddMultipleAttributes}");
         context.CodeWriter.Write("-1");
         context.CodeWriter.WriteParameterSeparator();
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentDesignTimeNodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentDesignTimeNodeWriter.cs
@@ -15,8 +15,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components;
 // Based on the DesignTimeNodeWriter from Razor repo.
 internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
 {
-    private readonly ScopeStack _scopeStack = new ScopeStack();
-
     private const string DesignTimeVariable = "__o";
 
     public ComponentDesignTimeNodeWriter(RazorLanguageVersion version) : base(version)
@@ -322,7 +320,7 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
         }
 
         context.CodeWriter
-            .WriteStartMethodInvocation($"{_scopeStack.BuilderVariableName}.{nameof(ComponentsApi.RenderTreeBuilder.AddAttribute)}")
+            .WriteStartMethodInvocation($"{BuilderVariableName}.{nameof(ComponentsApi.RenderTreeBuilder.AddAttribute)}")
             .Write("-1")
             .WriteParameterSeparator()
             .WriteStringLiteral(key);
@@ -330,7 +328,7 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
 
     protected override void BeginWriteAttribute(CodeRenderingContext context, IntermediateNode expression)
     {
-        context.CodeWriter.WriteStartMethodInvocation($"{_scopeStack.BuilderVariableName}.{ComponentsApi.RenderTreeBuilder.AddAttribute}");
+        context.CodeWriter.WriteStartMethodInvocation($"{BuilderVariableName}.{ComponentsApi.RenderTreeBuilder.AddAttribute}");
         context.CodeWriter.Write("-1");
         context.CodeWriter.WriteParameterSeparator();
 
@@ -454,7 +452,7 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
                     WriteTypeInferenceMethodParameterInnards(context, parameter);
                     context.CodeWriter.Write(", out var ");
 
-                    var variableName = $"__typeInferenceArg_{_scopeStack.Depth}_{parameter.ParameterName}";
+                    var variableName = $"__typeInferenceArg_{ScopeStack.Depth}_{parameter.ParameterName}";
                     context.CodeWriter.Write(variableName);
 
                     UseCapturedCascadingGenericParameterVariable(node, parameter, variableName);
@@ -485,7 +483,7 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
             context.CodeWriter.Write(node.TypeInferenceNode.MethodName);
             context.CodeWriter.Write("(");
 
-            context.CodeWriter.Write(_scopeStack.BuilderVariableName);
+            context.CodeWriter.Write(BuilderVariableName);
             context.CodeWriter.Write(", ");
 
             context.CodeWriter.Write("-1");
@@ -942,7 +940,7 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
         // ((person) => (__builder73) => { })
         var parameterName = node.IsParameterized ? node.ParameterName : null;
 
-        using (_scopeStack.OpenComponentScope(context,  parameterName))
+        using (ScopeStack.OpenComponentScope(context,  parameterName))
         {
             foreach (var child in node.Children)
             {
@@ -991,7 +989,7 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
         // Looks like:
         //
         // (__builder73) => { ... }
-        using (_scopeStack.OpenTemplateScope(context))
+        using (ScopeStack.OpenTemplateScope(context))
         {
             context.RenderChildren(node);
         }
@@ -1015,7 +1013,7 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
 
         var codeWriter = context.CodeWriter;
 
-        codeWriter.WriteStartMethodInvocation($"{_scopeStack.BuilderVariableName}.{ComponentsApi.RenderTreeBuilder.SetKey}");
+        codeWriter.WriteStartMethodInvocation($"{BuilderVariableName}.{ComponentsApi.RenderTreeBuilder.SetKey}");
         WriteSetKeyInnards(context, node);
         codeWriter.WriteEndMethodInvocation();
     }
@@ -1047,7 +1045,7 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
         // Looks like:
         //
         // __builder.AddMultipleAttributes(2, ...);
-        context.CodeWriter.WriteStartMethodInvocation($"{_scopeStack.BuilderVariableName}.{ComponentsApi.RenderTreeBuilder.AddMultipleAttributes}");
+        context.CodeWriter.WriteStartMethodInvocation($"{BuilderVariableName}.{ComponentsApi.RenderTreeBuilder.AddMultipleAttributes}");
         context.CodeWriter.Write("-1");
         context.CodeWriter.WriteParameterSeparator();
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentNodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentNodeWriter.cs
@@ -246,7 +246,7 @@ internal abstract class ComponentNodeWriter : IntermediateNodeWriter, ITemplateT
 
         if (renderModeParameterName is not null)
         {
-            WriteAddComponentRenderMode(context, ComponentsApi.RenderTreeBuilder.BuilderParameter, renderModeParameterName);
+            WriteAddComponentRenderMode(context, BuilderName.Default, renderModeParameterName);
         }
 
         context.CodeWriter.WriteInstanceMethodInvocation(ComponentsApi.RenderTreeBuilder.BuilderParameter, ComponentsApi.RenderTreeBuilder.CloseComponent);
@@ -488,7 +488,7 @@ internal abstract class ComponentNodeWriter : IntermediateNodeWriter, ITemplateT
         return expression == "default" || expression.StartsWith("default(", StringComparison.Ordinal);
     }
 
-    protected static void WriteAddComponentRenderMode(CodeRenderingContext context, string builderName, string variableName)
+    protected static void WriteAddComponentRenderMode(CodeRenderingContext context, BuilderName builderName, string variableName)
     {
         context.CodeWriter.Write(builderName);
         context.CodeWriter.Write(".");

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentNodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentNodeWriter.cs
@@ -15,11 +15,16 @@ namespace Microsoft.AspNetCore.Razor.Language.Components;
 internal abstract class ComponentNodeWriter : IntermediateNodeWriter, ITemplateTargetExtension
 {
     private readonly RazorLanguageVersion _version;
+    protected readonly ScopeStack ScopeStack = new();
 
     protected ComponentNodeWriter(RazorLanguageVersion version)
     {
         _version = version;
     }
+
+    public BuilderVariableName BuilderVariableName => ScopeStack.BuilderVariableName;
+    public RenderModeVariableName RenderModeVariableName => ScopeStack.RenderModeVariableName;
+    public FormNameVariableName FormNameVariableName => ScopeStack.FormNameVariableName;
 
     protected virtual bool CanUseAddComponentParameter(CodeRenderingContext context)
     {

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentNodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentNodeWriter.cs
@@ -246,7 +246,7 @@ internal abstract class ComponentNodeWriter : IntermediateNodeWriter, ITemplateT
 
         if (renderModeParameterName is not null)
         {
-            WriteAddComponentRenderMode(context, BuilderName.Default, renderModeParameterName);
+            WriteAddComponentRenderMode(context, BuilderVariableName.Default, renderModeParameterName);
         }
 
         context.CodeWriter.WriteInstanceMethodInvocation(ComponentsApi.RenderTreeBuilder.BuilderParameter, ComponentsApi.RenderTreeBuilder.CloseComponent);
@@ -488,16 +488,11 @@ internal abstract class ComponentNodeWriter : IntermediateNodeWriter, ITemplateT
         return expression == "default" || expression.StartsWith("default(", StringComparison.Ordinal);
     }
 
-    protected static void WriteAddComponentRenderMode(CodeRenderingContext context, BuilderName builderName, string variableName)
-    {
-        context.CodeWriter.Write(builderName);
-        context.CodeWriter.Write(".");
-        context.CodeWriter.Write(ComponentsApi.RenderTreeBuilder.AddComponentRenderMode);
-        context.CodeWriter.Write("(");
-        context.CodeWriter.Write(variableName);
-        context.CodeWriter.Write(");");
-        context.CodeWriter.WriteLine();
-    }
+    protected static void WriteAddComponentRenderMode(CodeRenderingContext context, BuilderVariableName builderName, RenderModeVariableName renderModeName)
+        => context.CodeWriter.WriteLine($"{builderName}.{ComponentsApi.RenderTreeBuilder.AddComponentRenderMode}({renderModeName});");
+
+    protected static void WriteAddComponentRenderMode(CodeRenderingContext context, BuilderVariableName builderName, string renderModeName)
+        => context.CodeWriter.WriteLine($"{builderName}.{ComponentsApi.RenderTreeBuilder.AddComponentRenderMode}({renderModeName});");
 
     protected static void WriteGloballyQualifiedTypeName(CodeRenderingContext context, ComponentAttributeIntermediateNode node)
     {

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentNodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentNodeWriter.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
@@ -525,6 +526,7 @@ internal abstract class ComponentNodeWriter : IntermediateNodeWriter, ITemplateT
         }
     }
 
+    [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
     protected internal readonly struct SeqName(int index) : IWriteableValue
     {
         public void WriteTo(CodeWriter writer)
@@ -532,8 +534,12 @@ internal abstract class ComponentNodeWriter : IntermediateNodeWriter, ITemplateT
             writer.Write("__seq");
             writer.WriteIntegerLiteral(index);
         }
+
+        internal string GetDebuggerDisplay()
+            => $"__seq{index}";
     }
 
+    [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
     protected internal readonly struct ParameterName(int index, bool isSynthetic = false) : IWriteableValue
     {
         public void WriteTo(CodeWriter writer)
@@ -549,8 +555,12 @@ internal abstract class ComponentNodeWriter : IntermediateNodeWriter, ITemplateT
 
             writer.WriteIntegerLiteral(index);
         }
+
+        internal string GetDebuggerDisplay()
+            => isSynthetic ? $"__syntheticArg{index}" : $"__arg{index}";
     }
 
+    [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
     protected internal readonly struct TypeInferenceArgName(int depth, ParameterName parameterName) : IWriteableValue
     {
         public void WriteTo(CodeWriter writer)
@@ -559,6 +569,9 @@ internal abstract class ComponentNodeWriter : IntermediateNodeWriter, ITemplateT
             writer.WriteIntegerLiteral(depth);
             writer.Write($"_{parameterName}");
         }
+
+        internal string GetDebuggerDisplay()
+            => $"__typeInferenceArg_{depth}_{parameterName.GetDebuggerDisplay()}";
     }
 
     protected class TypeInferenceMethodParameter

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentRuntimeNodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentRuntimeNodeWriter.cs
@@ -221,13 +221,7 @@ internal class ComponentRuntimeNodeWriter : ComponentNodeWriter
         if (hasFormName)
         {
             // _builder.AddNamedEvent("onsubmit", __formName);
-            context.CodeWriter.Write(_scopeStack.BuilderVarName);
-            context.CodeWriter.Write(".");
-            context.CodeWriter.Write(ComponentsApi.RenderTreeBuilder.AddNamedEvent);
-            context.CodeWriter.Write("(\"onsubmit\", ");
-            context.CodeWriter.Write(_scopeStack.FormNameVarName);
-            context.CodeWriter.Write(");");
-            context.CodeWriter.WriteLine();
+            context.CodeWriter.WriteLine($"{_scopeStack.BuilderVarName}.{ComponentsApi.RenderTreeBuilder.AddNamedEvent}(\"onsubmit\", {_scopeStack.FormNameVarName});");
             _scopeStack.IncrementFormName();
         }
 
@@ -950,14 +944,9 @@ internal class ComponentRuntimeNodeWriter : ComponentNodeWriter
         }
 
         // string __formName = expression;
-        context.CodeWriter.Write("string ");
-        context.CodeWriter.Write(_scopeStack.FormNameVarName);
-        context.CodeWriter.Write(" = ");
-        context.CodeWriter.Write(ComponentsApi.RuntimeHelpers.TypeCheck);
-        context.CodeWriter.Write("<string>(");
+        context.CodeWriter.Write($"string {_scopeStack.FormNameVarName} = {ComponentsApi.RuntimeHelpers.TypeCheck}<string>(");
         WriteAttributeValue(context, node.FindDescendantNodes<IntermediateToken>());
-        context.CodeWriter.Write(")");
-        context.CodeWriter.WriteLine(";");
+        context.CodeWriter.WriteLine(");");
     }
 
     public override void WriteReferenceCapture(CodeRenderingContext context, ReferenceCaptureIntermediateNode node)
@@ -1009,19 +998,15 @@ internal class ComponentRuntimeNodeWriter : ComponentNodeWriter
     {
         // Looks like:
         // global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode0 = expression;
+        context.CodeWriter.Write($"global::{ComponentsApi.IComponentRenderMode.FullTypeName} {_scopeStack.RenderModeVarName} = ");
+
         WriteCSharpCode(context, new CSharpCodeIntermediateNode
         {
-            Children =
-            {
-                IntermediateNodeFactory.CSharpToken($"global::{ComponentsApi.IComponentRenderMode.FullTypeName} {_scopeStack.RenderModeVarName} = "),
-                new CSharpCodeIntermediateNode
-                {
-                    Source = node.Source,
-                    Children = { node.Children[0] }
-                },
-                IntermediateNodeFactory.CSharpToken(";")
-            }
+            Source = node.Source,
+            Children = { node.Children[0] }
         });
+
+        context.CodeWriter.WriteLine(";");
     }
 
     private void WriteAttribute(CodeRenderingContext context, string key, ImmutableArray<IntermediateToken> value)

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/FormNameVariableName.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/FormNameVariableName.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
+
+namespace Microsoft.AspNetCore.Razor.Language.Components;
+
+internal readonly struct FormNameVariableName(int index, int builderIndex) : IWriteableValue
+{
+    public static FormNameVariableName Default => new(0, 1);
+
+    public int Index { get; } = index;
+    public int BuilderIndex { get; } = builderIndex;
+
+    public void WriteTo(CodeWriter writer)
+    {
+        if (BuilderIndex == 1 && Index == 0)
+        {
+            writer.Write(ComponentsApi.RenderTreeBuilder.FormNameVariableName);
+        }
+        else
+        {
+            writer.Write(ComponentsApi.RenderTreeBuilder.FormNameVariableName);
+            writer.WriteIntegerLiteral(BuilderIndex);
+            writer.Write("_");
+            writer.WriteIntegerLiteral(Index);
+        }
+    }
+}

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/FormNameVariableName.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/FormNameVariableName.cs
@@ -1,10 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 
 namespace Microsoft.AspNetCore.Razor.Language.Components;
 
+[DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
 internal readonly struct FormNameVariableName(int index, int builderIndex) : IWriteableValue
 {
     public static FormNameVariableName Default => new(0, 1);
@@ -26,4 +28,9 @@ internal readonly struct FormNameVariableName(int index, int builderIndex) : IWr
             writer.WriteIntegerLiteral(Index);
         }
     }
+
+    internal string GetDebuggerDisplay()
+        => BuilderIndex == 1 && Index == 0
+            ? ComponentsApi.RenderTreeBuilder.FormNameVariableName
+            : $"{ComponentsApi.RenderTreeBuilder.FormNameVariableName}{BuilderIndex}_{Index}";
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/RenderModeVariableName.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/RenderModeVariableName.cs
@@ -1,10 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 
 namespace Microsoft.AspNetCore.Razor.Language.Components;
 
+[DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
 internal readonly struct RenderModeVariableName(int index, int builderIndex) : IWriteableValue
 {
     public static RenderModeVariableName Default => new(0, 1);
@@ -26,4 +28,9 @@ internal readonly struct RenderModeVariableName(int index, int builderIndex) : I
             writer.WriteIntegerLiteral(Index);
         }
     }
+
+    internal string GetDebuggerDisplay()
+        => BuilderIndex == 1 && Index == 0
+            ? ComponentsApi.RenderTreeBuilder.RenderModeVariableName
+            : $"{ComponentsApi.RenderTreeBuilder.RenderModeVariableName}{BuilderIndex}_{Index}";
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/RenderModeVariableName.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/RenderModeVariableName.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
+
+namespace Microsoft.AspNetCore.Razor.Language.Components;
+
+internal readonly struct RenderModeVariableName(int index, int builderIndex) : IWriteableValue
+{
+    public static RenderModeVariableName Default => new(0, 1);
+
+    public int Index { get; } = index;
+    public int BuilderIndex { get; } = builderIndex;
+
+    public void WriteTo(CodeWriter writer)
+    {
+        if (BuilderIndex == 1 && Index == 0)
+        {
+            writer.Write(ComponentsApi.RenderTreeBuilder.RenderModeVariableName);
+        }
+        else
+        {
+            writer.Write(ComponentsApi.RenderTreeBuilder.RenderModeVariableName);
+            writer.WriteIntegerLiteral(BuilderIndex);
+            writer.Write("_");
+            writer.WriteIntegerLiteral(Index);
+        }
+    }
+}

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ScopeStack.Entry.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ScopeStack.Entry.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
+using static Microsoft.AspNetCore.Razor.Language.CodeGeneration.CodeWriterExtensions;
+
+namespace Microsoft.AspNetCore.Razor.Language.Components;
+
+internal sealed partial class ScopeStack
+{
+    private sealed class Entry : IDisposable
+    {
+        private readonly int _builderIndex;
+        private readonly CSharpCodeWritingScope _scope;
+
+        private int _renderModeIndex;
+        private int _formNameIndex;
+
+        public BuilderVariableName BuilderVariableName => new(_builderIndex);
+        public RenderModeVariableName RenderModeVariableName => new(_renderModeIndex, _builderIndex);
+        public FormNameVariableName FormNameVariableName => new(_formNameIndex, _builderIndex);
+
+        private Entry(int builderIndex, CodeRenderingContext? context)
+        {
+            _builderIndex = builderIndex;
+
+            if (context is not null)
+            {
+                _scope = context.CodeWriter.BuildLambda(BuilderVariableName);
+            }
+        }
+
+        public void Dispose()
+        {
+            _scope.Dispose();
+        }
+
+        public static Entry CreateFirst()
+            => new(1, context: null);
+
+        public Entry Next(CodeRenderingContext context)
+            => new(_builderIndex + 1, context);
+
+        public void IncrementRenderMode()
+        {
+            _renderModeIndex++;
+        }
+
+        public void IncrementFormName()
+        {
+            _formNameIndex++;
+        }
+    }
+}

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ScopeStack.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ScopeStack.cs
@@ -18,10 +18,7 @@ internal class ScopeStack
 {
     private readonly Stack<ScopeEntry> _stack = new Stack<ScopeEntry>();
 
-    public string BuilderVarName =>
-        Current.BuilderVarNumber == 1
-            ? ComponentsApi.RenderTreeBuilder.BuilderParameter
-            : $"{ComponentsApi.RenderTreeBuilder.BuilderParameter}{Current.BuilderVarNumber}";
+    public BuilderName BuilderVarName => new(Current.BuilderVarNumber);
 
     public string RenderModeVarName =>
        Current.BuilderVarNumber == 1 && Current.RenderModeCount == 0

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ScopeStack.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ScopeStack.cs
@@ -18,17 +18,9 @@ internal class ScopeStack
 {
     private readonly Stack<ScopeEntry> _stack = new Stack<ScopeEntry>();
 
-    public BuilderName BuilderVarName => new(Current.BuilderVarNumber);
-
-    public string RenderModeVarName =>
-       Current.BuilderVarNumber == 1 && Current.RenderModeCount == 0
-            ? ComponentsApi.RenderTreeBuilder.RenderModeVariableName
-            : $"{ComponentsApi.RenderTreeBuilder.RenderModeVariableName}{Current.BuilderVarNumber}_{Current.RenderModeCount}";
-   
-    public string FormNameVarName =>
-       Current.BuilderVarNumber == 1 && Current.FormNameCount == 0
-            ? ComponentsApi.RenderTreeBuilder.FormNameVariableName
-            : $"{ComponentsApi.RenderTreeBuilder.FormNameVariableName}{Current.BuilderVarNumber}_{Current.FormNameCount}";
+    public BuilderVariableName BuilderVarName => new(Current.BuilderVarNumber);
+    public RenderModeVariableName RenderModeVarName => new(Current.RenderModeCount, Current.BuilderVarNumber);
+    public FormNameVariableName FormNameVarName => new(Current.FormNameCount, Current.BuilderVarNumber);
 
     public int Depth => _stack.Count - 1;
 
@@ -75,7 +67,7 @@ internal class ScopeStack
     }
 
     public void IncrementFormName()
-    { 
+    {
         Current.FormNameCount++;
     }
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/CascadingGenericTypeParameter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/CascadingGenericTypeParameter.cs
@@ -31,5 +31,5 @@ public sealed class CascadingGenericTypeParameter
     /// generic parameters, this will only be populated once a variable is emitted corresponding to
     /// <see cref="ValueSourceNode"/>.
     /// </summary>
-    internal string ValueExpression { get; set; }
+    internal object ValueExpression { get; set; }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/Int32ExtensionsTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/Int32ExtensionsTests.cs
@@ -1,0 +1,95 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Utilities.Shared.Test;
+
+public class Int32ExtensionsTests
+{
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(1, 1)]
+    [InlineData(9, 1)]
+    [InlineData(10, 2)]
+    [InlineData(99, 2)]
+    [InlineData(100, 3)]
+    [InlineData(999, 3)]
+    [InlineData(1000, 4)]
+    [InlineData(9999, 4)]
+    [InlineData(10000, 5)]
+    [InlineData(99999, 5)]
+    [InlineData(100000, 6)]
+    [InlineData(999999, 6)]
+    [InlineData(1000000, 7)]
+    [InlineData(9999999, 7)]
+    [InlineData(10000000, 8)]
+    [InlineData(99999999, 8)]
+    [InlineData(100000000, 9)]
+    [InlineData(999999999, 9)]
+    [InlineData(1000000000, 10)]
+    [InlineData(int.MaxValue, 10)]
+    public void CountDigits_PositiveNumbers_ReturnsCorrectCount(int number, int expectedDigits)
+    {
+        // Act
+        var result = number.CountDigits();
+
+        // Assert
+        Assert.Equal(expectedDigits, result);
+    }
+
+    [Theory]
+    [InlineData(-1, 1)]
+    [InlineData(-9, 1)]
+    [InlineData(-10, 2)]
+    [InlineData(-99, 2)]
+    [InlineData(-100, 3)]
+    [InlineData(-999, 3)]
+    [InlineData(-1000, 4)]
+    [InlineData(-9999, 4)]
+    [InlineData(-10000, 5)]
+    [InlineData(-99999, 5)]
+    [InlineData(-100000, 6)]
+    [InlineData(-999999, 6)]
+    [InlineData(-1000000, 7)]
+    [InlineData(-9999999, 7)]
+    [InlineData(-10000000, 8)]
+    [InlineData(-99999999, 8)]
+    [InlineData(-100000000, 9)]
+    [InlineData(-999999999, 9)]
+    [InlineData(-1000000000, 10)]
+    [InlineData(int.MinValue, 10)]
+    public void CountDigits_NegativeNumbers_ReturnsCorrectCount(int number, int expectedDigits)
+    {
+        // Act
+        var result = number.CountDigits();
+
+        // Assert
+        Assert.Equal(expectedDigits, result);
+    }
+
+    [Fact]
+    public void CountDigits_BoundaryValues_ReturnsCorrectCount()
+    {
+        // Test specific boundary values for each digit count
+        Assert.Equal(1, 0.CountDigits());
+        Assert.Equal(2, 10.CountDigits());
+        Assert.Equal(3, 100.CountDigits());
+        Assert.Equal(4, 1000.CountDigits());
+        Assert.Equal(5, 10000.CountDigits());
+        Assert.Equal(6, 100000.CountDigits());
+        Assert.Equal(7, 1000000.CountDigits());
+        Assert.Equal(8, 10000000.CountDigits());
+        Assert.Equal(9, 100000000.CountDigits());
+        Assert.Equal(10, 1000000000.CountDigits());
+    }
+
+    [Fact]
+    public void CountDigits_ExtremeValues_ReturnsCorrectCount()
+    {
+        // Test extreme values
+        Assert.Equal(10, int.MaxValue.CountDigits());
+        Assert.Equal(10, int.MinValue.CountDigits());
+    }
+}

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Int32Extensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Int32Extensions.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System;
+
+internal static class Int32Extensions
+{
+    public static int CountDigits(this int number)
+    {
+        var value = number < 0 ? (uint)-(number + 1) + 1 : (uint)number;
+        
+        // Binary search approach for better branch prediction
+        if (value < 100000)
+        {
+            if (value < 100)
+            {
+                return value < 10 ? 1 : 2;
+            }
+            
+            if (value < 10000)
+            {
+                return value < 1000 ? 3 : 4;
+            }
+            
+            return 5;
+        }
+
+        if (value < 10000000)
+        {
+            return value < 1000000 ? 6 : 7;
+        }
+
+        if (value < 1000000000)
+        {
+            return value < 100000000 ? 8 : 9;
+        }
+
+        return 10;
+    }
+}

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Int32Extensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Int32Extensions.cs
@@ -7,8 +7,9 @@ internal static class Int32Extensions
 {
     public static int CountDigits(this int number)
     {
+        // Avoid overflow when negating Int32.MinValue by using unsigned arithmetic
         var value = number < 0 ? (uint)-(number + 1) + 1 : (uint)number;
-        
+
         // Binary search approach for better branch prediction
         if (value < 100000)
         {
@@ -16,12 +17,12 @@ internal static class Int32Extensions
             {
                 return value < 10 ? 1 : 2;
             }
-            
+
             if (value < 10000)
             {
                 return value < 1000 ? 3 : 4;
             }
-            
+
             return 5;
         }
 

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Int32Extensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Int32Extensions.cs
@@ -11,29 +11,29 @@ internal static class Int32Extensions
         var value = number < 0 ? (uint)-(number + 1) + 1 : (uint)number;
 
         // Binary search approach for better branch prediction
-        if (value < 100000)
+        if (value < 100_000)
         {
             if (value < 100)
             {
                 return value < 10 ? 1 : 2;
             }
 
-            if (value < 10000)
+            if (value < 10_000)
             {
-                return value < 1000 ? 3 : 4;
+                return value < 1_000 ? 3 : 4;
             }
 
             return 5;
         }
 
-        if (value < 10000000)
+        if (value < 10_000_000)
         {
-            return value < 1000000 ? 6 : 7;
+            return value < 1_000_000 ? 6 : 7;
         }
 
-        if (value < 1000000000)
+        if (value < 1_000_000_000)
         {
-            return value < 100000000 ? 8 : 9;
+            return value < 100_000_000 ? 8 : 9;
         }
 
         return 10;


### PR DESCRIPTION
This change is targeted primarily at `ScopeStack` and `TypeInferenceMethodParameter`. Each of these holds onto strings that are created for variable names written during code generation. These variable names all take the form of some well-formed prefix and a suffix generated from int values, i.e. `"__seq0"`. We can avoid allocating these strings by providing lightweight abstractions to hold the bits that change (i.e. the suffix data) and write the data directly.

----
CI Build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2771119&view=results
Test Insertion: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/661321
Toolset Run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2771120&view=results