### PR TITLE
Add missing `global::` prefix in a `@ref` scenario

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithCssScope/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithCssScope/TestComponent.codegen.cs
@@ -71,7 +71,7 @@ __o = typeof(global::Test.TemplatedComponent);
 #nullable disable
 #nullable restore
 #line 13 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                      myElementReference = default(Microsoft.AspNetCore.Components.ElementReference)!;
+                                      myElementReference = default(global::Microsoft.AspNetCore.Components.ElementReference)!;
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithCssScope/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithCssScope/TestComponent.mappings.txt
@@ -35,19 +35,19 @@ Generated Location: (2223:73,38 [18] )
 Source Location: (557:12,84 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     |
-Generated Location: (2439:78,84 [6] )
+Generated Location: (2447:78,84 [6] )
 |
     |
 
 Source Location: (589:13,30 [10] x:\dir\subdir\Test\TestComponent.cshtml)
 |myVariable|
-Generated Location: (2634:83,30 [10] )
+Generated Location: (2642:83,30 [10] )
 |myVariable|
 
 Source Location: (637:13,78 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |
 }|
-Generated Location: (3007:92,78 [3] )
+Generated Location: (3015:92,78 [3] )
 |
 }|
 
@@ -62,7 +62,7 @@ Source Location: (651:16,7 [245] x:\dir\subdir\Test\TestComponent.cshtml)
         for (var i = 0; i < 10; i++)
         {
             |
-Generated Location: (3189:102,7 [245] )
+Generated Location: (3197:102,7 [245] )
 |
     ElementReference myElementReference;
     TemplatedComponent myComponentReference;
@@ -76,12 +76,12 @@ Generated Location: (3189:102,7 [245] )
 
 Source Location: (912:25,28 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |i|
-Generated Location: (3601:119,28 [1] )
+Generated Location: (3609:119,28 [1] )
 |i|
 
 Source Location: (925:25,41 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |i|
-Generated Location: (3777:127,41 [1] )
+Generated Location: (3785:127,41 [1] )
 |i|
 
 Source Location: (931:25,47 [166] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -93,7 +93,7 @@ Source Location: (931:25,47 [166] x:\dir\subdir\Test\TestComponent.cshtml)
         System.GC.KeepAlive(myVariable);
     }
 |
-Generated Location: (3949:134,47 [166] )
+Generated Location: (3957:134,47 [166] )
 |
         }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithRef/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithRef/TestComponent.codegen.cs
@@ -26,7 +26,7 @@ namespace Test
         {
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                     myElem = default(Microsoft.AspNetCore.Components.ElementReference)!;
+                                     myElem = default(global::Microsoft.AspNetCore.Components.ElementReference)!;
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithRef/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithRef/TestComponent.mappings.txt
@@ -8,7 +8,7 @@ Source Location: (91:2,7 [128] x:\dir\subdir\Test\TestComponent.cshtml)
     private Microsoft.AspNetCore.Components.ElementReference myElem;
     public void Foo() { System.GC.KeepAlive(myElem); }
 |
-Generated Location: (1268:37,7 [128] )
+Generated Location: (1276:37,7 [128] )
 |
     private Microsoft.AspNetCore.Components.ElementReference myElem;
     public void Foo() { System.GC.KeepAlive(myElem); }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithRef_AndOtherAttributes/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithRef_AndOtherAttributes/TestComponent.codegen.cs
@@ -35,7 +35,7 @@ namespace Test
             ;
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                                 _element = default(Microsoft.AspNetCore.Components.ElementReference)!;
+                                                 _element = default(global::Microsoft.AspNetCore.Components.ElementReference)!;
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithRef_AndOtherAttributes/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Element_WithRef_AndOtherAttributes/TestComponent.mappings.txt
@@ -15,7 +15,7 @@ Source Location: (72:2,7 [164] x:\dir\subdir\Test\TestComponent.cshtml)
         [Parameter] public int Min { get; set; }
         public void Foo() { System.GC.KeepAlive(_element); }
     |
-Generated Location: (1479:46,7 [164] )
+Generated Location: (1487:46,7 [164] )
 |
         private ElementReference _element;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithCssScope/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithCssScope/TestComponent.codegen.cs
@@ -57,7 +57,7 @@ myComponentReference
 #line default
 #line hidden
 #nullable disable
-                 = (Test.TemplatedComponent)__value;
+                 = (global::Test.TemplatedComponent)__value;
             }
             );
             __builder.CloseComponent();

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithCssScope/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithCssScope/TestComponent.mappings.txt
@@ -22,25 +22,25 @@ Source Location: (439:10,1 [34] x:\dir\subdir\Test\TestComponent.cshtml)
 |if (DateTime.Now.Year > 1950)
 {
 |
-Generated Location: (2505:66,0 [34] )
+Generated Location: (2513:66,0 [34] )
 |if (DateTime.Now.Year > 1950)
 {
 |
 
 Source Location: (511:12,38 [18] x:\dir\subdir\Test\TestComponent.cshtml)
 |myElementReference|
-Generated Location: (2915:79,0 [18] )
+Generated Location: (2923:79,0 [18] )
 |myElementReference|
 
 Source Location: (589:13,30 [10] x:\dir\subdir\Test\TestComponent.cshtml)
 |myVariable|
-Generated Location: (3576:96,0 [10] )
+Generated Location: (3584:96,0 [10] )
 |myVariable|
 
 Source Location: (639:14,0 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |}
 |
-Generated Location: (4070:108,0 [3] )
+Generated Location: (4078:108,0 [3] )
 |}
 |
 
@@ -55,7 +55,7 @@ Source Location: (651:16,7 [233] x:\dir\subdir\Test\TestComponent.cshtml)
         for (var i = 0; i < 10; i++)
         {
 |
-Generated Location: (4256:118,0 [233] )
+Generated Location: (4264:118,0 [233] )
 |
     ElementReference myElementReference;
     TemplatedComponent myComponentReference;
@@ -69,12 +69,12 @@ Generated Location: (4256:118,0 [233] )
 
 Source Location: (912:25,28 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |i|
-Generated Location: (4718:136,0 [1] )
+Generated Location: (4726:136,0 [1] )
 |i|
 
 Source Location: (925:25,41 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |i|
-Generated Location: (4997:146,25 [1] )
+Generated Location: (5005:146,25 [1] )
 |i|
 
 Source Location: (933:26,0 [164] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -85,7 +85,7 @@ Source Location: (933:26,0 [164] x:\dir\subdir\Test\TestComponent.cshtml)
         System.GC.KeepAlive(myVariable);
     }
 |
-Generated Location: (5179:155,0 [164] )
+Generated Location: (5187:155,0 [164] )
 |        }
 
         System.GC.KeepAlive(myElementReference);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef/TestComponent.codegen.cs
@@ -28,7 +28,7 @@ myInstance
 #line default
 #line hidden
 #nullable disable
-                 = (Test.MyComponent)__value;
+                 = (global::Test.MyComponent)__value;
             }
             );
             __builder.CloseComponent();

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef/TestComponent.mappings.txt
@@ -8,7 +8,7 @@ Source Location: (84:2,7 [104] x:\dir\subdir\Test\TestComponent.cshtml)
     private Test.MyComponent myInstance;
     public void Foo() { System.GC.KeepAlive(myInstance); }
 |
-Generated Location: (1329:38,0 [104] )
+Generated Location: (1337:38,0 [104] )
 |
     private Test.MyComponent myInstance;
     public void Foo() { System.GC.KeepAlive(myInstance); }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef_Nullable/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef_Nullable/TestComponent.codegen.cs
@@ -26,7 +26,7 @@ myComponent
 #line default
 #line hidden
 #nullable disable
-                 = (Test.TestComponent)__value;
+                 = (global::Test.TestComponent)__value;
             }
             );
             __builder.CloseComponent();

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef_Nullable/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef_Nullable/TestComponent.mappings.txt
@@ -8,7 +8,7 @@ Source Location: (47:2,7 [111] x:\dir\subdir\Test\TestComponent.cshtml)
     private TestComponent myComponent = null!;
     public void Use() { System.GC.KeepAlive(myComponent); }
 |
