### PR TITLE
Compiler: Clean up and reduce allocations in ComponentBindLoweringPass

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentBindLoweringPass.AttributeInfo.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentBindLoweringPass.AttributeInfo.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Razor.Language.Intermediate;
+
+namespace Microsoft.AspNetCore.Razor.Language.Components;
+
+internal partial class ComponentBindLoweringPass
+{
+    private struct AttributeInfo
+    {
+        public IntermediateNode Node { get; }
+        public int Index { get; }
+        public TagHelperDescriptor TagHelper { get; }
+        public string AttributeName { get; }
+        public string OriginalAttributeName { get; }
+
+        private bool? _isFallbackBindTagHelper;
+        private bool? _isBindTagHelper;
+        private bool? _isInputElementFallbackBindTagHelper;
+        private bool? _isInputElementBindTagHelper;
+
+        public bool IsFallbackBindTagHelper
+            => _isFallbackBindTagHelper ??= TagHelper.IsFallbackBindTagHelper();
+
+        public bool IsBindTagHelper
+            => _isBindTagHelper ??= TagHelper.IsBindTagHelper();
+
+        public bool IsInputElementFallbackBindTagHelper
+            => _isInputElementFallbackBindTagHelper ??= TagHelper.IsInputElementFallbackBindTagHelper();
+
+        public bool IsInputElementBindTagHelper
+            => _isInputElementBindTagHelper ??= TagHelper.IsInputElementBindTagHelper();
+
+        public bool IsFallback => IsFallbackBindTagHelper || IsInputElementFallbackBindTagHelper;
+
+        private AttributeInfo(
+            IntermediateNode node,
+            int index,
+            TagHelperDescriptor tagHelper,
+            string attributeName,
+            string originalAttributeName)
+        {
+            Node = node;
+            Index = index;
+            TagHelper = tagHelper;
+            AttributeName = attributeName;
+            OriginalAttributeName = originalAttributeName;
+        }
+
+        public AttributeInfo(TagHelperDirectiveAttributeIntermediateNode node, int index)
+            : this(node, index, node.TagHelper, node.AttributeName, node.OriginalAttributeName)
+        {
+        }
+
+        public AttributeInfo(TagHelperDirectiveAttributeParameterIntermediateNode node, int index)
+            : this(node, index, node.TagHelper, node.AttributeName, node.OriginalAttributeName)
+        {
+        }
+    }
+}

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentBindLoweringPass.BindEntryKey.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentBindLoweringPass.BindEntryKey.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Razor.Language.Intermediate;
+using Microsoft.Extensions.Internal;
+
+namespace Microsoft.AspNetCore.Razor.Language.Components;
+
+internal partial class ComponentBindLoweringPass
+{
+    private readonly record struct BindEntryKey(IntermediateNode Parent, string AttributeName)
+    {
+        public BindEntryKey(IntermediateNode parent, TagHelperDirectiveAttributeIntermediateNode node)
+            : this(parent, node.AttributeName)
+        {
+        }
+
+        public BindEntryKey(IntermediateNode parent, TagHelperDirectiveAttributeParameterIntermediateNode node)
+            : this(parent, node.AttributeNameWithoutParameter)
+        {
+        }
+
+        public bool Equals(BindEntryKey other)
+            => ReferenceEquals(Parent, other.Parent) &&
+               AttributeName == other.AttributeName;
+
+        public override int GetHashCode()
+        {
+            var hash = HashCodeCombiner.Start();
+
+            hash.Add(Parent);
+            hash.Add(AttributeName);
+
+            return hash.CombinedHash;
+        }
+    }
+}

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentBindLoweringPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentBindLoweringPass.cs
@@ -16,11 +16,9 @@ using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Razor.Language.Components;
 
