### PR TITLE
*** WIP: Remove the feature flag for precise semantic tokens

### DIFF
--- a/eng/scripts/CIFeatureFlags.ps1
+++ b/eng/scripts/CIFeatureFlags.ps1
@@ -13,7 +13,6 @@ if ($flags -eq '') {
 $knownFlags = @{
     ShowAllCSharpCodeActions = "Razor.LSP.ShowAllCSharpCodeActions";
     IncludeProjectKeyInGeneratedFilePath = "Razor.LSP.IncludeProjectKeyInGeneratedFilePath";
-    UsePreciseSemanticTokenRanges = "Razor.LSP.UsePreciseSemanticTokenRanges";
     UseRazorCohostServer = "Razor.LSP.UseRazorCohostServer";
     DisableRazorLanguageServer = "Razor.LSP.DisableRazorLanguageServer";
     ForceRuntimeCodeGeneration = "Razor.LSP.ForceRuntimeCodeGeneration";

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensBenchmark.cs
@@ -15,7 +15,6 @@ using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.SemanticTokens;
-using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -95,11 +94,10 @@ public class RazorSemanticTokensBenchmark : RazorLanguageServerBenchmarkBase
     internal class TestRazorSemanticTokensInfoService : RazorSemanticTokensInfoService
     {
         public TestRazorSemanticTokensInfoService(
-            LanguageServerFeatureOptions languageServerFeatureOptions,
             IDocumentMappingService documentMappingService,
             RazorSemanticTokensLegendService razorSemanticTokensLegendService,
             ILoggerFactory loggerFactory)
-            : base(documentMappingService, razorSemanticTokensLegendService, csharpSemanticTokensProvider: null!, languageServerFeatureOptions, loggerFactory)
+            : base(documentMappingService, razorSemanticTokensLegendService, csharpSemanticTokensProvider: null!, loggerFactory)
         {
         }
 

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensRangeEndpointBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensRangeEndpointBenchmark.cs
@@ -17,7 +17,6 @@ using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.SemanticTokens;
-using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -131,11 +130,10 @@ public class RazorSemanticTokensRangeEndpointBenchmark : RazorLanguageServerBenc
     internal class TestCustomizableRazorSemanticTokensInfoService : RazorSemanticTokensInfoService
     {
         public TestCustomizableRazorSemanticTokensInfoService(
-            LanguageServerFeatureOptions languageServerFeatureOptions,
             IDocumentMappingService documentMappingService,
             RazorSemanticTokensLegendService razorSemanticTokensLegendService,
             ILoggerFactory loggerFactory)
-            : base(documentMappingService, razorSemanticTokensLegendService, csharpSemanticTokensProvider: null!, languageServerFeatureOptions, loggerFactory)
+            : base(documentMappingService, razorSemanticTokensLegendService, csharpSemanticTokensProvider: null!, loggerFactory)
         {
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
@@ -31,8 +31,6 @@ internal class DefaultLanguageServerFeatureOptions : LanguageServerFeatureOption
 
     public override bool IncludeProjectKeyInGeneratedFilePath => false;
 
-    public override bool UsePreciseSemanticTokenRanges => false;
-
     public override bool UseRazorCohostServer => false;
 
     public override bool UseNewFormattingEngine => true;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hosting/ConfigurableLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hosting/ConfigurableLanguageServerFeatureOptions.cs
@@ -17,7 +17,6 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     private readonly bool? _delegateToCSharpOnDiagnosticPublish;
     private readonly bool? _returnCodeActionAndRenamePathsWithPrefixedSlash;
     private readonly bool? _showAllCSharpCodeActions;
-    private readonly bool? _usePreciseSemanticTokenRanges;
     private readonly bool? _updateBuffersForClosedDocuments;
     private readonly bool? _includeProjectKeyInGeneratedFilePath;
     private readonly bool? _useRazorCohostServer;
@@ -31,7 +30,6 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     public override bool DelegateToCSharpOnDiagnosticPublish => _delegateToCSharpOnDiagnosticPublish ?? _defaults.DelegateToCSharpOnDiagnosticPublish;
     public override bool ReturnCodeActionAndRenamePathsWithPrefixedSlash => _returnCodeActionAndRenamePathsWithPrefixedSlash ?? _defaults.ReturnCodeActionAndRenamePathsWithPrefixedSlash;
     public override bool ShowAllCSharpCodeActions => _showAllCSharpCodeActions ?? _defaults.ShowAllCSharpCodeActions;
-    public override bool UsePreciseSemanticTokenRanges => _usePreciseSemanticTokenRanges ?? _defaults.UsePreciseSemanticTokenRanges;
     public override bool UpdateBuffersForClosedDocuments => _updateBuffersForClosedDocuments ?? _defaults.UpdateBuffersForClosedDocuments;
     public override bool IncludeProjectKeyInGeneratedFilePath => _includeProjectKeyInGeneratedFilePath ?? _defaults.IncludeProjectKeyInGeneratedFilePath;
     public override bool UseRazorCohostServer => _useRazorCohostServer ?? _defaults.UseRazorCohostServer;
@@ -61,7 +59,6 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
             TryProcessBoolOption(nameof(DelegateToCSharpOnDiagnosticPublish), ref _delegateToCSharpOnDiagnosticPublish, option, args, i);
             TryProcessBoolOption(nameof(ReturnCodeActionAndRenamePathsWithPrefixedSlash), ref _returnCodeActionAndRenamePathsWithPrefixedSlash, option, args, i);
             TryProcessBoolOption(nameof(ShowAllCSharpCodeActions), ref _showAllCSharpCodeActions, option, args, i);
-            TryProcessBoolOption(nameof(UsePreciseSemanticTokenRanges), ref _usePreciseSemanticTokenRanges, option, args, i);
             TryProcessBoolOption(nameof(UpdateBuffersForClosedDocuments), ref _updateBuffersForClosedDocuments, option, args, i);
             TryProcessBoolOption(nameof(IncludeProjectKeyInGeneratedFilePath), ref _includeProjectKeyInGeneratedFilePath, option, args, i);
             TryProcessBoolOption(nameof(UseRazorCohostServer), ref _useRazorCohostServer, option, args, i);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/RazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/RazorSemanticTokensInfoService.cs
@@ -12,8 +12,7 @@ internal class RazorSemanticTokensInfoService(
     IDocumentMappingService documentMappingService,
     ISemanticTokensLegendService semanticTokensLegendService,
     ICSharpSemanticTokensProvider csharpSemanticTokensProvider,
-    LanguageServerFeatureOptions languageServerFeatureOptions,
     ILoggerFactory loggerFactory)
-    : AbstractRazorSemanticTokensInfoService(documentMappingService, semanticTokensLegendService, csharpSemanticTokensProvider, languageServerFeatureOptions, loggerFactory.GetOrCreateLogger<RazorSemanticTokensInfoService>())
+    : AbstractRazorSemanticTokensInfoService(documentMappingService, semanticTokensLegendService, csharpSemanticTokensProvider, loggerFactory.GetOrCreateLogger<RazorSemanticTokensInfoService>())
 {
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -15,8 +15,6 @@ internal abstract class LanguageServerFeatureOptions
 
     public abstract bool DelegateToCSharpOnDiagnosticPublish { get; }
 
-    public abstract bool UsePreciseSemanticTokenRanges { get; }
-
     public abstract bool ShowAllCSharpCodeActions { get; }
 
     public abstract bool UpdateBuffersForClosedDocuments { get; }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/CustomMessageNames.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/CustomMessageNames.cs
@@ -37,7 +37,6 @@ internal static class CustomMessageNames
     public const string RazorResolveCodeActionsEndpoint = "razor/resolveCodeActions";
     public const string RazorProvideHtmlColorPresentationEndpoint = "razor/provideHtmlColorPresentation";
     public const string RazorProvideHtmlDocumentColorEndpoint = "razor/provideHtmlDocumentColor";
-    public const string RazorProvideSemanticTokensRangeEndpoint = "razor/provideSemanticTokensRange";
     public const string RazorFoldingRangeEndpoint = "razor/foldingRange";
     public const string RazorHtmlFormattingEndpoint = "razor/htmlFormatting";
     public const string RazorHtmlOnTypeFormattingEndpoint = "razor/htmlOnTypeFormatting";

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteClientInitializationOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteClientInitializationOptions.cs
@@ -10,9 +10,6 @@ internal struct RemoteClientInitializationOptions
     [JsonPropertyName("useRazorCohostServer")]
     public required bool UseRazorCohostServer { get; set; }
 
-    [JsonPropertyName("usePreciseSemanticTokenRanges")]
-    public required bool UsePreciseSemanticTokenRanges { get; set; }
-
     [JsonPropertyName("htmlVirtualDocumentSuffix")]
     public required string HtmlVirtualDocumentSuffix { get; set; }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Initialization/RemoteLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Initialization/RemoteLanguageServerFeatureOptions.cs
@@ -34,8 +34,6 @@ internal class RemoteLanguageServerFeatureOptions : LanguageServerFeatureOptions
 
     public override bool DelegateToCSharpOnDiagnosticPublish => throw new InvalidOperationException("This option has not been synced to OOP.");
 
-    public override bool UsePreciseSemanticTokenRanges => _options.UsePreciseSemanticTokenRanges;
-
     public override bool ShowAllCSharpCodeActions => _options.ShowAllCSharpCodeActions;
 
     public override bool UpdateBuffersForClosedDocuments => throw new InvalidOperationException("This option has not been synced to OOP.");

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RazorSemanticTokensInfoService.cs
@@ -5,7 +5,6 @@ using System.Composition;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.SemanticTokens;
-using Microsoft.CodeAnalysis.Razor.Workspaces;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor.SemanticTokens;
 
@@ -15,13 +14,11 @@ internal class RazorSemanticTokensInfoService(
     IDocumentMappingService documentMappingService,
     ISemanticTokensLegendService semanticTokensLegendService,
     ICSharpSemanticTokensProvider csharpSemanticTokensProvider,
-    LanguageServerFeatureOptions languageServerFeatureOptions,
     ILoggerFactory loggerFactory)
     : AbstractRazorSemanticTokensInfoService(
         documentMappingService,
         semanticTokensLegendService,
         csharpSemanticTokensProvider,
-        languageServerFeatureOptions,
         loggerFactory.GetOrCreateLogger<RazorSemanticTokensInfoService>())
 {
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceInvoker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceInvoker.cs
@@ -180,7 +180,6 @@ internal sealed class RemoteServiceInvoker(
                 var initParams = new RemoteClientInitializationOptions
                 {
                     UseRazorCohostServer = _languageServerFeatureOptions.UseRazorCohostServer,
-                    UsePreciseSemanticTokenRanges = _languageServerFeatureOptions.UsePreciseSemanticTokenRanges,
                     HtmlVirtualDocumentSuffix = _languageServerFeatureOptions.HtmlVirtualDocumentSuffix,
                     ReturnCodeActionAndRenamePathsWithPrefixedSlash = _languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash,
                     SupportsFileManipulation = _languageServerFeatureOptions.SupportsFileManipulation,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioLanguageServerFeatureOptions.cs
@@ -15,7 +15,6 @@ internal class VisualStudioLanguageServerFeatureOptions : LanguageServerFeatureO
     private readonly ILspEditorFeatureDetector _lspEditorFeatureDetector;
     private readonly Lazy<bool> _showAllCSharpCodeActions;
     private readonly Lazy<bool> _includeProjectKeyInGeneratedFilePath;
-    private readonly Lazy<bool> _usePreciseSemanticTokenRanges;
     private readonly Lazy<bool> _useRazorCohostServer;
     private readonly Lazy<bool> _useNewFormattingEngine;
 
@@ -41,13 +40,6 @@ internal class VisualStudioLanguageServerFeatureOptions : LanguageServerFeatureO
             var featureFlags = (IVsFeatureFlags)Package.GetGlobalService(typeof(SVsFeatureFlags));
             var includeProjectKeyInGeneratedFilePath = featureFlags.IsFeatureEnabled(WellKnownFeatureFlagNames.IncludeProjectKeyInGeneratedFilePath, defaultValue: true);
             return includeProjectKeyInGeneratedFilePath;
-        });
-
-        _usePreciseSemanticTokenRanges = new Lazy<bool>(() =>
-        {
-            var featureFlags = (IVsFeatureFlags)Package.GetGlobalService(typeof(SVsFeatureFlags));
-            var usePreciseSemanticTokenRanges = featureFlags.IsFeatureEnabled(WellKnownFeatureFlagNames.UsePreciseSemanticTokenRanges, defaultValue: false);
-            return usePreciseSemanticTokenRanges;
         });
 
         _useRazorCohostServer = new Lazy<bool>(() =>
@@ -85,8 +77,6 @@ internal class VisualStudioLanguageServerFeatureOptions : LanguageServerFeatureO
     public override bool ShowAllCSharpCodeActions => _showAllCSharpCodeActions.Value;
 
     public override bool IncludeProjectKeyInGeneratedFilePath => _includeProjectKeyInGeneratedFilePath.Value;
-
-    public override bool UsePreciseSemanticTokenRanges => _usePreciseSemanticTokenRanges.Value;
 
     public override bool UseRazorCohostServer => _useRazorCohostServer.Value;
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/WellKnownFeatureFlagNames.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/WellKnownFeatureFlagNames.cs
@@ -7,7 +7,6 @@ internal static class WellKnownFeatureFlagNames
 {
     public const string ShowAllCSharpCodeActions = "Razor.LSP.ShowAllCSharpCodeActions";
     public const string IncludeProjectKeyInGeneratedFilePath = "Razor.LSP.IncludeProjectKeyInGeneratedFilePath";
-    public const string UsePreciseSemanticTokenRanges = "Razor.LSP.UsePreciseSemanticTokenRanges";
     public const string UseRazorCohostServer = "Razor.LSP.UseRazorCohostServer";
     public const string DisableRazorLanguageServer = "Razor.LSP.DisableRazorLanguageServer";
     public const string UseRoslynTokenizer = "Razor.LSP.UseRoslynTokenizer";

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -50,13 +50,6 @@
 "Title"="Experimental Razor project multi-targeting support (requires restart)"
 "PreviewPaneChannels"="*"
 
-[$RootKey$\FeatureFlags\Razor\LSP\UsePreciseSemanticTokenRanges]
-"Description"="Use precise semantic token ranges when requesting semantic token information on razor files. Note: This is experimental, some actions may not apply correctly, or at all!"
-"Value"=dword:00000000
-"Title"="Use precise semantic token ranges when requesting semantic token information on Razor files (requires restart)"
-"PreviewPaneChannels"="*"
-"VisibleToInternalUsersOnlyChannels"="*"
-
 [$RootKey$\FeatureFlags\Razor\LSP\UseRazorCohostServer]
 "Description"="Uses the Razor language server that is cohosted in Roslyn to provide some Razor tooling functionality."
 "Value"=dword:00000000

--- a/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Services/VSCodeLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Services/VSCodeLanguageServerFeatureOptions.cs
@@ -29,7 +29,6 @@ internal class VSCodeLanguageServerFeatureOptions(RazorClientServerManagerProvid
     // Options that are set to their defaults
     public override bool SupportsFileManipulation => true;
     public override bool SingleServerSupport => false;
-    public override bool UsePreciseSemanticTokenRanges => false;
     public override bool ShowAllCSharpCodeActions => false;
     public override bool ReturnCodeActionAndRenamePathsWithPrefixedSlash => PlatformInformation.IsWindows;
     public override bool IncludeProjectKeyInGeneratedFilePath => false;

--- a/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Services/VSCodeRemoteServicesInitializer.cs
+++ b/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Services/VSCodeRemoteServicesInitializer.cs
@@ -54,7 +54,6 @@ internal class VSCodeRemoteServicesInitializer(
         await service.InitializeAsync(new RemoteClientInitializationOptions
         {
             UseRazorCohostServer = _featureOptions.UseRazorCohostServer,
-            UsePreciseSemanticTokenRanges = _featureOptions.UsePreciseSemanticTokenRanges,
             HtmlVirtualDocumentSuffix = _featureOptions.HtmlVirtualDocumentSuffix,
             ReturnCodeActionAndRenamePathsWithPrefixedSlash = _featureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash,
             SupportsFileManipulation = _featureOptions.SupportsFileManipulation,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.SemanticTokens;
-using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Protocol.SemanticTokens;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
@@ -59,7 +58,7 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_CSharp_RazorIfNotReady(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_CSharp_RazorIfNotReady(bool supportsVSExtensions)
     {
         var documentText = """
             <p></p>@{
@@ -68,12 +67,12 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             """;
 
         var csharpTokens = new ProvideSemanticTokensResponse(tokens: [], hostDocumentSyncVersion: 1);
-        await AssertSemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, csharpTokens: csharpTokens, documentVersion: 1);
+        await AssertSemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, csharpTokens: csharpTokens, documentVersion: 1);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_CSharpBlock_HTML(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_CSharpBlock_HTML(bool supportsVSExtensions)
     {
         var documentText = """
             @{
@@ -82,24 +81,24 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             }
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_CSharp_Nested_HTML(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_CSharp_Nested_HTML(bool supportsVSExtensions)
     {
         var documentText = """
             @addTagHelper *, TestAssembly
             <!--@{var d = "string";@<a></a>}-->
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_CSharp_VSCodeWorks(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_CSharp_VSCodeWorks(bool supportsVSExtensions)
     {
         var documentText = """
             @addTagHelper *, TestAssembly
@@ -107,12 +106,12 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             """;
 
         var csharpTokens = new ProvideSemanticTokensResponse(tokens: [], hostDocumentSyncVersion: 1);
-        await AssertSemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, csharpTokens: csharpTokens, documentVersion: 1);
+        await AssertSemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, csharpTokens: csharpTokens, documentVersion: 1);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_CSharp_Explicit(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_CSharp_Explicit(bool supportsVSExtensions)
     {
         var documentText = """
             @using System
@@ -120,12 +119,12 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             @(DateTime.Now)
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_CSharp_Attribute(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_CSharp_Attribute(bool supportsVSExtensions)
     {
         var documentText = """
             @using System.Diagnostics
@@ -137,12 +136,12 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             }
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, isRazorFile: true, supportsVSExtensions: supportsVSExtensions);
+        await VerifySemanticTokensAsync(documentText, isRazorFile: true, supportsVSExtensions: supportsVSExtensions);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_CSharp_Implicit(bool serverSupportsPreciseRanges, bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_CSharp_Implicit(bool supportsVSExtensions)
     {
         var documentText = """
             @addTagHelper *, TestAssembly
@@ -150,40 +149,40 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             @d
             """;
 
-        var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions);
-        await AssertSemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, csharpTokens: csharpTokens, serverSupportsPreciseRanges: serverSupportsPreciseRanges);
-        VerifyTimesLanguageServerCalled(serverSupportsPreciseRanges, precise);
+        var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, supportsVSExtensions: supportsVSExtensions);
+        await AssertSemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, csharpTokens: csharpTokens);
+        VerifyTimesLanguageServerCalled();
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_CSharp_VersionMismatch(bool serverSupportsPreciseRanges, bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_CSharp_VersionMismatch(bool supportsVSExtensions)
     {
         var documentText = """
             @addTagHelper *, TestAssembly
             @{ var d = }
             """;
 
-        var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions);
-        await AssertSemanticTokensAsync(documentText, precise, csharpTokens: csharpTokens, documentVersion: 21, serverSupportsPreciseRanges: serverSupportsPreciseRanges);
-        VerifyTimesLanguageServerCalled(serverSupportsPreciseRanges, precise);
+        var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, supportsVSExtensions: supportsVSExtensions);
+        await AssertSemanticTokensAsync(documentText, csharpTokens: csharpTokens, documentVersion: 21);
+        VerifyTimesLanguageServerCalled();
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_CSharp_FunctionAsync(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_CSharp_FunctionAsync(bool supportsVSExtensions)
     {
         var documentText = """
             @addTagHelper *, TestAssembly
             @{ var d = }
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_CSharp_StaticModifier(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_CSharp_StaticModifier(bool supportsVSExtensions)
     {
         var documentText = """
             @code
@@ -192,12 +191,12 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             }
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_MultipleBlankLines(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_MultipleBlankLines(bool supportsVSExtensions)
     {
         var documentText = """
             @addTagHelper *, TestAssembly
@@ -206,178 +205,178 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             second</p>
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_IncompleteTag(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_IncompleteTag(bool supportsVSExtensions)
     {
         var documentText = """
             <str class='
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_MinimizedHTMLAttribute(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_MinimizedHTMLAttribute(bool supportsVSExtensions)
     {
         var documentText = """
             <p attr />
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_MinimizedHTMLAsync(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_MinimizedHTMLAsync(bool supportsVSExtensions)
     {
         var documentText = """
             @addTagHelper *, TestAssembly
             <input/>
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_HTMLCommentAsync(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_HTMLCommentAsync(bool supportsVSExtensions)
     {
         var documentText = """
             @addTagHelper *, TestAssembly
             <!-- comment with comma's -->
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_PartialHTMLCommentAsync(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_PartialHTMLCommentAsync(bool supportsVSExtensions)
     {
         var documentText = """
             @addTagHelper *, TestAssembly
             <!-- comment
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_HTMLIncludesBang(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_HTMLIncludesBang(bool supportsVSExtensions)
     {
         var documentText = """
             @addTagHelper *, TestAssembly
             <!input/>
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_HalfOfCommentAsync(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_HalfOfCommentAsync(bool supportsVSExtensions)
     {
         var documentText = """
             @addTagHelper *, TestAssembly
             @* comment
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_NoAttributesAsync(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_NoAttributesAsync(bool supportsVSExtensions)
     {
         var documentText = """
             @addTagHelper *, TestAssembly
             <test1></test1>
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_WithAttributeAsync(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_WithAttributeAsync(bool supportsVSExtensions)
     {
         var documentText = """
             @addTagHelper *, TestAssembly
             <test1 bool-val='true'></test1>
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_MinimizedAttribute_BoundAsync(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_MinimizedAttribute_BoundAsync(bool supportsVSExtensions)
     {
         var documentText = """
             @addTagHelper *, TestAssembly
             <test1 bool-val></test1>
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_MinimizedAttribute_NotBoundAsync(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_MinimizedAttribute_NotBoundAsync(bool supportsVSExtensions)
     {
         var documentText = """
             @addTagHelper *, TestAssembly
             <test1 notbound></test1>
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_IgnoresNonTagHelperAttributesAsync(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_IgnoresNonTagHelperAttributesAsync(bool supportsVSExtensions)
     {
         var documentText = """
             @addTagHelper *, TestAssembly
             <test1 bool-val='true' class='display:none'></test1>
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_TagHelpersNotAvailableInRazorAsync(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_TagHelpersNotAvailableInRazorAsync(bool supportsVSExtensions)
     {
         var documentText = """
             @addTagHelper *, TestAssembly
             <test1 bool-val='true' class='display:none'></test1>
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_DoesNotApplyOnNonTagHelpersAsync(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_DoesNotApplyOnNonTagHelpersAsync(bool supportsVSExtensions)
     {
         var documentText = """
             @addTagHelper *, TestAssembly
             <p bool-val='true'></p>
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_Razor_MinimizedDirectiveAttributeParameters(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_Razor_MinimizedDirectiveAttributeParameters(bool supportsVSExtensions)
     {
         // Capitalized, non-well-known-HTML elements should not be marked as TagHelpers
         var documentText = """
@@ -385,24 +384,24 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             }<NotATagHelp @minimized:something />
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_Razor_ComponentAttributeAsync(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_Razor_ComponentAttributeAsync(bool supportsVSExtensions)
     {
         var documentText = """
             @addTagHelper *, TestAssembly
             <Component1 bool-val=""true""></Component1>
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_Razor_ComponentAttribute_DoesntGetABackground(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_Razor_ComponentAttribute_DoesntGetABackground(bool supportsVSExtensions)
     {
         // Need C# around the component for the C# range to be valid, to correctly validate the attribute handling
         var documentText = """
@@ -413,105 +412,105 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             @DateTime.Now
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true, withCSharpBackground: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true, withCSharpBackground: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_Razor_DirectiveAttributesParametersAsync(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_Razor_DirectiveAttributesParametersAsync(bool supportsVSExtensions)
     {
         var documentText = """
             @addTagHelper *, TestAssembly
             <Component1 @test:something='Function'></Component1>
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_Razor_NonComponentsDoNotShowInRazorAsync(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_Razor_NonComponentsDoNotShowInRazorAsync(bool supportsVSExtensions)
     {
         var documentText = """
             @addTagHelper *, TestAssembly
             <test1 bool-val='true'></test1>
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_Razor_DirectivesAsync(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_Razor_DirectivesAsync(bool supportsVSExtensions)
     {
         var documentText = """
             @addTagHelper *, TestAssembly
             <Component1 @test='Function'></Component1>
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_Razor_DirectiveWithExplicitStatementAsync(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_Razor_DirectiveWithExplicitStatementAsync(bool supportsVSExtensions)
     {
         var documentText = """
             @addTagHelper *, TestAssembly
             <Component1 @onclick="@(Function())"></Component1>
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_HandleTransitionEscape(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_HandleTransitionEscape(bool supportsVSExtensions)
     {
         var documentText = """
             @@text
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_Razor_DoNotColorNonTagHelpersAsync(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_Razor_DoNotColorNonTagHelpersAsync(bool supportsVSExtensions)
     {
         var documentText = """
             <p @test='Function'></p>
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_Razor_DoesNotApplyOnNonTagHelpersAsync(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_Razor_DoesNotApplyOnNonTagHelpersAsync(bool supportsVSExtensions)
     {
         var documentText = """
             @addTagHelpers *, TestAssembly
             <p></p>
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_Razor_CodeDirectiveAsync(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_Razor_CodeDirectiveAsync(bool supportsVSExtensions)
     {
         var documentText = """
             @code {}
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_Razor_CodeDirectiveBodyAsync(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_Razor_CodeDirectiveBodyAsync(bool supportsVSExtensions)
     {
         var documentText = """
             @using System
@@ -523,34 +522,34 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             }
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_Razor_UsingDirective(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_Razor_UsingDirective(bool supportsVSExtensions)
     {
         var documentText = """
             @using System.Threading
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_Razor_FunctionsDirectiveAsync(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_Razor_FunctionsDirectiveAsync(bool supportsVSExtensions)
     {
         var documentText = """
             @functions {}
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_Razor_NestedTextDirectives(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_Razor_NestedTextDirectives(bool supportsVSExtensions)
     {
         var documentText = """
             @using System
@@ -570,12 +569,12 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             }
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_Razor_NestedTransitions(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_Razor_NestedTransitions(bool supportsVSExtensions)
     {
         var documentText = """
             @using System
@@ -584,23 +583,23 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             }
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_Razor_CommentAsync(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_Razor_CommentAsync(bool supportsVSExtensions)
     {
         var documentText = """
             @* A comment *@
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_Razor_MultiLineCommentMidlineAsync(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_Razor_MultiLineCommentMidlineAsync(bool supportsVSExtensions)
     {
         var documentText = """
             <a />@* kdl
@@ -608,12 +607,12 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             slf*@
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_Razor_MultiLineCommentWithBlankLines(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_Razor_MultiLineCommentWithBlankLines(bool supportsVSExtensions)
     {
         var documentText = """
             @* kdl
@@ -624,34 +623,34 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             slf*@
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions);
     }
 
     [Theory]
     [CombinatorialData]
     [WorkItem("https://github.com/dotnet/razor/issues/8176")]
-    public async Task GetSemanticTokens_Razor_MultiLineCommentWithBlankLines_LF(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_Razor_MultiLineCommentWithBlankLines_LF(bool supportsVSExtensions)
     {
         var documentText = "@* kdl\n\nskd\n    \n        sdfasdfasdf\nslf*@";
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_Razor_MultiLineCommentAsync(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_Razor_MultiLineCommentAsync(bool supportsVSExtensions)
     {
         var documentText = """
             @*stuff
             things *@
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_CSharp_Static(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_CSharp_Static(bool supportsVSExtensions)
     {
         var documentText = """
             @using System
@@ -668,12 +667,12 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             }
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_Legacy_Model(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_Legacy_Model(bool supportsVSExtensions)
     {
         var documentText = """
             @using System
@@ -688,12 +687,12 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             </div>
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: false);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: false);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_CSharp_LargeFile(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_CSharp_LargeFile(bool supportsVSExtensions)
     {
         var start = """
             @page
@@ -768,12 +767,12 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
 
         var documentText = builder.ToString();
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_CSharp_Static_WithBackground(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_CSharp_Static_WithBackground(bool supportsVSExtensions)
     {
         var documentText = """
             @using System
@@ -791,12 +790,12 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             }
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true, withCSharpBackground: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true, withCSharpBackground: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_CSharp_Tabs_Static_WithBackground(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_CSharp_Tabs_Static_WithBackground(bool supportsVSExtensions)
     {
         var documentText = """
             @using System
@@ -814,12 +813,12 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             }
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true, withCSharpBackground: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true, withCSharpBackground: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_CSharp_WithBackground(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_CSharp_WithBackground(bool supportsVSExtensions)
     {
         var documentText = """
             @using System
@@ -836,12 +835,12 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             }
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true, withCSharpBackground: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true, withCSharpBackground: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_CSharp_WitRenderFragment(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_CSharp_WitRenderFragment(bool supportsVSExtensions)
     {
         var documentText = """
             <div>This is some HTML</div>
@@ -854,12 +853,12 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             }
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_CSharp_WitRenderFragmentAndBackground(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_CSharp_WitRenderFragmentAndBackground(bool supportsVSExtensions)
     {
         var documentText = """
             <div>This is some HTML</div>
@@ -872,12 +871,12 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             }
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true, withCSharpBackground: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true, withCSharpBackground: true);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task GetSemanticTokens_CSharp_ExplicitStatement_WithBackground(bool precise, bool supportsVSExtensions)
+    public async Task GetSemanticTokens_CSharp_ExplicitStatement_WithBackground(bool supportsVSExtensions)
     {
         var documentText = """
             @DateTime.Now
@@ -885,7 +884,7 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             @("hello" + "\\n" + "world" + Environment.NewLine + "how are you?")
             """;
 
-        await VerifySemanticTokensAsync(documentText, precise, supportsVSExtensions: supportsVSExtensions, isRazorFile: true, withCSharpBackground: true);
+        await VerifySemanticTokensAsync(documentText, supportsVSExtensions: supportsVSExtensions, isRazorFile: true, withCSharpBackground: true);
     }
 
     [Theory]
@@ -927,26 +926,24 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
         }
     }
 
-    private async Task VerifySemanticTokensAsync(string documentText, bool precise, bool isRazorFile = false, bool withCSharpBackground = false, bool supportsVSExtensions = true, [CallerMemberName] string? testName = null)
+    private async Task VerifySemanticTokensAsync(string documentText, bool isRazorFile = false, bool withCSharpBackground = false, bool supportsVSExtensions = true, [CallerMemberName] string? testName = null)
     {
-        var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, precise, isRazorFile, supportsVSExtensions);
-        await AssertSemanticTokensAsync(documentText, precise, csharpTokens, isRazorFile, withCSharpBackground: withCSharpBackground, supportsVSExtensions: supportsVSExtensions, testName: testName);
+        var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, isRazorFile, supportsVSExtensions);
+        await AssertSemanticTokensAsync(documentText, csharpTokens, isRazorFile, withCSharpBackground: withCSharpBackground, supportsVSExtensions: supportsVSExtensions, testName: testName);
     }
 
     private async Task AssertSemanticTokensAsync(
         string documentText,
-        bool precise,
         ProvideSemanticTokensResponse csharpTokens,
         bool isRazorFile = false,
         int documentVersion = 0,
         bool withCSharpBackground = false,
-        bool serverSupportsPreciseRanges = true,
         bool supportsVSExtensions = true,
         [CallerMemberName] string? testName = null)
     {
         var documentContext = CreateDocumentContext(documentText, isRazorFile, DefaultTagHelpers, documentVersion);
 
-        var service = await CreateServiceAsync(documentContext, csharpTokens, withCSharpBackground, serverSupportsPreciseRanges, precise, supportsVSExtensions);
+        var service = await CreateServiceAsync(documentContext, csharpTokens, withCSharpBackground, supportsVSExtensions);
 
         var range = GetSpan(documentText);
         var tokens = await service.GetSemanticTokensAsync(documentContext, range, withCSharpBackground, Guid.Empty, DisposalToken);
@@ -990,25 +987,14 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
         DocumentContext documentSnapshot,
         ProvideSemanticTokensResponse? csharpTokens,
         bool withCSharpBackground,
-        bool serverSupportsPreciseRanges,
-        bool precise,
         bool supportsVSExtensions)
     {
-        _clientConnection
-            .Setup(l => l.SendRequestAsync<SemanticTokensParams, ProvideSemanticTokensResponse?>(
-                CustomMessageNames.RazorProvideSemanticTokensRangeEndpoint,
-                It.IsAny<SemanticTokensParams>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(csharpTokens);
-
         _clientConnection
             .Setup(l => l.SendRequestAsync<SemanticTokensParams, ProvideSemanticTokensResponse?>(
                 CustomMessageNames.RazorProvidePreciseRangeSemanticTokensEndpoint,
                 It.IsAny<SemanticTokensParams>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(serverSupportsPreciseRanges
-                ? csharpTokens
-                : It.Is<ProvideSemanticTokensResponse>(x => x.Tokens == null));
+            .ReturnsAsync(csharpTokens);
 
         var documentContextFactory = new TestDocumentContextFactory(documentSnapshot);
         var documentMappingService = new LspDocumentMappingService(FilePathService, documentContextFactory, LoggerFactory);
@@ -1025,26 +1011,18 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
 
         await optionsMonitor.UpdateAsync(DisposalToken);
 
-        var featureOptions = Mock.Of<LanguageServerFeatureOptions>(options =>
-            options.DelegateToCSharpOnDiagnosticPublish == true &&
-            options.UsePreciseSemanticTokenRanges == precise &&
-            options.CSharpVirtualDocumentSuffix == ".ide.g.cs" &&
-            options.HtmlVirtualDocumentSuffix == "__virtual.html",
-            MockBehavior.Strict);
-
-        var csharpSemanticTokensProvider = new LSPCSharpSemanticTokensProvider(featureOptions, _clientConnection.Object, LoggerFactory);
+        var csharpSemanticTokensProvider = new LSPCSharpSemanticTokensProvider(_clientConnection.Object, LoggerFactory);
 
         var service = new RazorSemanticTokensInfoService(
             documentMappingService,
             TestRazorSemanticTokensLegendService.GetInstance(supportsVSExtensions),
             csharpSemanticTokensProvider,
-            featureOptions,
             LoggerFactory);
 
         return service;
     }
 
-    private async Task<ProvideSemanticTokensResponse> GetCSharpSemanticTokensResponseAsync(string documentText, bool precise, bool isRazorFile = false, bool supportsVSExtensions = true)
+    private async Task<ProvideSemanticTokensResponse> GetCSharpSemanticTokensResponseAsync(string documentText, bool isRazorFile = false, bool supportsVSExtensions = true)
     {
         var codeDocument = CreateCodeDocument(documentText, isRazorFile, DefaultTagHelpers);
         var csharpDocumentUri = new Uri("C:\\TestSolution\\TestProject\\TestDocument.cs");
@@ -1062,47 +1040,27 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             DisposalToken);
 
         var razorRange = GetSpan(documentText);
-        var csharpRanges = GetMappedCSharpRanges(codeDocument, razorRange, precise);
+        var csharpRanges = GetMappedCSharpRanges(codeDocument, razorRange);
         if (csharpRanges == null)
         {
             return new ProvideSemanticTokensResponse(tokens: [], hostDocumentSyncVersion: 0);
         }
 
-        if (precise)
-        {
-            var result = await csharpServer.ExecuteRequestAsync<SemanticTokensRangesParams, SemanticTokens>(
-                "roslyn/semanticTokenRanges",
-                CreateVSSemanticTokensRangesParams(csharpRanges.Value, csharpDocumentUri),
-                DisposalToken);
+        var result = await csharpServer.ExecuteRequestAsync<SemanticTokensRangesParams, SemanticTokens>(
+            "roslyn/semanticTokenRanges",
+            CreateVSSemanticTokensRangesParams(csharpRanges.Value, csharpDocumentUri),
+            DisposalToken);
 
-            return new ProvideSemanticTokensResponse(tokens: result?.Data, hostDocumentSyncVersion: 0);
-        }
-        else
-        {
-            var range = Assert.Single(csharpRanges.Value);
-            var result = await csharpServer.ExecuteRequestAsync<SemanticTokensRangeParams, SemanticTokens>(
-                "textDocument/semanticTokens/range",
-                CreateVSSemanticTokensRangeParams(range, csharpDocumentUri),
-                DisposalToken);
-
-            return new ProvideSemanticTokensResponse(tokens: result?.Data, hostDocumentSyncVersion: 0);
-        }
+        return new ProvideSemanticTokensResponse(tokens: result?.Data, hostDocumentSyncVersion: 0);
     }
 
-    private void VerifyTimesLanguageServerCalled(bool serverSupportsPreciseRanges, bool precise)
+    private void VerifyTimesLanguageServerCalled()
     {
         _clientConnection
             .Verify(l => l.SendRequestAsync<SemanticTokensParams, ProvideSemanticTokensResponse?>(
                 CustomMessageNames.RazorProvidePreciseRangeSemanticTokensEndpoint,
                 It.IsAny<SemanticTokensParams>(),
-                It.IsAny<CancellationToken>()), Times.Exactly(precise ? 1 : 0));
-
-        _clientConnection
-            .Verify(l => l.SendRequestAsync<SemanticTokensParams, ProvideSemanticTokensResponse?>(
-                CustomMessageNames.RazorProvideSemanticTokensRangeEndpoint,
-                It.IsAny<SemanticTokensParams>(),
-                It.IsAny<CancellationToken>()), Times.Exactly(
-                    !precise || !serverSupportsPreciseRanges ? 1 : 0));
+                It.IsAny<CancellationToken>()), Times.Exactly(1));
     }
 
     private static LinePositionSpan GetSpan(string text)
@@ -1153,29 +1111,11 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
         return baselineContents;
     }
 
-    private ImmutableArray<LinePositionSpan>? GetMappedCSharpRanges(RazorCodeDocument codeDocument, LinePositionSpan razorRange, bool precise)
+    private ImmutableArray<LinePositionSpan>? GetMappedCSharpRanges(RazorCodeDocument codeDocument, LinePositionSpan razorRange)
     {
-        var documentMappingService = new LspDocumentMappingService(FilePathService, new TestDocumentContextFactory(), LoggerFactory);
-
-        if (precise)
-        {
-            if (!RazorSemanticTokensInfoService.TryGetSortedCSharpRanges(codeDocument, razorRange, out var csharpRanges))
-            {
-                // No C# in the range.
-                return null;
-            }
-
-            return csharpRanges;
-        }
-
-        if (!documentMappingService.TryMapToCSharpDocumentRange(codeDocument.GetRequiredCSharpDocument(), razorRange, out var range) &&
-            !codeDocument.TryGetMinimalCSharpRange(razorRange, out range))
-        {
-            // No C# in the range.
-            return null;
-        }
-
-        return [range];
+        return RazorSemanticTokensInfoService.TryGetSortedCSharpRanges(codeDocument, razorRange, out var csharpRanges)
+            ? csharpRanges
+            : null;
     }
 
     private static SemanticTokensRangesParams CreateVSSemanticTokensRangesParams(ImmutableArray<LinePositionSpan> ranges, Uri uri)
@@ -1183,13 +1123,6 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
         {
             TextDocument = new TextDocumentIdentifier { DocumentUri = new(uri) },
             Ranges = ranges.Select(s => s.ToRange()).ToArray()
-        };
-
-    private static SemanticTokensRangeParams CreateVSSemanticTokensRangeParams(LinePositionSpan range, Uri uri)
-        => new()
-        {
-            TextDocument = new TextDocumentIdentifier { DocumentUri = new(uri) },
-            Range = range.ToRange()
         };
 
     private static void GenerateSemanticBaseline(string actualFileContents, string baselineFileName)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
@@ -29,8 +29,6 @@ internal class TestLanguageServerFeatureOptions(
 
     public override bool ShowAllCSharpCodeActions => false;
 
-    public override bool UsePreciseSemanticTokenRanges => true;
-
     public override bool UpdateBuffersForClosedDocuments => updateBuffersForClosedDocuments;
 
     public override bool IncludeProjectKeyInGeneratedFilePath => includeProjectKeyInGeneratedFilePath;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostEndpointTestBase.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostEndpointTestBase.cs
@@ -88,7 +88,6 @@ public abstract class CohostEndpointTestBase(ITestOutputHelper testOutputHelper)
         _clientInitializationOptions = new()
         {
             HtmlVirtualDocumentSuffix = ".g.html",
-            UsePreciseSemanticTokenRanges = false,
             UseRazorCohostServer = true,
             ReturnCodeActionAndRenamePathsWithPrefixedSlash = false,
             SupportsFileManipulation = true,

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostSemanticTokensRangeEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostSemanticTokensRangeEndpointTest.cs
@@ -22,7 +22,7 @@ public class CohostSemanticTokensRangeEndpointTest(ITestOutputHelper testOutputH
 {
     [Theory]
     [CombinatorialData]
-    public async Task Razor(bool colorBackground, bool precise, bool supportsVSExtensions, bool miscellaneousFile)
+    public async Task Razor(bool colorBackground, bool supportsVSExtensions, bool miscellaneousFile)
     {
         var input = """
             @page "/"
@@ -63,12 +63,12 @@ public class CohostSemanticTokensRangeEndpointTest(ITestOutputHelper testOutputH
             }
             """;
 
-        await VerifySemanticTokensAsync(input, colorBackground, precise, supportsVSExtensions, miscellaneousFile);
+        await VerifySemanticTokensAsync(input, colorBackground, supportsVSExtensions, miscellaneousFile);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task Legacy(bool colorBackground, bool precise, bool supportsVSExtensions, bool miscellaneousFile)
+    public async Task Legacy(bool colorBackground, bool supportsVSExtensions, bool miscellaneousFile)
     {
         var input = """
             @page "/"
@@ -91,12 +91,12 @@ public class CohostSemanticTokensRangeEndpointTest(ITestOutputHelper testOutputH
             }
             """;
 
-        await VerifySemanticTokensAsync(input, colorBackground, precise, supportsVSExtensions, miscellaneousFile, fileKind: RazorFileKind.Legacy);
+        await VerifySemanticTokensAsync(input, colorBackground, supportsVSExtensions, miscellaneousFile, fileKind: RazorFileKind.Legacy);
     }
 
     [Theory]
     [CombinatorialData]
-    public async Task Legacy_Compatibility(bool colorBackground, bool precise, bool supportsVSExtensions, bool miscellaneousFile)
+    public async Task Legacy_Compatibility(bool colorBackground, bool supportsVSExtensions, bool miscellaneousFile)
     {
         // Same test as above, but with only the things that work in FUSE and non-FUSE, to prevent regressions
 
@@ -116,13 +116,12 @@ public class CohostSemanticTokensRangeEndpointTest(ITestOutputHelper testOutputH
             }
             """;
 
-        await VerifySemanticTokensAsync(input, colorBackground, precise, supportsVSExtensions, miscellaneousFile, fileKind: RazorFileKind.Legacy);
+        await VerifySemanticTokensAsync(input, colorBackground, supportsVSExtensions, miscellaneousFile, fileKind: RazorFileKind.Legacy);
     }
 
     private async Task VerifySemanticTokensAsync(
         string input,
         bool colorBackground,
-        bool precise,
         bool supportsVSExtensions,
         bool miscellaneousFile,
         RazorFileKind? fileKind = null,
@@ -144,9 +143,6 @@ public class CohostSemanticTokensRangeEndpointTest(ITestOutputHelper testOutputH
                 TokenModifiers = legend.TokenModifiers.All,
             };
         });
-
-        // Update the client initialization options to control the precise ranges option
-        UpdateClientInitializationOptions(c => c with { UsePreciseSemanticTokenRanges = precise });
 
         var clientSettingsManager = new ClientSettingsManager([], null, null);
         clientSettingsManager.Update(ClientAdvancedSettings.Default with { ColorBackground = colorBackground });

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/RazorCustomMessageTargetTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/RazorCustomMessageTargetTest.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.Editor;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
@@ -358,10 +357,8 @@ public class RazorCustomMessageTargetTest : ToolingTestBase
         Assert.Equal(expectedCodeAction.Title, result.Title);
     }
 
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task ProvideSemanticTokensAsync_CannotLookupDocument_ReturnsNullAsync(bool isPreciseRange)
+    [Fact]
+    public async Task ProvideSemanticTokensAsync_CannotLookupDocument_ReturnsNullAsync()
     {
         // Arrange
         LSPDocumentSnapshot document;
@@ -395,18 +392,14 @@ public class RazorCustomMessageTargetTest : ToolingTestBase
             correlationId: Guid.Empty);
 
         // Act
-        var result = isPreciseRange
-            ? await target.ProvidePreciseRangeSemanticTokensAsync(request, DisposalToken)
-            : await target.ProvideMinimalRangeSemanticTokensAsync(request, DisposalToken);
+        var result = await target.ProvidePreciseRangeSemanticTokensAsync(request, DisposalToken);
 
         // Assert
         Assert.Null(result);
     }
 
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task ProvideSemanticTokensAsync_CannotLookupVirtualDocument_ReturnsNullAsync(bool isPreciseRange)
+    [Fact]
+    public async Task ProvideSemanticTokensAsync_CannotLookupVirtualDocument_ReturnsNullAsync()
     {
         // Arrange
         var testDocUri = new Uri("C:/path/to/file.razor");
@@ -442,18 +435,14 @@ public class RazorCustomMessageTargetTest : ToolingTestBase
             correlationId: Guid.Empty);
 
         // Act
-        var result = isPreciseRange
-            ? await target.ProvidePreciseRangeSemanticTokensAsync(request, DisposalToken)
-            : await target.ProvideMinimalRangeSemanticTokensAsync(request, DisposalToken);
+        var result = await target.ProvidePreciseRangeSemanticTokensAsync(request, DisposalToken);
 
         // Assert
         Assert.Null(result);
     }
 
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task ProvideSemanticTokensAsync_ContainsRange_ReturnsSemanticTokens(bool isPreciseRange)
+    [Fact]
+    public async Task ProvideSemanticTokensAsync_ContainsRange_ReturnsSemanticTokens()
     {
         // Arrange
         var testDocUri = new Uri("C:/path/to%20-%20project/file.razor");
@@ -522,19 +511,15 @@ public class RazorCustomMessageTargetTest : ToolingTestBase
             correlationId: Guid.Empty);
 
         // Act
-        var result = isPreciseRange
-            ? await target.ProvidePreciseRangeSemanticTokensAsync(request, DisposalToken)
-            : await target.ProvideMinimalRangeSemanticTokensAsync(request, DisposalToken);
+        var result = await target.ProvidePreciseRangeSemanticTokensAsync(request, DisposalToken);
 
         // Assert
         Assert.Equal(documentVersion, result.HostDocumentSyncVersion);
         Assert.Equal(expectedCSharpResults.Data, result.Tokens);
     }
 
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task ProvideSemanticTokensAsync_EmptyRange_ReturnsNoSemanticTokens(bool isPreciseRange)
+    [Fact]
+    public async Task ProvideSemanticTokensAsync_EmptyRange_ReturnsNoSemanticTokens()
     {
         // Arrange
         var testDocUri = new Uri("C:/path/to%20-%20project/file.razor");
@@ -604,9 +589,7 @@ public class RazorCustomMessageTargetTest : ToolingTestBase
         var expectedResults = new ProvideSemanticTokensResponse(null, documentVersion);
 
         // Act
-        var result = isPreciseRange
-            ? await target.ProvidePreciseRangeSemanticTokensAsync(request, DisposalToken)
-            : await target.ProvideMinimalRangeSemanticTokensAsync(request, DisposalToken);
+        var result = await target.ProvidePreciseRangeSemanticTokensAsync(request, DisposalToken);
 
         // Assert
         Assert.Equal(documentVersion, result.HostDocumentSyncVersion);


### PR DESCRIPTION
Note: This is in draft mode until I complete a test insertion validating functionality equivalence (in tests at least) and performance characteristics.

Locally, I see this as a pretty drastic improvement, reducing the number of ints in the classified response from roslyn from 25675 to 790.