-Generated Location: (1188:36,0 [111] )
+Generated Location: (1196:36,0 [111] )
 |
     private TestComponent myComponent = null!;
     public void Use() { System.GC.KeepAlive(myComponent); }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.codegen.cs
@@ -32,7 +32,7 @@ myInstance
 #line default
 #line hidden
 #nullable disable
-                 = (Test.MyComponent)__value;
+                 = (global::Test.MyComponent)__value;
             }
             );
             __builder.CloseComponent();

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.mappings.txt
@@ -8,7 +8,7 @@ Source Location: (108:4,7 [104] x:\dir\subdir\Test\TestComponent.cshtml)
     private Test.MyComponent myInstance;
     public void Foo() { System.GC.KeepAlive(myInstance); }
 |
-Generated Location: (1560:42,0 [104] )
+Generated Location: (1568:42,0 [104] )
 |
     private Test.MyComponent myInstance;
     public void Foo() { System.GC.KeepAlive(myInstance); }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef_CreatesDiagnostic/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef_CreatesDiagnostic/TestComponent.codegen.cs
@@ -51,7 +51,7 @@ _my
 #line default
 #line hidden
 #nullable disable
-                 = (Test.MyComponent<int>)__value;
+                 = (global::Test.MyComponent<int>)__value;
             }
             );
             __builder.CloseComponent();

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef_CreatesDiagnostic/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef_CreatesDiagnostic/TestComponent.mappings.txt
@@ -23,7 +23,7 @@ Source Location: (56:2,7 [90] x:\dir\subdir\Test\TestComponent.cshtml)
     private MyComponent<int> _my;
     public void Foo() { System.GC.KeepAlive(_my); }
 |