-internal partial class ComponentBindLoweringPass(bool bindGetSetSupported) : ComponentIntermediateNodePassBase, IRazorOptimizationPass
+internal partial class ComponentBindLoweringPass : ComponentIntermediateNodePassBase, IRazorOptimizationPass
 {
     private static readonly string s_cultureInvariantText = $"global::{typeof(CultureInfo).FullName}.{nameof(CultureInfo.InvariantCulture)}";
-
-    private readonly bool _bindGetSetSupported = bindGetSetSupported;
 
     // Run after event handler pass
     public override int Order => 100;
@@ -39,6 +37,8 @@ internal partial class ComponentBindLoweringPass(bool bindGetSetSupported) : Com
             // Nothing to do, bail. We can't function without the standard structure.
             return;
         }
+
+        var bindGetSetSupported = codeDocument.ParserOptions.LanguageVersion >= RazorLanguageVersion.Version_7_0;
 
         using var references = new PooledArrayBuilder<IntermediateNodeReference>();
         using var parameterReferences = new PooledArrayBuilder<IntermediateNodeReference>();
@@ -90,7 +90,7 @@ internal partial class ComponentBindLoweringPass(bool bindGetSetSupported) : Com
                 continue;
             }
 
-            if (!_bindGetSetSupported)
+            if (!bindGetSetSupported)
             {
                 node.AddDiagnostic(ComponentDiagnosticFactory.CreateBindAttributeParameter_UnsupportedSyntaxBindGetSet(
                     node.Source,

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentBindLoweringPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentBindLoweringPass.cs
@@ -214,7 +214,7 @@ internal class ComponentBindLoweringPass : ComponentIntermediateNodePassBase, IR
         }
     }
 
-    private void ProcessDuplicates(IntermediateNode node)
+    private static void ProcessDuplicates(IntermediateNode node)
     {
         // Reverse order because we will remove nodes.
         //
@@ -330,7 +330,7 @@ internal class ComponentBindLoweringPass : ComponentIntermediateNodePassBase, IR
         }
     }
 
-    private IntermediateNode[] RewriteUsage(IntermediateNode parent, BindEntry bindEntry)
+    private static IntermediateNode[] RewriteUsage(IntermediateNode parent, BindEntry bindEntry)
     {
         // Bind works similarly to a macro, it always expands to code that the user could have written.
         //
@@ -608,7 +608,7 @@ internal class ComponentBindLoweringPass : ComponentIntermediateNodePassBase, IR
         builder.Add(helperNode);
     }
 
-    private bool TryParseBindAttribute(BindEntry bindEntry, out string? valueAttributeName)
+    private static bool TryParseBindAttribute(BindEntry bindEntry, out string? valueAttributeName)
     {
         var attributeName = bindEntry.GetEffectiveBindNodeAttributeName();
         valueAttributeName = null;
@@ -628,7 +628,7 @@ internal class ComponentBindLoweringPass : ComponentIntermediateNodePassBase, IR
     }
 
     // Attempts to compute the attribute names that should be used for an instance of 'bind'.
-    private bool TryComputeAttributeNames(
+    private static bool TryComputeAttributeNames(
         IntermediateNode parent,
         BindEntry bindEntry,
         out string? valueAttributeName,
@@ -759,7 +759,7 @@ internal class ComponentBindLoweringPass : ComponentIntermediateNodePassBase, IR
         }
     }
 
-    private void RewriteNodesForComponentDelegateBind(
+    private static void RewriteNodesForComponentDelegateBind(
         IntermediateToken original,
         IntermediateToken? setter,
         IntermediateToken? after,
@@ -823,7 +823,7 @@ internal class ComponentBindLoweringPass : ComponentIntermediateNodePassBase, IR
         }
     }
 
