### PR TITLE
Avoid boxing ImmutableArray<T> as IReadOnlyList<T> or IEnumerable<T> when calling helpers

### DIFF
--- a/src/Analyzers/Razor.Diagnostics.Analyzers.Test/ImmutableArrayBoxingAnalyzerTests.cs
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers.Test/ImmutableArrayBoxingAnalyzerTests.cs
@@ -1,0 +1,91 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Razor.Diagnostics.Analyzers.Test;
+
+using VerifyCS = CSharpAnalyzerVerifier<ImmutableArrayBoxingAnalyzer>;
+
+public class ImmutableArrayBoxingAnalyzerTests
+{
+    private const string ExtensionsSource = """
+        namespace System.Collections.Immutable
+        {
+            public struct ImmutableArray<T> : IReadOnlyList<T>
+            {
+                public static readonly ImmutableArray<T> Empty = default;
+
+                public T this[int index] => default!;
+                public int Count => 0;
+
+                public IEnumerator<T> GetEnumerator() => null!;
+                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => null!;
+            }
+        }
+
+        namespace System.Collections.Generic
+        {
+            using System.Collections.Immutable;
+
+            internal static class ReadOnlyListExtensions
+            {
+                public static bool Any<T>(this IReadOnlyList<T> list) => false;
+            }
+
+            internal static class EnumerableExtensions
+            {
+                public static ImmutableArray<T> OrderAsArray<T>(this IEnumerable<T> sequence) => default;
+            }
+        }
+        """;
+
+    [Fact]
+    public async Task TestReadOnlyListExtensions_CSharpAsync()
+    {
+        var code = $$"""
+            using System.Collections.Generic;
+
+            class C
+            {
+                void Method()
+                {
+                    System.Collections.Immutable.ImmutableArray<int> array = System.Collections.Immutable.ImmutableArray<int>.Empty;
+                    _ = [|array|].Any();
+                }
+            }
+
+            {{ExtensionsSource}}
+            """;
+
+        await new VerifyCS.Test
+        {
+            TestCode = code,
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task TestEnumerableExtensions_CSharpAsync()
+    {
+        var code = $$"""
+            using System.Collections.Generic;
+
+            class C
+            {
+                void Method()
+                {
+                    System.Collections.Immutable.ImmutableArray<int> array = System.Collections.Immutable.ImmutableArray<int>.Empty;
+                    _ = [|array|].OrderAsArray();
+                }
+            }
+
+            {{ExtensionsSource}}
+            """;
+
+        await new VerifyCS.Test
+        {
+            TestCode = code,
+        }.RunAsync();
+    }
+}

--- a/src/Analyzers/Razor.Diagnostics.Analyzers/DiagnosticCategory.cs
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers/DiagnosticCategory.cs
@@ -5,5 +5,6 @@ namespace Razor.Diagnostics.Analyzers;
 
 internal static class DiagnosticCategory
 {
+    public const string Performance = nameof(Performance);
     public const string Reliability = nameof(Reliability);
 }

--- a/src/Analyzers/Razor.Diagnostics.Analyzers/DiagnosticIds.cs
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers/DiagnosticIds.cs
@@ -8,4 +8,6 @@ internal static class DiagnosticIds
     public const string PooledArrayBuilderAsRef = "RZD001";
 
     public const string IRemoteJsonServiceParameter = "RZD002";
+
+    public const string ImmutableArrayBoxing = "RZD003";
 }

--- a/src/Analyzers/Razor.Diagnostics.Analyzers/Extensions.cs
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers/Extensions.cs
@@ -7,7 +7,7 @@ namespace Razor.Diagnostics.Analyzers;
 
 internal static class Extensions
 {
-    public static Diagnostic CreateDiagnostic(this IOperation operation, DiagnosticDescriptor rule)
+    public static Diagnostic CreateDiagnostic(this IOperation operation, DiagnosticDescriptor rule, params object?[]? messageArgs)
     {
         var location = operation.Syntax.GetLocation();
 
@@ -16,6 +16,6 @@ internal static class Extensions
             location = Location.None;
         }
 
-        return Diagnostic.Create(rule, location);
+        return Diagnostic.Create(rule, location, messageArgs);
     }
 }

--- a/src/Analyzers/Razor.Diagnostics.Analyzers/GlobalSuppressions.cs
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers/GlobalSuppressions.cs
@@ -10,3 +10,4 @@ using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage("MicrosoftCodeAnalysisReleaseTracking", "RS2008:Enable analyzer release tracking", Justification = "<Pending>", Scope = "member", Target = "~F:Razor.Diagnostics.Analyzers.PooledArrayBuilderAsRefAnalyzer.Rule")]
 [assembly: SuppressMessage("MicrosoftCodeAnalysisReleaseTracking", "RS2008:Enable analyzer release tracking", Justification = "<Pending>", Scope = "member", Target = "~F:Razor.Diagnostics.Analyzers.IRemoteJsonServiceParameterAnalyzer.Rule")]
+[assembly: SuppressMessage("MicrosoftCodeAnalysisReleaseTracking", "RS2008:Enable analyzer release tracking", Justification = "<Pending>", Scope = "member", Target = "~F:Razor.Diagnostics.Analyzers.ImmutableArrayBoxingAnalyzer.Rule")]

--- a/src/Analyzers/Razor.Diagnostics.Analyzers/ImmutableArrayBoxingAnalyzer.cs
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers/ImmutableArrayBoxingAnalyzer.cs
@@ -1,0 +1,101 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using static Razor.Diagnostics.Analyzers.Resources;
+
+namespace Razor.Diagnostics.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ImmutableArrayBoxingAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticIds.ImmutableArrayBoxing,
+        CreateLocalizableResourceString(nameof(ImmutableArrayBoxingTitle)),
+        CreateLocalizableResourceString(nameof(ImmutableArrayBoxingMessage)),
+        DiagnosticCategory.Performance,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: CreateLocalizableResourceString(nameof(ImmutableArrayBoxingDescription)));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
+        context.RegisterCompilationStartAction(context =>
+        {
+            var immutableArray = context.Compilation.GetTypeByMetadataName(WellKnownTypeNames.ImmutableArray_T);
+            if (immutableArray is null)
+            {
+                return;
+            }
+
+            var readOnlyListExtensions = context.Compilation.GetTypeByMetadataName(WellKnownTypeNames.ReadOnlyListExtensions);
+            if (readOnlyListExtensions is null)
+            {
+                return;
+            }
+
+            var enumerableExtensions = context.Compilation.GetTypeByMetadataName(WellKnownTypeNames.EnumerableExtensions);
+            if (enumerableExtensions is null)
+            {
+                return;
+            }
+
+            context.RegisterOperationAction(
+                context => AnalyzeInvocation(context, immutableArray, readOnlyListExtensions, enumerableExtensions),
+                OperationKind.Invocation);
+        });
+    }
+
+    private static void AnalyzeInvocation(
+        OperationAnalysisContext context,
+        INamedTypeSymbol immutableArrayType,
+        INamedTypeSymbol readOnlyListExtensionsType,
+        INamedTypeSymbol enumerableExtensionsType)
+    {
+        var invocation = (IInvocationOperation)context.Operation;
+        var targetMethod = invocation.TargetMethod.ReducedFrom ?? invocation.TargetMethod;
+
+        var isReadOnlyListExtensions = SymbolEqualityComparer.Default.Equals(targetMethod.OriginalDefinition.ContainingType, readOnlyListExtensionsType);
+        var isEnumerableExtensions = SymbolEqualityComparer.Default.Equals(targetMethod.OriginalDefinition.ContainingType, enumerableExtensionsType);
+
+        if (!isReadOnlyListExtensions && !isEnumerableExtensions)
+        {
+            return;
+        }
+
+        var instance = invocation.Instance ?? invocation.Arguments.FirstOrDefault()?.Value;
+
+        if (instance is not IConversionOperation conversionOperation)
+        {
+            return;
+        }
+
+        var conversion = conversionOperation.GetConversion();
+        if (!conversion.IsBoxing)
+        {
+            return;
+        }
+
+        if (conversionOperation.Operand.Type is not INamedTypeSymbol operandType ||
+            !SymbolEqualityComparer.Default.Equals(operandType.OriginalDefinition, immutableArrayType))
+        {
+            return;
+        }
+
+        var typeName = isReadOnlyListExtensions
+            ? WellKnownTypeNames.ReadOnlyListExtensions
+            : WellKnownTypeNames.EnumerableExtensions;
+
+        context.ReportDiagnostic(instance.CreateDiagnostic(Rule, $"{typeName}.{targetMethod.Name}"));
+    }
+}

--- a/src/Analyzers/Razor.Diagnostics.Analyzers/Resources.resx
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers/Resources.resx
@@ -138,4 +138,13 @@
     <value>Instance of PooledArrayBuilder&lt;T&gt;.AsRef() must be a 'using' variable</value>
     <comment>The title of the diagnostic.</comment>
   </data>
+  <data name="ImmutableArrayBoxingTitle" xml:space="preserve">
+    <value>ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</value>
+  </data>
+  <data name="ImmutableArrayBoxingDescription" xml:space="preserve">
+    <value>Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</value>
+  </data>
+  <data name="ImmutableArrayBoxingMessage" xml:space="preserve">
+    <value>Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</value>
+  </data>
 </root>