-Generated Location: (1814:61,0 [90] )
+Generated Location: (1822:61,0 [90] )
 |
     private MyComponent<int> _my;
     public void Foo() { System.GC.KeepAlive(_my); }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentDesignTimeNodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentDesignTimeNodeWriter.cs
@@ -1120,9 +1120,6 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
             // The runtime node writer moves the call elsewhere. At design time we
             // just want sufficiently similar code that any unknown-identifier or type
             // errors will be equivalent
-            var captureTypeName = node.IsComponentCapture
-                ? TypeNameHelper.GetGloballyQualifiedNameIfNeeded(node.ComponentCaptureTypeName)
-                : ComponentsApi.ElementReference.FullTypeName;
             var nullSuppression = !context.Options.SuppressNullabilityEnforcement ? "!" : string.Empty;
             WriteCSharpCode(context, new CSharpCodeIntermediateNode
             {
@@ -1130,7 +1127,7 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
                 Children =
                 {
                     node.IdentifierToken,
-                    IntermediateNodeFactory.CSharpToken($" = default({captureTypeName}){nullSuppression};")
+                    IntermediateNodeFactory.CSharpToken($" = default({node.FieldTypeName}){nullSuppression};")
                 }
             });
         }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentNodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentNodeWriter.cs
@@ -226,7 +226,7 @@ internal abstract class ComponentNodeWriter : IntermediateNodeWriter, ITemplateT
                     context.CodeWriter.Write(parameter.SeqName);
                     context.CodeWriter.Write(", ");
 
-                    var cast = capture.IsComponentCapture ? $"({capture.ComponentCaptureTypeName})" : string.Empty;
+                    var cast = capture.IsComponentCapture ? $"({capture.FieldTypeName})" : string.Empty;
                     context.CodeWriter.Write($"(__value) => {{ {parameter.ParameterName}({cast}__value); }}");
                     context.CodeWriter.WriteEndMethodInvocation();
                     break;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentRuntimeNodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentRuntimeNodeWriter.cs
@@ -990,7 +990,7 @@ internal class ComponentRuntimeNodeWriter : ComponentNodeWriter
         const string refCaptureParamName = "__value";
         using (var lambdaScope = context.CodeWriter.BuildLambda(refCaptureParamName))
         {
-            var typecastIfNeeded = shouldTypeCheck && node.IsComponentCapture ? $"({node.ComponentCaptureTypeName})" : string.Empty;
+            var typecastIfNeeded = shouldTypeCheck && node.IsComponentCapture ? $"({node.FieldTypeName})" : string.Empty;
             WriteCSharpCode(context, new CSharpCodeIntermediateNode
             {
                 Source = node.Source,

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/ReferenceCaptureIntermediateNode.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/ReferenceCaptureIntermediateNode.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System;
-using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 using Microsoft.AspNetCore.Razor.Language.Components;
 
 namespace Microsoft.AspNetCore.Razor.Language.Intermediate;
@@ -35,9 +34,14 @@ public sealed class ReferenceCaptureIntermediateNode : IntermediateNode
 
     public bool IsComponentCapture { get; }
 
+    /// <remarks>
+    /// This is not <c>global::</c>-prefixed, for that consider using <see cref="FieldTypeName"/> instead.
+    /// </remarks>
     public string ComponentCaptureTypeName { get; set; }
 
-    public string FieldTypeName => IsComponentCapture ? ComponentCaptureTypeName : $"global::{ComponentsApi.ElementReference.FullTypeName}";
+    public string FieldTypeName => IsComponentCapture
+        ? TypeNameHelper.GetGloballyQualifiedNameIfNeeded(ComponentCaptureTypeName)
+        : $"global::{ComponentsApi.ElementReference.FullTypeName}";
 
     public string TypeName => $"global::System.Action<{FieldTypeName}>";
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/12043.