### PR TITLE
Update publishdata for main branch

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -28,8 +28,8 @@
         "NonShipping"
       ],
       "vsBranch": "main",
-      "insertionCreateDraftPR": false,
-      "insertionTitlePrefix": "[dNext]"
+      "insertionCreateDraftPR": true,
+      "insertionTitlePrefix": "[Validation]"
     },
     "release/dev17.6": {
       "nugetKind": [


### PR DESCRIPTION
Same change as https://github.com/dotnet/roslyn/pull/79981 for roslyn - ensures that we only have one branch (which is dev/18.0 at the moment) creating non-draft prs into a VS branch. We'll change this back later in the week...