--- a/src/Analyzers/Razor.Diagnostics.Analyzers/WellKnownTypeNames.cs
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers/WellKnownTypeNames.cs
@@ -5,7 +5,12 @@ namespace Razor.Diagnostics.Analyzers;
 
 internal static class WellKnownTypeNames
 {
+    public const string ImmutableArray_T = "System.Collections.Immutable.ImmutableArray`1";
+
     public const string PooledArrayBuilderExtensions = "Microsoft.AspNetCore.Razor.PooledObjects.PooledArrayBuilderExtensions";
+
+    public const string EnumerableExtensions = "System.Collections.Generic.EnumerableExtensions";
+    public const string ReadOnlyListExtensions = "System.Collections.Generic.ReadOnlyListExtensions";
 
     public const string IRemoteJsonService = "Microsoft.CodeAnalysis.Razor.Remote.IRemoteJsonService";
     public const string RazorPinnedSolutionInfoWrapper = "Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorPinnedSolutionInfoWrapper";

--- a/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.cs.xlf
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.cs.xlf
@@ -17,6 +17,21 @@
         <target state="translated">Neplatný typ parametru v metodě IRemoteJsonService</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingDescription">
+        <source>Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</source>
+        <target state="new">Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingMessage">
+        <source>Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</source>
+        <target state="new">Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingTitle">
+        <source>ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</source>
+        <target state="new">ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PooledArrayBuilderAsRefDescription">
         <source>Instance of PooledArrayBuilder&lt;T&gt;.AsRef() must be a 'using' variable.</source>
         <target state="translated">Instance PooledArrayBuilder&lt;T&gt;.AsRef() musí být proměnná using.</target>

--- a/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.de.xlf
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.de.xlf
@@ -17,6 +17,21 @@
         <target state="translated">Ungültiger Parametertyp in der IRemoteJsonService-Methode.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingDescription">
+        <source>Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</source>
+        <target state="new">Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingMessage">
+        <source>Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</source>
+        <target state="new">Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingTitle">
+        <source>ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</source>
+        <target state="new">ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PooledArrayBuilderAsRefDescription">
         <source>Instance of PooledArrayBuilder&lt;T&gt;.AsRef() must be a 'using' variable.</source>
         <target state="translated">Instanz von PooledArrayBuilder&lt;T&gt;. AsRef() muss eine using-Variable sein.</target>

--- a/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.es.xlf
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.es.xlf
@@ -17,6 +17,21 @@
         <target state="translated">Tipo de parámetro no válido en el método IRemoteJsonService</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingDescription">
+        <source>Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</source>
+        <target state="new">Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingMessage">
+        <source>Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</source>
+        <target state="new">Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingTitle">
+        <source>ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</source>
+        <target state="new">ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PooledArrayBuilderAsRefDescription">
         <source>Instance of PooledArrayBuilder&lt;T&gt;.AsRef() must be a 'using' variable.</source>
         <target state="translated">La instancia de PooledArrayBuilder&lt;T&gt;.AsRef() debe ser una variable "using".</target>

--- a/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.fr.xlf
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.fr.xlf
@@ -17,6 +17,21 @@
         <target state="translated">Type de paramètre non valide dans la méthode IRemoteJsonService</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingDescription">
+        <source>Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</source>
+        <target state="new">Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingMessage">
+        <source>Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</source>
+        <target state="new">Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingTitle">
+        <source>ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</source>
+        <target state="new">ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PooledArrayBuilderAsRefDescription">
         <source>Instance of PooledArrayBuilder&lt;T&gt;.AsRef() must be a 'using' variable.</source>
         <target state="translated">L’instance de PooledArrayBuilder&lt;T&gt;.AsRef() doit être une variable 'using'.</target>

--- a/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.it.xlf
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.it.xlf
@@ -17,6 +17,21 @@
         <target state="translated">Tipo di parametro non valido nel metodo IRemoteJsonService</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingDescription">
+        <source>Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</source>
+        <target state="new">Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingMessage">
+        <source>Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</source>
+        <target state="new">Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingTitle">
+        <source>ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</source>
+        <target state="new">ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PooledArrayBuilderAsRefDescription">
         <source>Instance of PooledArrayBuilder&lt;T&gt;.AsRef() must be a 'using' variable.</source>
         <target state="translated">L'istanza di PooledArrayBuilder&lt;T&gt;.AsRef() deve essere una variabile 'using'.</target>

--- a/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.ja.xlf
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.ja.xlf
@@ -17,6 +17,21 @@
         <target state="translated">IRemoteJsonService メソッドのパラメーターの型が無効です</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingDescription">
+        <source>Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</source>
+        <target state="new">Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingMessage">
+        <source>Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</source>
+        <target state="new">Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingTitle">
+        <source>ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</source>
+        <target state="new">ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PooledArrayBuilderAsRefDescription">
         <source>Instance of PooledArrayBuilder&lt;T&gt;.AsRef() must be a 'using' variable.</source>
         <target state="translated">PooledArrayBuilder&lt;T&gt;.AsRef() のインスタンスは 'using' 変数でなければなりません。</target>

--- a/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.ko.xlf
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.ko.xlf
@@ -17,6 +17,21 @@
         <target state="translated">IRemoteJsonService 메서드의 매개 변수 형식이 잘못되었습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingDescription">
+        <source>Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</source>
+        <target state="new">Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingMessage">
+        <source>Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</source>
+        <target state="new">Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingTitle">
+        <source>ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</source>
+        <target state="new">ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PooledArrayBuilderAsRefDescription">
         <source>Instance of PooledArrayBuilder&lt;T&gt;.AsRef() must be a 'using' variable.</source>
         <target state="translated">PooledArrayBuilder&lt;T&gt; 인스턴스입니다. AsRef()는 반드시 'using' 변수여야 합니다.</target>

--- a/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.pl.xlf
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.pl.xlf
@@ -17,6 +17,21 @@
         <target state="translated">Nieprawidłowy typ parametru w metodzie IRemoteJsonService</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingDescription">
+        <source>Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</source>
+        <target state="new">Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingMessage">
+        <source>Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</source>
+        <target state="new">Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingTitle">
+        <source>ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</source>
+        <target state="new">ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PooledArrayBuilderAsRefDescription">
         <source>Instance of PooledArrayBuilder&lt;T&gt;.AsRef() must be a 'using' variable.</source>
         <target state="translated">Wystąpienie klasy PooledArrayBuilder&lt;T&gt;. Element AsRef() musi być zmienną „using”.</target>

--- a/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.pt-BR.xlf
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.pt-BR.xlf
@@ -17,6 +17,21 @@
         <target state="translated">Tipo de parâmetro inválido no método IRemoteJsonService</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingDescription">
+        <source>Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</source>
+        <target state="new">Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingMessage">
+        <source>Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</source>
+        <target state="new">Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingTitle">
+        <source>ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</source>
+        <target state="new">ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PooledArrayBuilderAsRefDescription">
         <source>Instance of PooledArrayBuilder&lt;T&gt;.AsRef() must be a 'using' variable.</source>
         <target state="translated">A instância de PooledArrayBuilder&lt;T&gt;.AsRef() deve ser uma variável 'usando'.</target>

--- a/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.ru.xlf
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.ru.xlf
@@ -17,6 +17,21 @@
         <target state="translated">Недопустимый тип параметра в методе IRemoteJsonService</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingDescription">
+        <source>Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</source>
+        <target state="new">Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingMessage">
+        <source>Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</source>
+        <target state="new">Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingTitle">
+        <source>ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</source>
+        <target state="new">ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PooledArrayBuilderAsRefDescription">
         <source>Instance of PooledArrayBuilder&lt;T&gt;.AsRef() must be a 'using' variable.</source>
         <target state="translated">Экземпляр PooledArrayBuilder&lt;T&gt;.AsRef() должен представлять собой переменную "using".</target>

--- a/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.tr.xlf
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.tr.xlf
@@ -17,6 +17,21 @@
         <target state="translated">IRemoteJsonService yönteminde geçersiz parametre türü</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingDescription">
+        <source>Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</source>
+        <target state="new">Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingMessage">
+        <source>Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</source>
+        <target state="new">Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingTitle">
+        <source>ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</source>
+        <target state="new">ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PooledArrayBuilderAsRefDescription">
         <source>Instance of PooledArrayBuilder&lt;T&gt;.AsRef() must be a 'using' variable.</source>
         <target state="translated">PooledArrayBuilder&lt;T&gt;.AsRef() örneği bir 'using' değişkeni olmalıdır.</target>

--- a/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.zh-Hans.xlf
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.zh-Hans.xlf
@@ -17,6 +17,21 @@
         <target state="translated">IRemoteJsonService 方法中的参数类型无效</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingDescription">
+        <source>Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</source>
+        <target state="new">Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingMessage">
+        <source>Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</source>
+        <target state="new">Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingTitle">
+        <source>ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</source>
+        <target state="new">ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PooledArrayBuilderAsRefDescription">
         <source>Instance of PooledArrayBuilder&lt;T&gt;.AsRef() must be a 'using' variable.</source>
         <target state="translated">PooledArrayBuilder&lt;T&gt;.AsRef() 的实例必须是 'using' 变量。</target>

--- a/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.zh-Hant.xlf
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers/xlf/Resources.zh-Hant.xlf
@@ -17,6 +17,21 @@
         <target state="translated">IRemoteJsonService 方法中無效的參數類型</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingDescription">
+        <source>Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</source>
+        <target state="new">Calling EnumerableExtensions or ReadOnlyListExtensions methods on ImmutableArray&lt;T&gt; causes the struct to be boxed, which creates unnecessary allocations. Use the corresponding ImmutableArray&lt;T&gt; extension methods instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingMessage">
+        <source>Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</source>
+        <target state="new">Call to '{0}' on ImmutableArray&lt;T&gt; causes boxing. Consider using the ImmutableArray&lt;T&gt; extension method instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImmutableArrayBoxingTitle">
+        <source>ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</source>
+        <target state="new">ImmutableArray&lt;T&gt; is being boxed to IReadOnlyList&lt;T&gt;</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PooledArrayBuilderAsRefDescription">
         <source>Instance of PooledArrayBuilder&lt;T&gt;.AsRef() must be a 'using' variable.</source>
         <target state="translated">PooledArrayBuilder 的執行個體&lt;T&gt;。AsRef() 必須是 'using' 變數。</target>

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/RazorProjectEngineBuilderExtensionsTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/RazorProjectEngineBuilderExtensionsTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 using Microsoft.CodeAnalysis.CSharp;
 using Moq;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/TagHelperDescriptorExtensions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/TagHelperDescriptorExtensions.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/TagHelperParseTreeRewriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/TagHelperParseTreeRewriter.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Razor/SimplifyTagToSelfClosingCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Razor/SimplifyTagToSelfClosingCodeActionProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Diagnostics/RazorTranslateDiagnosticsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Diagnostics/RazorTranslateDiagnosticsService.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/FormattingContext.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/FormattingContext.cs
@@ -204,7 +204,7 @@ internal sealed class FormattingContext
     {
         result = null;
         var formattingSpans = GetFormattingSpans();
-        foreach (var formattingSpan in formattingSpans.AsEnumerable())
+        foreach (var formattingSpan in formattingSpans)
         {
             var span = formattingSpan.Span;
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/RoslynCodeActionHelpers.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/CodeActions/RoslynCodeActionHelpers.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToComponentCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToComponentCodeActionProviderTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ImmutableArrayExtensionsTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ImmutableArrayExtensionsTests.cs
@@ -266,10 +266,129 @@ public class ImmutableArrayExtensionsTests
     }
 
     [Fact]
-    public void WhereAsArray_ImmutableArrayBuilder()
+    public void WhereAsArray_ImmutableArray_Empty()
     {
-        var data = ImmutableArray.CreateBuilder<int>();
-        data.AddRange(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        ImmutableArray<int> data = [];
+        ImmutableArray<int> expected = [];
+
+        var actual = data.WhereAsArray(static x => x > 0);
+        Assert.Equal<int>(expected, actual);
+    }
+
+    [Fact]
+    public void WhereAsArray_ImmutableArray_WithIndex()
+    {
+        ImmutableArray<int> data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        ImmutableArray<int> expected = [1, 3, 5, 7, 9]; // Even indices (0, 2, 4, 6, 8)
+
+        var actual = data.WhereAsArray(static (x, index) => index % 2 == 0);
+        Assert.Equal<int>(expected, actual);
+    }
+
+    [Fact]
+    public void WhereAsArray_ImmutableArray_WithIndex_None()
+    {
+        ImmutableArray<int> data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        ImmutableArray<int> expected = [];
+
+        var actual = data.WhereAsArray(static (x, index) => false);
+        Assert.Equal<int>(expected, actual);
+    }
+
+    [Fact]
+    public void WhereAsArray_ImmutableArray_WithIndex_All()
+    {
+        ImmutableArray<int> data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        var expected = data;
+
+        var actual = data.WhereAsArray(static (x, index) => true);
+        Assert.Equal<int>(expected, actual);
+        Assert.Same(ImmutableCollectionsMarshal.AsArray(expected), ImmutableCollectionsMarshal.AsArray(actual));
+    }
+
+    [Fact]
+    public void WhereAsArray_ImmutableArray_WithArg()
+    {
+        ImmutableArray<int> data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        ImmutableArray<int> expected = [5, 6, 7, 8, 9, 10];
+        var threshold = 5;
+
+        var actual = data.WhereAsArray(threshold, static (x, arg) => x >= arg);
+        Assert.Equal<int>(expected, actual);
+    }
+
+    [Fact]
+    public void WhereAsArray_ImmutableArray_WithArg_None()
+    {
+        ImmutableArray<int> data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        ImmutableArray<int> expected = [];
+        var threshold = 15;
+
+        var actual = data.WhereAsArray(threshold, static (x, arg) => x >= arg);
+        Assert.Equal<int>(expected, actual);
+    }
+
+    [Fact]
+    public void WhereAsArray_ImmutableArray_WithArg_All()
+    {
+        ImmutableArray<int> data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        var expected = data;
+        var threshold = 0;
+
+        var actual = data.WhereAsArray(threshold, static (x, arg) => x >= arg);
+        Assert.Equal<int>(expected, actual);
+        Assert.Same(ImmutableCollectionsMarshal.AsArray(expected), ImmutableCollectionsMarshal.AsArray(actual));
+    }
+
+    [Fact]
+    public void WhereAsArray_ImmutableArray_WithArgAndIndex()
+    {
+        ImmutableArray<int> data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        ImmutableArray<int> expected = [4, 6, 8, 10]; // Values at odd indices (1, 3, 5, 7, 9) where value >= 3
+        var threshold = 3;
+
+        var actual = data.WhereAsArray(threshold, static (x, arg, index) => index % 2 == 1 && x >= arg);
+        Assert.Equal<int>(expected, actual);
+    }
+
+    [Fact]
+    public void WhereAsArray_ImmutableArray_WithArgAndIndex_None()
+    {
+        ImmutableArray<int> data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        ImmutableArray<int> expected = [];
+        var threshold = 0;
+
+        var actual = data.WhereAsArray(threshold, static (x, arg, index) => false);
+        Assert.Equal<int>(expected, actual);
+    }
+
+    [Fact]
+    public void WhereAsArray_ImmutableArray_WithArgAndIndex_All()
+    {
+        ImmutableArray<int> data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        var expected = data;
+        var threshold = 0;
+
+        var actual = data.WhereAsArray(threshold, static (x, arg, index) => true);
+        Assert.Equal<int>(expected, actual);
+        Assert.Same(ImmutableCollectionsMarshal.AsArray(expected), ImmutableCollectionsMarshal.AsArray(actual));
+    }
+
+    [Fact]
+    public void WhereAsArray_ImmutableArray_WithReferenceTypes()
+    {
+        ImmutableArray<string> data = ["apple", "banana", "cherry", "date", "elderberry"];
+        ImmutableArray<string> expected = ["banana", "cherry", "elderberry"];
+
+        var actual = data.WhereAsArray(static x => x.Length > 5);
+        Assert.Equal<string>(expected, actual);
+    }
+
+    [Fact]
+    public void WhereAsArray_ImmutableArray_OptimizationTest()
+    {
+        // Test that the optimization works correctly when some items match and some don't
+        ImmutableArray<int> data = [1, 3, 2, 5, 4, 7, 6, 9, 8, 10];
         ImmutableArray<int> expected = [2, 4, 6, 8, 10];
 
         var actual = data.WhereAsArray(static x => x % 2 == 0);
@@ -277,24 +396,24 @@ public class ImmutableArrayExtensionsTests
     }
 
     [Fact]
-    public void WhereAsArray_ImmutableArrayBuilder_None()
+    public void WhereAsArray_ImmutableArray_FirstItemDoesNotMatch()
     {
-        var data = ImmutableArray.CreateBuilder<int>();
-        data.AddRange(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
-        ImmutableArray<int> expected = [];
+        // Test optimization when the first item doesn't match the predicate
+        ImmutableArray<int> data = [1, 2, 4, 6, 8];
+        ImmutableArray<int> expected = [2, 4, 6, 8];
 
-        var actual = data.WhereAsArray(static x => false);
+        var actual = data.WhereAsArray(static x => x % 2 == 0);
         Assert.Equal<int>(expected, actual);
     }
 
     [Fact]
-    public void WhereAsArray_ImmutableArrayBuilder_All()
+    public void WhereAsArray_ImmutableArray_LastItemDoesNotMatch()
     {
-        var data = ImmutableArray.CreateBuilder<int>();
-        data.AddRange(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
-        var expected = data;
+        // Test optimization when the last item doesn't match the predicate
+        ImmutableArray<int> data = [2, 4, 6, 8, 9];
+        ImmutableArray<int> expected = [2, 4, 6, 8];
 
-        var actual = data.WhereAsArray(static x => true);
+        var actual = data.WhereAsArray(static x => x % 2 == 0);
         Assert.Equal<int>(expected, actual);
     }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ReadOnlyListExtensionsTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ReadOnlyListExtensionsTests.cs
@@ -458,7 +458,7 @@ public class ReadOnlyListExtensionsTest
     {
         IReadOnlyList<int> list = [1, 2, 3, 4, 5];
 
-        var result = Enumerate(list.AsEnumerable().Reversed);
+        var result = Enumerate(list.AsEnumerable().Reversed());
 
         Assert.Equal([5, 4, 3, 2, 1], result);
     }
@@ -468,7 +468,7 @@ public class ReadOnlyListExtensionsTest
     {
         IReadOnlyList<int> list = [1, 2, 3, 4, 5];
 
-        var result = Enumerate(list.AsEnumerable(start: 1, count: 3).Reversed);
+        var result = Enumerate(list.AsEnumerable(start: 1, count: 3).Reversed());
 
         Assert.Equal([4, 3, 2], result);
     }
@@ -478,7 +478,7 @@ public class ReadOnlyListExtensionsTest
     {
         IReadOnlyList<int> list = [];
 
-        var result = Enumerate(list.AsEnumerable().Reversed);
+        var result = Enumerate(list.AsEnumerable().Reversed());
 
         Assert.Empty(result);
     }
@@ -515,7 +515,7 @@ public class ReadOnlyListExtensionsTest
     public void AsEnumerable_ReverseEnumeratorReset()
     {
         IReadOnlyList<int> list = [1, 2, 3];
-        var enumerable = list.AsEnumerable().Reversed;
+        var enumerable = list.AsEnumerable().Reversed();
         var enumerator = enumerable.GetEnumerator();
 
         // First enumeration
@@ -669,7 +669,7 @@ public class ReadOnlyListExtensionsTest
         return [.. result];
     }
 
-    private static T[] Enumerate<T>(ReadOnlyListExtensions.Enumerable<T>.ReverseEnumerable enumerable)
+    private static T[] Enumerate<T>(ReadOnlyListExtensions.Enumerable<T>.ReversedEnumerable enumerable)
     {
         var result = new List<T>();
 

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ReadOnlyListExtensionsTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ReadOnlyListExtensionsTests.cs
@@ -322,4 +322,362 @@ public class ReadOnlyListExtensionsTest
         var actual = enumerable.SelectAsArray(static (x, index) => x + index);
         Assert.Equal<int>(expected, actual);
     }
+
+    [Fact]
+    public void AsEnumerable_Basic()
+    {
+        IReadOnlyList<int> list = [1, 2, 3, 4, 5];
+
+        var result = Enumerate(list.AsEnumerable());
+
+        Assert.Equal([1, 2, 3, 4, 5], result);
+    }
+
+    [Fact]
+    public void AsEnumerable_Basic_EmptyList()
+    {
+        IReadOnlyList<int> list = [];
+
+        var result = Enumerate(list.AsEnumerable());
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void AsEnumerable_WithStart()
+    {
+        IReadOnlyList<int> list = [1, 2, 3, 4, 5];
+
+        var result = Enumerate(list.AsEnumerable(start: 2));
+
+        Assert.Equal([3, 4, 5], result);
+    }
+
+    [Fact]
+    public void AsEnumerable_WithStart_StartAtEnd()
+    {
+        IReadOnlyList<int> list = [1, 2, 3, 4, 5];
+
+        var result = Enumerate(list.AsEnumerable(start: 5));
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void AsEnumerable_WithStart_StartAtZero()
+    {
+        IReadOnlyList<int> list = [1, 2, 3, 4, 5];
+
+        var result = Enumerate(list.AsEnumerable(start: 0));
+
+        Assert.Equal([1, 2, 3, 4, 5], result);
+    }
+
+    [Fact]
+    public void AsEnumerable_WithStartIndex_FromStart()
+    {
+        IReadOnlyList<int> list = [1, 2, 3, 4, 5];
+
+        var result = Enumerate(list.AsEnumerable(^3)); // Last 3 elements
+
+        Assert.Equal([3, 4, 5], result);
+    }
+
+    [Fact]
+    public void AsEnumerable_WithStartIndex_FromEnd()
+    {
+        IReadOnlyList<int> list = [1, 2, 3, 4, 5];
+
+        var result = Enumerate(list.AsEnumerable(^1)); // Last element
+
+        Assert.Equal([5], result);
+    }
+
+    [Fact]
+    public void AsEnumerable_WithRange()
+    {
+        IReadOnlyList<int> list = [1, 2, 3, 4, 5];
+
+        var result = Enumerate(list.AsEnumerable(1..4)); // Elements at indices 1, 2, 3
+
+        Assert.Equal([2, 3, 4], result);
+    }
+
+    [Fact]
+    public void AsEnumerable_WithRange_FromEnd()
+    {
+        IReadOnlyList<int> list = [1, 2, 3, 4, 5];
+
+        var result = Enumerate(list.AsEnumerable(^3..^1)); // Last 3 elements excluding the very last
+
+        Assert.Equal([3, 4], result);
+    }
+
+    [Fact]
+    public void AsEnumerable_WithRange_EntireRange()
+    {
+        IReadOnlyList<int> list = [1, 2, 3, 4, 5];
+
+        var result = Enumerate(list.AsEnumerable(..)); // Entire range
+
+        Assert.Equal([1, 2, 3, 4, 5], result);
+    }
+
+    [Fact]
+    public void AsEnumerable_WithStartAndCount()
+    {
+        IReadOnlyList<int> list = [1, 2, 3, 4, 5];
+
+        var result = Enumerate(list.AsEnumerable(start: 1, count: 3));
+
+        Assert.Equal([2, 3, 4], result);
+    }
+
+    [Fact]
+    public void AsEnumerable_WithStartAndCount_ZeroCount()
+    {
+        IReadOnlyList<int> list = [1, 2, 3, 4, 5];
+
+        var result = Enumerate(list.AsEnumerable(start: 2, count: 0));
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void AsEnumerable_WithStartAndCount_SingleElement()
+    {
+        IReadOnlyList<int> list = [1, 2, 3, 4, 5];
+
+        var result = Enumerate(list.AsEnumerable(start: 3, count: 1));
+
+        Assert.Equal([4], result);
+    }
+
+    [Fact]
+    public void AsEnumerable_Reversed()
+    {
+        IReadOnlyList<int> list = [1, 2, 3, 4, 5];
+
+        var result = Enumerate(list.AsEnumerable().Reversed);
+
+        Assert.Equal([5, 4, 3, 2, 1], result);
+    }
+
+    [Fact]
+    public void AsEnumerable_Reversed_WithRange()
+    {
+        IReadOnlyList<int> list = [1, 2, 3, 4, 5];
+
+        var result = Enumerate(list.AsEnumerable(start: 1, count: 3).Reversed);
+
+        Assert.Equal([4, 3, 2], result);
+    }
+
+    [Fact]
+    public void AsEnumerable_Reversed_EmptyList()
+    {
+        IReadOnlyList<int> list = [];
+
+        var result = Enumerate(list.AsEnumerable().Reversed);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void AsEnumerable_EnumeratorReset()
+    {
+        IReadOnlyList<int> list = [1, 2, 3];
+        var enumerable = list.AsEnumerable();
+        var enumerator = enumerable.GetEnumerator();
+
+        // First enumeration
+        var firstPass = new List<int>();
+        while (enumerator.MoveNext())
+        {
+            firstPass.Add(enumerator.Current);
+        }
+
+        Assert.Equal([1, 2, 3], firstPass);
+
+        // Reset and enumerate again
+        enumerator.Reset();
+
+        var secondPass = new List<int>();
+        while (enumerator.MoveNext())
+        {
+            secondPass.Add(enumerator.Current);
+        }
+
+        Assert.Equal([1, 2, 3], secondPass);
+    }
+
+    [Fact]
+    public void AsEnumerable_ReverseEnumeratorReset()
+    {
+        IReadOnlyList<int> list = [1, 2, 3];
+        var enumerable = list.AsEnumerable().Reversed;
+        var enumerator = enumerable.GetEnumerator();
+
+        // First enumeration
+        var firstPass = new List<int>();
+        while (enumerator.MoveNext())
+        {
+            firstPass.Add(enumerator.Current);
+        }
+
+        Assert.Equal([3, 2, 1], firstPass);
+
+        // Reset and enumerate again
+        enumerator.Reset();
+
+        var secondPass = new List<int>();
+        while (enumerator.MoveNext())
+        {
+            secondPass.Add(enumerator.Current);
+        }
+
+        Assert.Equal([3, 2, 1], secondPass);
+    }
+
+    [Fact]
+    public void AsEnumerable_ImmutableArray()
+    {
+        ImmutableArray<int> array = [1, 2, 3, 4, 5];
+        IReadOnlyList<int> list = array;
+
+        var result = Enumerate(list.AsEnumerable(start: 1, count: 3));
+
+        Assert.Equal([2, 3, 4], result);
+    }
+
+    [Fact]
+    public void AsEnumerable_CustomReadOnlyList()
+    {
+        CustomReadOnlyList custom = [1, 2, 3, 4, 5];
+
+        var result = Enumerate(custom.AsEnumerable(start: 1, count: 3));
+
+        Assert.Equal([2, 3, 4], result);
+    }
+
+    [Fact]
+    public void AsEnumerable_NullList_ThrowsArgumentNullException()
+    {
+        IReadOnlyList<int> list = null!;
+
+        Assert.Throws<ArgumentNullException>(() => list.AsEnumerable());
+        Assert.Throws<ArgumentNullException>(() => list.AsEnumerable(start: 0));
+        Assert.Throws<ArgumentNullException>(() => list.AsEnumerable(^1));
+        Assert.Throws<ArgumentNullException>(() => list.AsEnumerable(0..3));
+        Assert.Throws<ArgumentNullException>(() => list.AsEnumerable(start: 0, count: 1));
+    }
+
+    [Fact]
+    public void AsEnumerable_NegativeStart_ThrowsArgumentOutOfRangeException()
+    {
+        IReadOnlyList<int> list = [1, 2, 3, 4, 5];
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.AsEnumerable(start: -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.AsEnumerable(start: -5, count: 2));
+    }
+
+    [Fact]
+    public void AsEnumerable_NegativeCount_ThrowsArgumentOutOfRangeException()
+    {
+        IReadOnlyList<int> list = [1, 2, 3, 4, 5];
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.AsEnumerable(start: 0, count: -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.AsEnumerable(start: 2, count: -3));
+    }
+
+    [Fact]
+    public void AsEnumerable_StartOutOfRange_ThrowsArgumentOutOfRangeException()
+    {
+        IReadOnlyList<int> list = [1, 2, 3, 4, 5];
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.AsEnumerable(start: 6));
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.AsEnumerable(start: 10, count: 1));
+    }
+
+    [Fact]
+    public void AsEnumerable_StartPlusCountExceedsLength_ThrowsArgumentOutOfRangeException()
+    {
+        IReadOnlyList<int> list = [1, 2, 3, 4, 5];
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.AsEnumerable(start: 3, count: 3)); // 3 + 3 = 6 > 5
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.AsEnumerable(start: 0, count: 6)); // 0 + 6 = 6 > 5
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.AsEnumerable(start: 5, count: 1)); // 5 + 1 = 6 > 5
+    }
+
+    [Fact]
+    public void AsEnumerable_ValidRangeAtBoundaries_Succeeds()
+    {
+        IReadOnlyList<int> list = [1, 2, 3, 4, 5];
+
+        // Valid boundary cases that should not throw
+        var result1 = list.AsEnumerable(start: 0, count: 0); // Empty range at start
+        Assert.Empty(Enumerate(result1));
+
+        var result2 = list.AsEnumerable(start: 5, count: 0); // Empty range at end
+        Assert.Empty(Enumerate(result2));
+
+        var result3 = list.AsEnumerable(start: 0, count: 5); // Full range
+        Assert.Equal([1, 2, 3, 4, 5], Enumerate(result3));
+
+        var result4 = list.AsEnumerable(start: 4, count: 1); // Last element
+        Assert.Equal([5], Enumerate(result4));
+    }
+
+    [Fact]
+    public void AsEnumerable_EmptyList_ValidArguments_Succeeds()
+    {
+        IReadOnlyList<int> list = [];
+
+        // These should not throw on empty list
+        var result1 = list.AsEnumerable();
+        Assert.Empty(Enumerate(result1));
+
+        var result2 = list.AsEnumerable(start: 0);
+        Assert.Empty(Enumerate(result2));
+
+        var result3 = list.AsEnumerable(start: 0, count: 0);
+        Assert.Empty(Enumerate(result3));
+
+        var result4 = list.AsEnumerable(..);
+        Assert.Empty(Enumerate(result4));
+    }
+
+    [Fact]
+    public void AsEnumerable_EmptyList_InvalidArguments_ThrowsArgumentOutOfRangeException()
+    {
+        IReadOnlyList<int> list = [];
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.AsEnumerable(start: 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.AsEnumerable(start: 0, count: 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.AsEnumerable(start: 1, count: 0));
+    }
+
+    private static T[] Enumerate<T>(ReadOnlyListExtensions.Enumerable<T> enumerable)
+    {
+        var result = new List<T>();
+
+        foreach (var item in enumerable)
+        {
+            result.Add(item);
+        }
+
+        return [.. result];
+    }
+
+    private static T[] Enumerate<T>(ReadOnlyListExtensions.Enumerable<T>.ReverseEnumerable enumerable)
+    {
+        var result = new List<T>();
+
+        foreach (var item in enumerable)
+        {
+            result.Add(item);
+        }
+
+        return [.. result];
+    }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/SpanExtensionsTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/SpanExtensionsTests.cs
@@ -1,0 +1,461 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Utilities.Shared.Test;
+
+public class SpanExtensionsTests
+{
+    [Fact]
+    public void Reversed_Span_BasicEnumeration()
+    {
+        // Arrange
+        Span<int> span = [1, 2, 3, 4, 5];
+
+        // Act
+        var result = new List<int>();
+        foreach (var item in span.Reversed)
+        {
+            result.Add(item);
+        }
+
+        // Assert
+        Assert.Equal([5, 4, 3, 2, 1], result);
+    }
+
+    [Fact]
+    public void Reversed_ReadOnlySpan_BasicEnumeration()
+    {
+        // Arrange
+        ReadOnlySpan<int> span = [1, 2, 3, 4, 5];
+
+        // Act
+        var result = new List<int>();
+        foreach (var item in span.Reversed)
+        {
+            result.Add(item);
+        }
+
+        // Assert
+        Assert.Equal([5, 4, 3, 2, 1], result);
+    }
+
+    [Fact]
+    public void Reversed_Span_EmptySpan_NoIteration()
+    {
+        // Arrange
+        Span<int> span = [];
+
+        // Act
+        var result = new List<int>();
+        foreach (var item in span.Reversed)
+        {
+            result.Add(item);
+        }
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Reversed_ReadOnlySpan_EmptySpan_NoIteration()
+    {
+        // Arrange
+        ReadOnlySpan<int> span = [];
+
+        // Act
+        var result = new List<int>();
+        foreach (var item in span.Reversed)
+        {
+            result.Add(item);
+        }
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Reversed_Span_SingleElement()
+    {
+        // Arrange
+        Span<int> span = [42];
+
+        // Act
+        var result = new List<int>();
+        foreach (var item in span.Reversed)
+        {
+            result.Add(item);
+        }
+
+        // Assert
+        Assert.Equal([42], result);
+    }
+
+    [Fact]
+    public void Reversed_ReadOnlySpan_SingleElement()
+    {
+        // Arrange
+        ReadOnlySpan<int> span = [42];
+
+        // Act
+        var result = new List<int>();
+        foreach (var item in span.Reversed)
+        {
+            result.Add(item);
+        }
+
+        // Assert
+        Assert.Equal([42], result);
+    }
+
+    [Fact]
+    public void Reversed_Span_TwoElements()
+    {
+        // Arrange
+        Span<int> span = [1, 2];
+
+        // Act
+        var result = new List<int>();
+        foreach (var item in span.Reversed)
+        {
+            result.Add(item);
+        }
+
+        // Assert
+        Assert.Equal([2, 1], result);
+    }
+
+    [Fact]
+    public void Reversed_ReadOnlySpan_TwoElements()
+    {
+        // Arrange
+        ReadOnlySpan<int> span = [1, 2];
+
+        // Act
+        var result = new List<int>();
+        foreach (var item in span.Reversed)
+        {
+            result.Add(item);
+        }
+
+        // Assert
+        Assert.Equal([2, 1], result);
+    }
+
+    [Fact]
+    public void Reversed_Span_StringElements()
+    {
+        // Arrange
+        Span<string> span = ["first", "second", "third"];
+
+        // Act
+        var result = new List<string>();
+        foreach (var item in span.Reversed)
+        {
+            result.Add(item);
+        }
+
+        // Assert
+        Assert.Equal(["third", "second", "first"], result);
+    }
+
+    [Fact]
+    public void Reversed_ReadOnlySpan_StringElements()
+    {
+        // Arrange
+        ReadOnlySpan<string> span = ["first", "second", "third"];
+
+        // Act
+        var result = new List<string>();
+        foreach (var item in span.Reversed)
+        {
+            result.Add(item);
+        }
+
+        // Assert
+        Assert.Equal(["third", "second", "first"], result);
+    }
+
+    [Fact]
+    public void Reversed_Enumerator_Current_ValidAfterMoveNext()
+    {
+        // Arrange
+        Span<int> span = [10, 20, 30];
+        var enumerator = span.Reversed.GetEnumerator();
+
+        // Act & Assert
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal(30, enumerator.Current);
+
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal(20, enumerator.Current);
+
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal(10, enumerator.Current);
+
+        Assert.False(enumerator.MoveNext());
+    }
+
+    [Fact]
+    public void Reversed_Enumerator_MoveNext_EmptySpan_ReturnsFalse()
+    {
+        // Arrange
+        Span<int> span = [];
+        var enumerator = span.Reversed.GetEnumerator();
+
+        // Act & Assert
+        Assert.False(enumerator.MoveNext());
+    }
+
+    [Fact]
+    public void Reversed_Enumerator_Reset_RestoresInitialState()
+    {
+        // Arrange
+        Span<int> span = [1, 2, 3];
+        var enumerator = span.Reversed.GetEnumerator();
+
+        // Move through some elements
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal(3, enumerator.Current);
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal(2, enumerator.Current);
+
+        // Act - Reset
+        enumerator.Reset();
+
+        // Assert - Should start over
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal(3, enumerator.Current);
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal(2, enumerator.Current);
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal(1, enumerator.Current);
+        Assert.False(enumerator.MoveNext());
+    }
+
+    [Fact]
+    public void Reversed_Enumerator_Reset_EmptySpan()
+    {
+        // Arrange
+        Span<int> span = [];
+        var enumerator = span.Reversed.GetEnumerator();
+
+        // Act
+        enumerator.Reset();
+
+        // Assert
+        Assert.False(enumerator.MoveNext());
+    }
+
+    [Fact]
+    public void Reversed_Enumerator_Reset_SingleElement()
+    {
+        // Arrange
+        Span<int> span = [42];
+        var enumerator = span.Reversed.GetEnumerator();
+
+        // Move through the element
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal(42, enumerator.Current);
+        Assert.False(enumerator.MoveNext());
+
+        // Act - Reset
+        enumerator.Reset();
+
+        // Assert - Should start over
+        Assert.True(enumerator.MoveNext());
+        Assert.Equal(42, enumerator.Current);
+        Assert.False(enumerator.MoveNext());
+    }
+
+    [Fact]
+    public void Reversed_MultipleEnumerators_Independent()
+    {
+        // Arrange
+        Span<int> span = [1, 2, 3];
+        var enumerator1 = span.Reversed.GetEnumerator();
+        var enumerator2 = span.Reversed.GetEnumerator();
+
+        // Act & Assert - Enumerators should be independent
+        Assert.True(enumerator1.MoveNext());
+        Assert.Equal(3, enumerator1.Current);
+
+        Assert.True(enumerator2.MoveNext());
+        Assert.Equal(3, enumerator2.Current);
+
+        Assert.True(enumerator1.MoveNext());
+        Assert.Equal(2, enumerator1.Current);
+
+        // enumerator2 should still be at the first position
+        Assert.True(enumerator2.MoveNext());
+        Assert.Equal(2, enumerator2.Current);
+    }
+
+    [Fact]
+    public void Reversed_Span_LargeSpan()
+    {
+        // Arrange
+        var array = new int[1000];
+        for (var i = 0; i < array.Length; i++)
+        {
+            array[i] = i;
+        }
+
+        Span<int> span = array;
+
+        // Act
+        var result = new List<int>();
+        foreach (var item in span.Reversed)
+        {
+            result.Add(item);
+        }
+
+        // Assert
+        Assert.Equal(1000, result.Count);
+        Assert.Equal(999, result[0]);
+        Assert.Equal(998, result[1]);
+        Assert.Equal(0, result[999]);
+    }
+
+    [Fact]
+    public void Reversed_ReadOnlySpan_LargeSpan()
+    {
+        // Arrange
+        var array = new int[1000];
+        for (var i = 0; i < array.Length; i++)
+        {
+            array[i] = i;
+        }
+
+        ReadOnlySpan<int> span = array;
+
+        // Act
+        var result = new List<int>();
+        foreach (var item in span.Reversed)
+        {
+            result.Add(item);
+        }
+
+        // Assert
+        Assert.Equal(1000, result.Count);
+        Assert.Equal(999, result[0]);
+        Assert.Equal(998, result[1]);
+        Assert.Equal(0, result[999]);
+    }
+
+    [Fact]
+    public void Reversed_Span_ReferenceTypes_NullElements()
+    {
+        // Arrange
+        Span<string?> span = ["first", null, "third"];
+
+        // Act
+        var result = new List<string?>();
+        foreach (var item in span.Reversed)
+        {
+            result.Add(item);
+        }
+
+        // Assert
+        Assert.Equal(["third", null, "first"], result);
+    }
+
+    [Fact]
+    public void Reversed_ReadOnlySpan_ReferenceTypes_NullElements()
+    {
+        // Arrange
+        ReadOnlySpan<string?> span = ["first", null, "third"];
+
+        // Act
+        var result = new List<string?>();
+        foreach (var item in span.Reversed)
+        {
+            result.Add(item);
+        }
+
+        // Assert
+        Assert.Equal(["third", null, "first"], result);
+    }
+
+    [Fact]
+    public void Reversed_NestedForeach_Works()
+    {
+        // Arrange
+        Span<int> span1 = [1, 2];
+        Span<int> span2 = [3, 4];
+
+        // Act
+        var result = new List<(int, int)>();
+        foreach (var item1 in span1.Reversed)
+        {
+            foreach (var item2 in span2.Reversed)
+            {
+                result.Add((item1, item2));
+            }
+        }
+
+        // Assert
+        Assert.Equal([(2, 4), (2, 3), (1, 4), (1, 3)], result);
+    }
+
+    [Fact]
+    public void Reversed_ManualEnumerator_Usage()
+    {
+        // Arrange
+        ReadOnlySpan<char> span = ['a', 'b', 'c'];
+        var enumerator = span.Reversed.GetEnumerator();
+
+        // Act & Assert - Manual enumeration
+        var result = new List<char>();
+        while (enumerator.MoveNext())
+        {
+            result.Add(enumerator.Current);
+        }
+
+        Assert.Equal(['c', 'b', 'a'], result);
+
+        // Trying to move next after completion should return false
+        Assert.False(enumerator.MoveNext());
+    }
+
+    [Fact]
+    public void Reversed_ValueTypes_StructElements()
+    {
+        // Arrange
+        var point1 = new System.Drawing.Point(1, 2);
+        var point2 = new System.Drawing.Point(3, 4);
+        var point3 = new System.Drawing.Point(5, 6);
+        Span<System.Drawing.Point> span = [point1, point2, point3];
+
+        // Act
+        var result = new List<System.Drawing.Point>();
+        foreach (var item in span.Reversed)
+        {
+            result.Add(item);
+        }
+
+        // Assert
+        Assert.Equal([point3, point2, point1], result);
+    }
+
+    [Fact]
+    public void Reversed_ImplicitConversion_SpanToReadOnlySpan()
+    {
+        // Arrange
+        Span<int> span = [1, 2, 3];
+
+        // Act - Implicit conversion to ReadOnlySpan<T>
+        ReadOnlySpan<int> readOnlySpan = span;
+        var result = new List<int>();
+        foreach (var item in readOnlySpan.Reversed)
+        {
+            result.Add(item);
+        }
+
+        // Assert
+        Assert.Equal([3, 2, 1], result);
+    }
+}

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
@@ -257,6 +257,350 @@ internal static partial class ImmutableArrayExtensions
     }
 
     /// <summary>
+    ///  Determines whether any element of an array satisfies a condition.
+    /// </summary>
+    /// <param name="array">
+    ///  An <see cref="ImmutableArray{T}"/> whose elements to apply the predicate to.
+    /// </param>
+    /// <param name="arg">
+    ///  An argument to pass to <paramref name="predicate"/>.
+    /// </param>
+    /// <param name="predicate">
+    ///  A function to test each element for a condition.
+    /// </param>
+    /// <returns>
+    ///  <see langword="true"/> if the array is not empty and at least one of its elements passes
+    ///  the test in the specified predicate; otherwise, <see langword="false"/>.
+    /// </returns>
+    public static bool Any<T, TArg>(this ImmutableArray<T> array, TArg arg, Func<T, TArg, bool> predicate)
+    {
+        foreach (var item in array)
+        {
+            if (predicate(item, arg))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///  Determines whether all elements of an array satisfy a condition.
+    /// </summary>
+    /// <param name="array">
+    ///  An <see cref="ImmutableArray{T}"/> whose elements to apply the predicate to.
+    /// </param>
+    /// <param name="arg">
+    ///  An argument to pass to <paramref name="predicate"/>.
+    /// </param>
+    /// <param name="predicate">
+    ///  A function to test each element for a condition.
+    /// </param>
+    /// <returns>
+    ///  <see langword="true"/> if every element of the array passes the test
+    ///  in the specified predicate, or if the array is empty; otherwise,
+    ///  <see langword="false"/>.</returns>
+    public static bool All<T, TArg>(this ImmutableArray<T> array, TArg arg, Func<T, TArg, bool> predicate)
+    {
+        foreach (var item in array)
+        {
+            if (!predicate(item, arg))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    ///  Returns the first element in an array that satisfies a specified condition.
+    /// </summary>
+    /// <param name="array">
+    ///  An <see cref="ImmutableArray{T}"/> to return an element from.
+    /// </param>
+    /// <param name="arg">
+    ///  An argument to pass to <paramref name="predicate"/>.
+    /// </param>
+    /// <param name="predicate">
+    ///  A function to test each element for a condition.
+    /// </param>
+    /// <returns>
+    ///  The first element in the array that passes the test in the specified predicate function.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    ///  No element satisfies the condition in <paramref name="predicate"/>.
+    /// </exception>
+    public static T First<T, TArg>(this ImmutableArray<T> array, TArg arg, Func<T, TArg, bool> predicate)
+    {
+        foreach (var item in array)
+        {
+            if (predicate(item, arg))
+            {
+                return item;
+            }
+        }
+
+        return ThrowHelper.ThrowInvalidOperationException<T>(SR.Contains_no_matching_elements);
+    }
+
+    /// <summary>
+    ///  Returns the first element of the array that satisfies a condition or a default value if no such element is found.
+    /// </summary>
+    /// <param name="array">
+    ///  An <see cref="ImmutableArray{T}"/> to return an element from.
+    /// </param>
+    /// <param name="arg">
+    ///  An argument to pass to <paramref name="predicate"/>.
+    /// </param>
+    /// <param name="predicate">
+    ///  A function to test each element for a condition.
+    /// </param>
+    /// <returns>
+    ///  <see langword="default"/>(<typeparamref name="T"/>) if <paramref name="array"/> is empty or if no element
+    ///  passes the test specified by <paramref name="predicate"/>; otherwise, the first element in <paramref name="array"/>
+    ///  that passes the test specified by <paramref name="predicate"/>.
+    /// </returns>
+    public static T? FirstOrDefault<T, TArg>(this ImmutableArray<T> array, TArg arg, Func<T, TArg, bool> predicate)
+    {
+        foreach (var item in array)
+        {
+            if (predicate(item, arg))
+            {
+                return item;
+            }
+        }
+
+        return default;
+    }
+
+    /// <summary>
+    ///  Returns the last element of an array that satisfies a specified condition.
+    /// </summary>
+    /// <param name="array">
+    ///  An <see cref="ImmutableArray{T}"/> to return an element from.
+    /// </param>
+    /// <param name="arg">
+    ///  An argument to pass to <paramref name="predicate"/>.
+    /// </param>
+    /// <param name="predicate">
+    ///  A function to test each element for a condition.
+    /// </param>
+    /// <returns>
+    ///  The last element in the array that passes the test in the specified predicate function.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    ///  No element satisfies the condition in <paramref name="predicate"/>.
+    /// </exception>
+    public static T Last<T, TArg>(this ImmutableArray<T> array, TArg arg, Func<T, TArg, bool> predicate)
+    {
+        foreach (var item in array.Reversed)
+        {
+            if (predicate(item, arg))
+            {
+                return item;
+            }
+        }
+
+        return ThrowHelper.ThrowInvalidOperationException<T>(SR.Contains_no_matching_elements);
+    }
+
+    /// <summary>
+    ///  Returns the last element of an array that satisfies a condition or a default value if no such element is found.
+    /// </summary>
+    /// <param name="array">
+    ///  An <see cref="ImmutableArray{T}"/> to return an element from.
+    /// </param>
+    /// <param name="arg">
+    ///  An argument to pass to <paramref name="predicate"/>.
+    /// </param>
+    /// <param name="predicate">
+    ///  A function to test each element for a condition.
+    /// </param>
+    /// <returns>
+    ///  <see langword="default"/>(<typeparamref name="T"/>) if <paramref name="array"/> is empty or if no element
+    ///  passes the test specified by <paramref name="predicate"/>; otherwise, the last element in <paramref name="array"/>
+    ///  that passes the test specified by <paramref name="predicate"/>.
+    /// </returns>
+    public static T? LastOrDefault<T, TArg>(this ImmutableArray<T> array, TArg arg, Func<T, TArg, bool> predicate)
+    {
+        foreach (var item in array.Reversed)
+        {
+            if (predicate(item, arg))
+            {
+                return item;
+            }
+        }
+
+        return default;
+    }
+
+    /// <summary>
+    ///  Returns the last element of an array that satisfies a condition, or a specified default value if no such element is found.
+    /// </summary>
+    /// <param name="array">
+    ///  An <see cref="ImmutableArray{T}"/> to return an element from.
+    /// </param>
+    /// <param name="arg">
+    ///  An argument to pass to <paramref name="predicate"/>.
+    /// </param>
+    /// <param name="predicate">
+    ///  A function to test each element for a condition.
+    /// </param>
+    /// <param name="defaultValue">
+    ///  The default value to return if the array is empty.
+    /// </param>
+    /// <returns>
+    ///  <paramref name="defaultValue"/> if <paramref name="array"/> is empty or if no element
+    ///  passes the test specified by <paramref name="predicate"/>; otherwise, the last element in <paramref name="array"/>
+    ///  that passes the test specified by <paramref name="predicate"/>.
+    /// </returns>
+    public static T LastOrDefault<T, TArg>(this ImmutableArray<T> array, TArg arg, Func<T, TArg, bool> predicate, T defaultValue)
+    {
+        foreach (var item in array.Reversed)
+        {
+            if (predicate(item, arg))
+            {
+                return item;
+            }
+        }
+
+        return defaultValue;
+    }
+
+    /// <summary>
+    ///  Returns the only element of an array that satisfies a specified condition or a default value
+    ///  if no such element exists; this method throws an exception if more than one element satisfies the condition.
+    /// </summary>
+    /// <param name="array">
+    ///  An <see cref="ImmutableArray{T}"/> to return a single element from.
+    /// </param>
+    /// <param name="arg">
+    ///  An argument to pass to <paramref name="predicate"/>.
+    /// </param>
+    /// <param name="predicate">
+    ///  A function to test an element for a condition.
+    /// </param>
+    /// <returns>
+    ///  The single element of the array that satisfies the condition, or
+    ///  <see langword="default"/>(<typeparamref name="T"/>) if no such element is found.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    ///  More than one element satisfies the condition in <paramref name="predicate"/>.
+    /// </exception>
+    public static T? SingleOrDefault<T, TArg>(this ImmutableArray<T> array, TArg arg, Func<T, TArg, bool> predicate)
+    {
+        var firstSeen = false;
+        T? result = default;
+
+        foreach (var item in array)
+        {
+            if (predicate(item, arg))
+            {
+                if (firstSeen)
+                {
+                    return ThrowHelper.ThrowInvalidOperationException<T>(SR.Contains_more_than_one_matching_element);
+                }
+
+                firstSeen = true;
+                result = item;
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Returns the only element of an array that satisfies a specified condition, or a specified default value
+    ///  if no such element exists; this method throws an exception if more than one element satisfies the condition.
+    /// </summary>
+    /// <param name="array">
+    ///  An <see cref="ImmutableArray{T}"/> to return a single element from.
+    /// </param>
+    /// <param name="arg">
+    ///  An argument to pass to <paramref name="predicate"/>.
+    /// </param>
+    /// <param name="predicate">
+    ///  A function to test an element for a condition.
+    /// </param>
+    /// <param name="defaultValue">
+    ///  The default value to return if the array is empty.
+    /// </param>
+    /// <returns>
+    ///  The single element of the array that satisfies the condition, or
+    ///  <paramref name="defaultValue"/> if no such element is found.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    ///  More than one element satisfies the condition in <paramref name="predicate"/>.
+    /// </exception>
+    public static T SingleOrDefault<T, TArg>(this ImmutableArray<T> array, TArg arg, Func<T, TArg, bool> predicate, T defaultValue)
+    {
+        var firstSeen = false;
+        var result = defaultValue;
+
+        foreach (var item in array)
+        {
+            if (predicate(item, arg))
+            {
+                if (firstSeen)
+                {
+                    return ThrowHelper.ThrowInvalidOperationException<T>(SR.Contains_more_than_one_matching_element);
+                }
+
+                firstSeen = true;
+                result = item;
+            }
+        }
+
+        return result;
+    }
+
+    extension<T>(ImmutableArray<T> array)
+    {
+        public ReverseEnumerable<T> Reversed => new(array);
+    }
+
+    public readonly ref struct ReverseEnumerable<T>(ImmutableArray<T> array)
+    {
+        public ReverseEnumerator<T> GetEnumerator() => new(array);
+    }
+
+    public ref struct ReverseEnumerator<T>
+    {
+        private readonly ImmutableArray<T> _array;
+        private int _index;
+        private T _current;
+
+        public readonly T Current => _current;
+
+        public ReverseEnumerator(ImmutableArray<T> array)
+        {
+            _array = array;
+            _index = _array.Length - 1;
+            _current = default!;
+        }
+
+        public bool MoveNext()
+        {
+            if (_index >= 0)
+            {
+                _current = _array[_index];
+                _index--;
+                return true;
+            }
+
+            return false;
+        }
+
+        public void Reset()
+        {
+            _index = _array.Length - 1;
+            _current = default!;
+        }
+    }
+
+    /// <summary>
     ///  Returns an <see cref="ImmutableArray{T}"/> that contains no duplicates from the <paramref name="source"/> array
     ///  and returns the most recent copy of each item.
     /// </summary>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
@@ -461,7 +461,7 @@ internal static partial class ImmutableArrayExtensions
     /// </exception>
     public static T Last<T, TArg>(this ImmutableArray<T> array, TArg arg, Func<T, TArg, bool> predicate)
     {
-        foreach (var item in array.Reversed)
+        foreach (var item in array.AsSpan().Reversed)
         {
             if (predicate(item, arg))
             {
@@ -491,7 +491,7 @@ internal static partial class ImmutableArrayExtensions
     /// </returns>
     public static T? LastOrDefault<T, TArg>(this ImmutableArray<T> array, TArg arg, Func<T, TArg, bool> predicate)
     {
-        foreach (var item in array.Reversed)
+        foreach (var item in array.AsSpan().Reversed)
         {
             if (predicate(item, arg))
             {
@@ -515,7 +515,7 @@ internal static partial class ImmutableArrayExtensions
     ///  A function to test each element for a condition.
     /// </param>
     /// <param name="defaultValue">
-    ///  The default value to return if the array is empty.
+    ///  The default value to return if the array is empty or no element was found.
     /// </param>
     /// <returns>
     ///  <paramref name="defaultValue"/> if <paramref name="array"/> is empty or if no element
@@ -524,7 +524,7 @@ internal static partial class ImmutableArrayExtensions
     /// </returns>
     public static T LastOrDefault<T, TArg>(this ImmutableArray<T> array, TArg arg, Func<T, TArg, bool> predicate, T defaultValue)
     {
-        foreach (var item in array.Reversed)
+        foreach (var item in array.AsSpan().Reversed)
         {
             if (predicate(item, arg))
             {
@@ -591,7 +591,7 @@ internal static partial class ImmutableArrayExtensions
     ///  A function to test an element for a condition.
     /// </param>
     /// <param name="defaultValue">
-    ///  The default value to return if the array is empty.
+    ///  The default value to return if the array is empty or no element was found.
     /// </param>
     /// <returns>
     ///  The single element of the array that satisfies the condition, or
@@ -620,50 +620,6 @@ internal static partial class ImmutableArrayExtensions
         }
 
         return result;
-    }
-
-    extension<T>(ImmutableArray<T> array)
-    {
-        public ReverseEnumerable<T> Reversed => new(array);
-    }
-
-    public readonly ref struct ReverseEnumerable<T>(ImmutableArray<T> array)
-    {
-        public ReverseEnumerator<T> GetEnumerator() => new(array);
-    }
-
-    public ref struct ReverseEnumerator<T>
-    {
-        private readonly ImmutableArray<T> _array;
-        private int _index;
-        private T _current;
-
-        public readonly T Current => _current;
-
-        public ReverseEnumerator(ImmutableArray<T> array)
-        {
-            _array = array;
-            _index = _array.Length - 1;
-            _current = default!;
-        }
-
-        public bool MoveNext()
-        {
-            if (_index >= 0)
-            {
-                _current = _array[_index];
-                _index--;
-                return true;
-            }
-
-            return false;
-        }
-
-        public void Reset()
-        {
-            _index = _array.Length - 1;
-            _current = default!;
-        }
     }
 
     /// <summary>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
@@ -128,6 +128,72 @@ internal static partial class ImmutableArrayExtensions
         return ImmutableCollectionsMarshal.AsImmutableArray(result);
     }
 
+    /// <summary>
+    ///  Projects each element of an <see cref="ImmutableArray{T}"/> into a new form.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TArg">The type of the argument to pass to <paramref name="selector"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="array">An array of values to invoke a transform function on.</param>
+    /// <param name="arg">An argument to pass to <paramref name="selector"/>.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="array"/>.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAsArray<T, TArg, TResult>(this ImmutableArray<T> array, TArg arg, Func<T, TArg, TResult> selector)
+    {
+        var length = array.Length;
+
+        if (length == 0)
+        {
+            return [];
+        }
+
+        var result = new TResult[length];
+
+        for (var i = 0; i < length; i++)
+        {
+            result[i] = selector(array[i], arg);
+        }
+
+        return ImmutableCollectionsMarshal.AsImmutableArray(result);
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="ImmutableArray{T}"/> into a new form by incorporating the element's index.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TArg">The type of the argument to pass to <paramref name="selector"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="array">An array of values to invoke a transform function on.</param>
+    /// <param name="arg">An argument to pass to <paramref name="selector"/>.</param>
+    /// <param name="selector">
+    ///  A transform function to apply to each element; the second parameter of the function represents the index of the element.
+    /// </param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="array"/>.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAsArray<T, TArg, TResult>(this ImmutableArray<T> array, TArg arg, Func<T, TArg, int, TResult> selector)
+    {
+        var length = array.Length;
+
+        if (length == 0)
+        {
+            return [];
+        }
+
+        var result = new TResult[length];
+
+        for (var i = 0; i < length; i++)
+        {
+            result[i] = selector(array[i], arg, i);
+        }
+
+        return ImmutableCollectionsMarshal.AsImmutableArray(result);
+    }
+
     public static ImmutableArray<TResult> SelectManyAsArray<TSource, TResult>(this IReadOnlyCollection<TSource>? source, Func<TSource, ImmutableArray<TResult>> selector)
     {
         if (source is null || source.Count == 0)

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadOnlyListExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadOnlyListExtensions.cs
@@ -336,7 +336,7 @@ internal static class ReadOnlyListExtensions
     ///  An <see cref="IReadOnlyList{T}"/> to return the first element of.
     /// </param>
     /// <param name="defaultValue">
-    ///  The default value to return if the list is empty
+    ///  The default value to return if the list is empty.
     /// </param>
     /// <returns>
     ///  <paramref name="defaultValue"/> if <paramref name="list"/> is empty; otherwise,
@@ -373,6 +373,36 @@ internal static class ReadOnlyListExtensions
     }
 
     /// <summary>
+    ///  Returns the first element of the list that satisfies a condition, or a specified default value if no such element is found.
+    /// </summary>
+    /// <param name="list">
+    ///  An <see cref="IReadOnlyList{T}"/> to return an element from.
+    /// </param>
+    /// <param name="predicate">
+    ///  A function to test each element for a condition.
+    /// </param>
+    /// <param name="defaultValue">
+    ///  The default value to return if the list is empty or no element is found.
+    /// </param>
+    /// <returns>
+    ///  <paramref name="defaultValue"/> if <paramref name="list"/> is empty or if no element
+    ///  passes the test specified by <paramref name="predicate"/>; otherwise, the first element in <paramref name="list"/>
+    ///  that passes the test specified by <paramref name="predicate"/>.
+    /// </returns>
+    public static T? FirstOrDefault<T>(this IReadOnlyList<T> list, Func<T, bool> predicate, T defaultValue)
+    {
+        foreach (var item in list.AsEnumerable())
+        {
+            if (predicate(item))
+            {
+                return item;
+            }
+        }
+
+        return defaultValue;
+    }
+
+    /// <summary>
     ///  Returns the first element of the list that satisfies a condition or a default value if no such element is found.
     /// </summary>
     /// <param name="list">
@@ -400,6 +430,39 @@ internal static class ReadOnlyListExtensions
         }
 
         return default;
+    }
+
+    /// <summary>
+    ///  Returns the first element of the list that satisfies a condition, or a specified default value if no such element is found.
+    /// </summary>
+    /// <param name="list">
+    ///  An <see cref="IReadOnlyList{T}"/> to return an element from.
+    /// </param>
+    /// <param name="arg">
+    ///  An argument to pass to <paramref name="predicate"/>.
+    /// </param>
+    /// <param name="predicate">
+    ///  A function to test each element for a condition.
+    /// </param>
+    /// <param name="defaultValue">
+    ///  The default value to return if the list is empty or no element is found.
+    /// </param>
+    /// <returns>
+    ///  <paramref name="defaultValue"/> if <paramref name="list"/> is empty or if no element
+    ///  passes the test specified by <paramref name="predicate"/>; otherwise, the first element in <paramref name="list"/>
+    ///  that passes the test specified by <paramref name="predicate"/>.
+    /// </returns>
+    public static T? FirstOrDefault<T, TArg>(this IReadOnlyList<T> list, TArg arg, Func<T, TArg, bool> predicate, T defaultValue)
+    {
+        foreach (var item in list.AsEnumerable())
+        {
+            if (predicate(item, arg))
+            {
+                return item;
+            }
+        }
+
+        return defaultValue;
     }
 
     /// <summary>
@@ -434,7 +497,7 @@ internal static class ReadOnlyListExtensions
     /// </exception>
     public static T Last<T>(this IReadOnlyList<T> list, Func<T, bool> predicate)
     {
-        foreach (var item in list.AsEnumerable().Reverse())
+        foreach (var item in list.AsEnumerable().Reversed)
         {
             if (predicate(item))
             {
@@ -465,7 +528,7 @@ internal static class ReadOnlyListExtensions
     /// </exception>
     public static T Last<T, TArg>(this IReadOnlyList<T> list, TArg arg, Func<T, TArg, bool> predicate)
     {
-        foreach (var item in list.AsEnumerable().Reverse())
+        foreach (var item in list.AsEnumerable().Reversed)
         {
             if (predicate(item, arg))
             {
@@ -521,7 +584,7 @@ internal static class ReadOnlyListExtensions
     /// </returns>
     public static T? LastOrDefault<T>(this IReadOnlyList<T> list, Func<T, bool> predicate)
     {
-        foreach (var item in list.AsEnumerable().Reverse())
+        foreach (var item in list.AsEnumerable().Reversed)
         {
             if (predicate(item))
             {
@@ -551,7 +614,7 @@ internal static class ReadOnlyListExtensions
     /// </returns>
     public static T? LastOrDefault<T, TArg>(this IReadOnlyList<T> list, TArg arg, Func<T, TArg, bool> predicate)
     {
-        foreach (var item in list.AsEnumerable().Reverse())
+        foreach (var item in list.AsEnumerable().Reversed)
         {
             if (predicate(item, arg))
             {
@@ -581,7 +644,7 @@ internal static class ReadOnlyListExtensions
     /// </returns>
     public static T LastOrDefault<T>(this IReadOnlyList<T> list, Func<T, bool> predicate, T defaultValue)
     {
-        foreach (var item in list.AsEnumerable().Reverse())
+        foreach (var item in list.AsEnumerable().Reversed)
         {
             if (predicate(item))
             {
@@ -605,7 +668,7 @@ internal static class ReadOnlyListExtensions
     ///  A function to test each element for a condition.
     /// </param>
     /// <param name="defaultValue">
-    ///  The default value to return if the list is empty.
+    ///  The default value to return if the list is empty or no element is found.
     /// </param>
     /// <returns>
     ///  <paramref name="defaultValue"/> if <paramref name="list"/> is empty or if no element
@@ -614,7 +677,7 @@ internal static class ReadOnlyListExtensions
     /// </returns>
     public static T LastOrDefault<T, TArg>(this IReadOnlyList<T> list, TArg arg, Func<T, TArg, bool> predicate, T defaultValue)
     {
-        foreach (var item in list.AsEnumerable().Reverse())
+        foreach (var item in list.AsEnumerable().Reversed)
         {
             if (predicate(item, arg))
             {
@@ -970,7 +1033,7 @@ internal static class ReadOnlyListExtensions
     {
         public Enumerator<T> GetEnumerator() => new(list);
 
-        public ReverseEnumerable<T> Reverse() => new(list);
+        public ReverseEnumerable<T> Reversed => new(list);
     }
 
     public ref struct Enumerator<T>(IReadOnlyList<T> list)

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadOnlyListExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadOnlyListExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
@@ -1074,10 +1074,11 @@ internal static class ReadOnlyListExtensions
 
     public readonly ref struct Enumerable<T>(IReadOnlyList<T> list, int start, int count)
     {
-        private readonly int First => start;
-        private readonly int Last => start + count - 1;
+        private readonly IReadOnlyList<T> _list = list;
+        private readonly int _first = start;
+        private readonly int _last = start + count - 1;
 
-        private readonly T this[int index] => list[index];
+        private readonly T this[int index] => _list[index];
 
         public Enumerator GetEnumerator() => new(this);
 
@@ -1087,14 +1088,14 @@ internal static class ReadOnlyListExtensions
         {
             private readonly Enumerable<T> _enumerable = enumerable;
 
-            private int _index = enumerable.First;
+            private int _index = enumerable._first;
             private T _current = default!;
 
             public readonly T Current => _current;
 
             public bool MoveNext()
             {
-                if (_index <= _enumerable.Last)
+                if (_index <= _enumerable._last)
                 {
                     _current = _enumerable[_index];
                     _index++;
@@ -1106,7 +1107,7 @@ internal static class ReadOnlyListExtensions
 
             public void Reset()
             {
-                _index = _enumerable.First;
+                _index = _enumerable._first;
                 _current = default!;
             }
         }
@@ -1121,14 +1122,14 @@ internal static class ReadOnlyListExtensions
             {
                 private readonly Enumerable<T> _enumerable = enumerable;
 
-                private int _index = enumerable.Last;
+                private int _index = enumerable._last;
                 private T _current = default!;
 
                 public readonly T Current => _current;
 
                 public bool MoveNext()
                 {
-                    if (_index >= _enumerable.First)
+                    if (_index >= _enumerable._first)
                     {
                         _current = _enumerable[_index];
                         _index--;
@@ -1140,7 +1141,7 @@ internal static class ReadOnlyListExtensions
 
                 public void Reset()
                 {
-                    _index = _enumerable.Last;
+                    _index = _enumerable._last;
                     _current = default!;
                 }
             }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadOnlyListExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadOnlyListExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
@@ -497,7 +497,7 @@ internal static class ReadOnlyListExtensions
     /// </exception>
     public static T Last<T>(this IReadOnlyList<T> list, Func<T, bool> predicate)
     {
-        foreach (var item in list.AsEnumerable().Reversed)
+        foreach (var item in list.AsEnumerable().Reversed())
         {
             if (predicate(item))
             {
@@ -528,7 +528,7 @@ internal static class ReadOnlyListExtensions
     /// </exception>
     public static T Last<T, TArg>(this IReadOnlyList<T> list, TArg arg, Func<T, TArg, bool> predicate)
     {
-        foreach (var item in list.AsEnumerable().Reversed)
+        foreach (var item in list.AsEnumerable().Reversed())
         {
             if (predicate(item, arg))
             {
@@ -584,7 +584,7 @@ internal static class ReadOnlyListExtensions
     /// </returns>
     public static T? LastOrDefault<T>(this IReadOnlyList<T> list, Func<T, bool> predicate)
     {
-        foreach (var item in list.AsEnumerable().Reversed)
+        foreach (var item in list.AsEnumerable().Reversed())
         {
             if (predicate(item))
             {
@@ -614,7 +614,7 @@ internal static class ReadOnlyListExtensions
     /// </returns>
     public static T? LastOrDefault<T, TArg>(this IReadOnlyList<T> list, TArg arg, Func<T, TArg, bool> predicate)
     {
-        foreach (var item in list.AsEnumerable().Reversed)
+        foreach (var item in list.AsEnumerable().Reversed())
         {
             if (predicate(item, arg))
             {
@@ -644,7 +644,7 @@ internal static class ReadOnlyListExtensions
     /// </returns>
     public static T LastOrDefault<T>(this IReadOnlyList<T> list, Func<T, bool> predicate, T defaultValue)
     {
-        foreach (var item in list.AsEnumerable().Reversed)
+        foreach (var item in list.AsEnumerable().Reversed())
         {
             if (predicate(item))
             {
@@ -677,7 +677,7 @@ internal static class ReadOnlyListExtensions
     /// </returns>
     public static T LastOrDefault<T, TArg>(this IReadOnlyList<T> list, TArg arg, Func<T, TArg, bool> predicate, T defaultValue)
     {
-        foreach (var item in list.AsEnumerable().Reversed)
+        foreach (var item in list.AsEnumerable().Reversed())
         {
             if (predicate(item, arg))
             {
@@ -1082,7 +1082,7 @@ internal static class ReadOnlyListExtensions
 
         public Enumerator GetEnumerator() => new(this);
 
-        public ReverseEnumerable Reversed => new(this);
+        public readonly ReversedEnumerable Reversed() => new(this);
 
         public ref struct Enumerator(Enumerable<T> enumerable)
         {
@@ -1112,13 +1112,13 @@ internal static class ReadOnlyListExtensions
             }
         }
 
-        public readonly ref struct ReverseEnumerable(Enumerable<T> enumerable)
+        public readonly ref struct ReversedEnumerable(Enumerable<T> enumerable)
         {
             private readonly Enumerable<T> _enumerable = enumerable;
 
-            public ReverseEnumerator GetEnumerator() => new(_enumerable);
+            public ReversedEnumerator GetEnumerator() => new(_enumerable);
 
-            public ref struct ReverseEnumerator(Enumerable<T> enumerable)
+            public ref struct ReversedEnumerator(Enumerable<T> enumerable)
             {
                 private readonly Enumerable<T> _enumerable = enumerable;
 

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadOnlyListExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadOnlyListExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
@@ -559,7 +559,7 @@ internal static class ReadOnlyListExtensions
     ///  An <see cref="IReadOnlyList{T}"/> to return the last element of.
     /// </param>
     /// <param name="defaultValue">
-    ///  The default value to return if the list is empty
+    ///  The default value to return if the list is empty.
     /// </param>
     /// <returns>
     ///  <paramref name="defaultValue"/> if <paramref name="list"/> is empty; otherwise,
@@ -635,7 +635,7 @@ internal static class ReadOnlyListExtensions
     ///  A function to test each element for a condition.
     /// </param>
     /// <param name="defaultValue">
-    ///  The default value to return if the list is empty.
+    ///  The default value to return if the list is empty or no element is found.
     /// </param>
     /// <returns>
     ///  <paramref name="defaultValue"/> if <paramref name="list"/> is empty or if no element
@@ -840,7 +840,7 @@ internal static class ReadOnlyListExtensions
     ///  An <see cref="IReadOnlyList{T}"/> to return the single element of.
     /// </param>
     /// <param name="defaultValue">
-    ///  The default value to return if the list is empty
+    ///  The default value to return if the list is empty.
     /// </param>
     /// <returns>
     ///  The single element in the list, or <paramref name="defaultValue"/>
@@ -951,7 +951,7 @@ internal static class ReadOnlyListExtensions
     ///  A function to test an element for a condition.
     /// </param>
     /// <param name="defaultValue">
-    ///  The default value to return if the list is empty.
+    ///  The default value to return if the list is empty or no element is found.
     /// </param>
     /// <returns>
     ///  The single element of the list that satisfies the condition, or
@@ -996,7 +996,7 @@ internal static class ReadOnlyListExtensions
     ///  A function to test an element for a condition.
     /// </param>
     /// <param name="defaultValue">
-    ///  The default value to return if the list is empty.
+    ///  The default value to return if the list is empty or no element is found.
     /// </param>
     /// <returns>
     ///  The single element of the list that satisfies the condition, or
@@ -1546,7 +1546,7 @@ internal static class ReadOnlyListExtensions
     /// <param name="selector">A transform function to apply to each element.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
-    ///  on each element of <paramref name="list"/> and sorted in decending order.
+    ///  on each element of <paramref name="list"/> and sorted in descending order.
     /// </returns>
     public static ImmutableArray<TResult> SelectAndOrderDescendingAsArray<T, TResult>(this IReadOnlyList<T> list, Func<T, TResult> selector)
     {
@@ -1566,7 +1566,7 @@ internal static class ReadOnlyListExtensions
     /// <param name="comparer">An <see cref="IComparer{T}"/> to compare elements.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
-    ///  on each element of <paramref name="list"/> and sorted in decending order.
+    ///  on each element of <paramref name="list"/> and sorted in descending order.
     /// </returns>
     public static ImmutableArray<TResult> SelectAndOrderDescendingAsArray<T, TResult>(
         this IReadOnlyList<T> list, Func<T, TResult> selector, IComparer<TResult> comparer)
@@ -1587,7 +1587,7 @@ internal static class ReadOnlyListExtensions
     /// <param name="comparison">An <see cref="Comparison{T}"/> to compare elements.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
-    ///  on each element of <paramref name="list"/> and sorted in decending order.
+    ///  on each element of <paramref name="list"/> and sorted in descending order.
     /// </returns>
     public static ImmutableArray<TResult> SelectAndOrderDescendingAsArray<T, TResult>(
         this IReadOnlyList<T> list, Func<T, TResult> selector, Comparison<TResult> comparison)

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/SpanExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/SpanExtensions.cs
@@ -80,4 +80,48 @@ internal static class SpanExtensions
         where T : IEquatable<T>? =>
         span.Length != 0 && (span[^1]?.Equals(value) ?? (object?)value is null);
 #endif
+
+    extension<T>(Span<T> span)
+    {
+        public ReversedEnumerable<T> Reversed => new(span);
+    }
+
+    extension<T>(ReadOnlySpan<T> span)
+    {
+        public ReversedEnumerable<T> Reversed => new(span);
+    }
+
+    public readonly ref struct ReversedEnumerable<T>(ReadOnlySpan<T> span)
+    {
+        private readonly ReadOnlySpan<T> _span = span;
+
+        public ReverseEnumerator<T> GetEnumerator() => new(_span);
+    }
+
+    public ref struct ReverseEnumerator<T>(ReadOnlySpan<T> span)
+    {
+        private readonly ReadOnlySpan<T> _span = span;
+        private int _index = span.Length - 1;
+        private T _current = default!;
+
+        public readonly T Current => _current;
+
+        public bool MoveNext()
+        {
+            if (_index >= 0)
+            {
+                _current = _span[_index];
+                _index--;
+                return true;
+            }
+
+            return false;
+        }
+
+        public void Reset()
+        {
+            _index = _span.Length - 1;
+            _current = default!;
+        }
+    }
 }


### PR DESCRIPTION
This change adds a new Roslyn analyzer that flags calls to methods defined by Razor's `EnumerableExtensions` and `ReadOnlyListExtensions` that box `ImmutableArray<T>`. This immediately reported several diagnostics, which were fixed by adding new extension methods that target `ImmutableArray<T>` or calling existing extension methods. In addition, this pull request fleshes out a handful helper APIs. The commits should be self-explanatory.