-    private void RewriteNodesForComponentEventCallbackBind(
+    private static void RewriteNodesForComponentEventCallbackBind(
         IntermediateToken original,
         IntermediateToken? setter,
         IntermediateToken? after,
@@ -874,7 +874,7 @@ internal class ComponentBindLoweringPass : ComponentIntermediateNodePassBase, IR
         changeExpressionTokens.Add(IntermediateNodeFactory.CSharpToken($", {original.Content})"));
     }
 
-    private void RewriteNodesForElementEventCallbackBind(
+    private static void RewriteNodesForElementEventCallbackBind(
         IntermediateToken original,
         IntermediateToken? format,
         IntermediateToken? culture,
@@ -1008,7 +1008,7 @@ internal class ComponentBindLoweringPass : ComponentIntermediateNodePassBase, IR
             return GetToken(node);
         }
 
-        IntermediateToken GetToken(IntermediateNode parent)
+        static IntermediateToken GetToken(IntermediateNode parent)
         {
             if (parent.Children.Count == 1 && parent.Children[0] is IntermediateToken token)
             {

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentDiagnosticFactory.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentDiagnosticFactory.cs
@@ -112,7 +112,8 @@ internal static class ComponentDiagnosticFactory
             "The attribute '{0}' was matched by multiple bind attributes. Duplicates:{1}",
             RazorDiagnosticSeverity.Error);
 
-    public static RazorDiagnostic CreateBindAttribute_Duplicates(SourceSpan? source, string attribute, TagHelperDirectiveAttributeIntermediateNode[] attributes)
+    public static RazorDiagnostic CreateBindAttribute_Duplicates(
+        SourceSpan? source, string attribute, IEnumerable<TagHelperDirectiveAttributeIntermediateNode> attributes)
         => RazorDiagnostic.Create(
             BindAttribute_Duplicates,
             source,

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentEventHandlerLoweringPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentEventHandlerLoweringPass.cs
@@ -209,20 +209,17 @@ internal class ComponentEventHandlerLoweringPass : ComponentIntermediateNodePass
         }
         else
         {
-            var result = new ComponentAttributeIntermediateNode(node)
-            {
-                OriginalAttributeName = node.OriginalAttributeName,
-            };
-
-            result.Children.Clear();
+            var result = ComponentAttributeIntermediateNode.From(node, addChildren: false);
+            result.OriginalAttributeName = node.OriginalAttributeName;
 
             var expressionNode = new CSharpExpressionIntermediateNode();
-            result.Children.Add(expressionNode);
 
             foreach (var token in tokens)
             {
                 expressionNode.Children.Add(token);
             }
+
+            result.Children.Add(expressionNode);
 
             return result;
         }
@@ -276,13 +273,9 @@ internal class ComponentEventHandlerLoweringPass : ComponentIntermediateNodePass
             return node;
         }
 
-        var result = new ComponentAttributeIntermediateNode(node)
-        {
-            OriginalAttributeName = node.OriginalAttributeName,
-            AddAttributeMethodName = eventHandlerMethod,
-        };
-
-        result.Children.Clear();
+        var result = ComponentAttributeIntermediateNode.From(node, addChildren: false);
+        result.OriginalAttributeName = node.OriginalAttributeName;
+        result.AddAttributeMethodName = eventHandlerMethod;
 
         if (node.AttributeStructure != AttributeStructure.Minimized)
         {

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/ComponentAttributeIntermediateNode.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/ComponentAttributeIntermediateNode.cs
@@ -93,51 +93,49 @@ public sealed class ComponentAttributeIntermediateNode : IntermediateNode
         AddDiagnosticsFromNode(propertyNode);
     }
 
-    public ComponentAttributeIntermediateNode(TagHelperDirectiveAttributeIntermediateNode directiveAttributeNode)
+    private ComponentAttributeIntermediateNode(TagHelperDirectiveAttributeIntermediateNode node, bool addChildren)
     {
-        if (directiveAttributeNode == null)
+        AttributeName = node.AttributeName;
+        AttributeStructure = node.AttributeStructure;
+        BoundAttribute = node.BoundAttribute;
+        OriginalAttributeSpan = node.OriginalAttributeSpan;
+        PropertyName = node.BoundAttribute.PropertyName;
+        Source = node.Source;
+        TypeName = node.BoundAttribute.IsWeaklyTyped
+            ? null
+            : node.BoundAttribute.TypeName;
+
+        if (addChildren)
         {
-            throw new ArgumentNullException(nameof(directiveAttributeNode));
+            Children.AddRange(node.Children);
         }
 
-        AttributeName = directiveAttributeNode.AttributeName;
-        AttributeStructure = directiveAttributeNode.AttributeStructure;
-        BoundAttribute = directiveAttributeNode.BoundAttribute;
-        OriginalAttributeSpan = directiveAttributeNode.OriginalAttributeSpan;
-        PropertyName = directiveAttributeNode.BoundAttribute.PropertyName;
-        Source = directiveAttributeNode.Source;
-        TypeName = directiveAttributeNode.BoundAttribute.IsWeaklyTyped ? null : directiveAttributeNode.BoundAttribute.TypeName;
-
-        for (var i = 0; i < directiveAttributeNode.Children.Count; i++)
-        {
-            Children.Add(directiveAttributeNode.Children[i]);
-        }
-
-        AddDiagnosticsFromNode(directiveAttributeNode);
+        AddDiagnosticsFromNode(node);
     }
 
-    public ComponentAttributeIntermediateNode(TagHelperDirectiveAttributeParameterIntermediateNode directiveAttributeParameterNode)
+    private ComponentAttributeIntermediateNode(TagHelperDirectiveAttributeParameterIntermediateNode node, bool addChildren)
     {
-        if (directiveAttributeParameterNode == null)
+        AttributeName = node.AttributeNameWithoutParameter;
+        AttributeStructure = node.AttributeStructure;
+        BoundAttribute = node.BoundAttribute;
+        OriginalAttributeSpan = node.OriginalAttributeSpan;
+        PropertyName = node.BoundAttributeParameter.PropertyName;
+        Source = node.Source;
+        TypeName = node.BoundAttributeParameter.TypeName;
+
+        if (addChildren)
         {
-            throw new ArgumentNullException(nameof(directiveAttributeParameterNode));
+            Children.AddRange(node.Children);
         }
 
-        AttributeName = directiveAttributeParameterNode.AttributeNameWithoutParameter;
-        AttributeStructure = directiveAttributeParameterNode.AttributeStructure;
-        BoundAttribute = directiveAttributeParameterNode.BoundAttribute;
-        OriginalAttributeSpan = directiveAttributeParameterNode.OriginalAttributeSpan;
-        PropertyName = directiveAttributeParameterNode.BoundAttributeParameter.PropertyName;
-        Source = directiveAttributeParameterNode.Source;
-        TypeName = directiveAttributeParameterNode.BoundAttributeParameter.TypeName;
-
-        for (var i = 0; i < directiveAttributeParameterNode.Children.Count; i++)
-        {
-            Children.Add(directiveAttributeParameterNode.Children[i]);
-        }
-
-        AddDiagnosticsFromNode(directiveAttributeParameterNode);
+        AddDiagnosticsFromNode(node);
     }
+
+    public static ComponentAttributeIntermediateNode From(TagHelperDirectiveAttributeIntermediateNode node, bool addChildren)
+        => new(node, addChildren);
+
+    public static ComponentAttributeIntermediateNode From(TagHelperDirectiveAttributeParameterIntermediateNode node, bool addChildren)
+        => new(node, addChildren);
 
     public override IntermediateNodeCollection Children { get; } = new IntermediateNodeCollection();
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorProjectEngine.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorProjectEngine.cs
@@ -450,7 +450,7 @@ public sealed class RazorProjectEngine
         builder.Features.Add(new ComponentReferenceCaptureLoweringPass());
         builder.Features.Add(new ComponentSplatLoweringPass());
         builder.Features.Add(new ComponentFormNameLoweringPass());
-        builder.Features.Add(new ComponentBindLoweringPass(razorLanguageVersion >= RazorLanguageVersion.Version_7_0));
+        builder.Features.Add(new ComponentBindLoweringPass());
         builder.Features.Add(new ComponentRenderModeLoweringPass());
         builder.Features.Add(new ComponentCssScopePass());
         builder.Features.Add(new ComponentTemplateDiagnosticPass());


### PR DESCRIPTION
This PR cleans up and clarifies `ComponentBindLoweringPass` while reducing allocations. The changes should be fairly clear in the commit history.

----
CI Build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2779968&view=results
Toolset Run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2779967&view=results