### PR TITLE
Allow cohosting to be used when files aren't in projects

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/CapabilityCheckResult.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/CapabilityCheckResult.cs
@@ -1,0 +1,6 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.VisualStudio.Razor;
+
+internal record struct CapabilityCheckResult(bool IsInProject, bool HasCapability);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ILspEditorFeatureDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ILspEditorFeatureDetector.cs
@@ -19,7 +19,7 @@ internal interface ILspEditorFeatureDetector
     /// <summary>
     /// Determines whether the project containing the given document is a .NET Core project.
     /// </summary>
-    bool IsDotNetCoreProject(string documentFilePath);
+    CapabilityCheckResult IsDotNetCoreProject(string documentFilePath);
 
     /// <summary>
     /// A remote client is a LiveShare guest or a Codespaces instance

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/IProjectCapabilityResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/IProjectCapabilityResolver.cs
@@ -8,5 +8,5 @@ internal interface IProjectCapabilityResolver
     /// <summary>
     /// Determines whether the project associated with the specified document has the given <paramref name="capability"/>.
     /// </summary>
-    bool ResolveCapability(string capability, string documentFilePath);
+    CapabilityCheckResult CheckCapability(string capability, string documentFilePath);
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/RazorFilePathToContentTypeProviderBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/RazorFilePathToContentTypeProviderBase.cs
@@ -31,9 +31,11 @@ internal abstract class RazorFilePathToContentTypeProviderBase(
     private bool UseLSPEditor(string filePath)
     {
         // When cohosting is on, it's on for all non .NET Framework projects, regardless of feature flags or
-        // project capabilities.
+        // project capabilities. If the file is not in a project (e.g. loose files, left side of diff), we
+        // also want to use the LSP editor, even though the .NET capability check would fail.
         if (_options.UseRazorCohostServer &&
-            _lspEditorFeatureDetector.IsDotNetCoreProject(filePath))
+            _lspEditorFeatureDetector.IsDotNetCoreProject(filePath) is { } check &&
+            (!check.IsInProject || check.HasCapability))
         {
             return true;
         }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostEndpointTest.cs
@@ -170,7 +170,7 @@ public class CohostEndpointTest(ITestOutputHelper testOutputHelper) : ToolingTes
         public bool IsLiveShareHost() => throw new NotImplementedException();
         public bool IsLspEditorEnabled() => throw new NotImplementedException();
         public bool IsLspEditorSupported(string documentFilePath) => throw new NotImplementedException();
-        public bool IsDotNetCoreProject(string documentFilePath) => throw new NotImplementedException();
+        public CapabilityCheckResult IsDotNetCoreProject(string documentFilePath) => throw new NotImplementedException();
         public bool IsRemoteClient() => throw new NotImplementedException();
     }
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LspEditorFeatureDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LspEditorFeatureDetectorTest.cs
@@ -183,11 +183,11 @@ public class LspEditorFeatureDetectorTest(ITestOutputHelper testOutput) : Toolin
         var projectCapabilityResolverMock = new StrictMock<IProjectCapabilityResolver>();
 
         projectCapabilityResolverMock
-            .Setup(x => x.ResolveCapability(WellKnownProjectCapabilities.LegacyRazorEditor, It.IsAny<string>()))
-            .Returns(hasLegacyRazorEditorCapability);
+            .Setup(x => x.CheckCapability(WellKnownProjectCapabilities.LegacyRazorEditor, It.IsAny<string>()))
+            .Returns(new CapabilityCheckResult(IsInProject: true, HasCapability: hasLegacyRazorEditorCapability));
         projectCapabilityResolverMock
-            .Setup(x => x.ResolveCapability(WellKnownProjectCapabilities.DotNetCoreCSharp, It.IsAny<string>()))
-            .Returns(hasDotNetCoreCSharpCapability);
+            .Setup(x => x.CheckCapability(WellKnownProjectCapabilities.DotNetCoreCSharp, It.IsAny<string>()))
+            .Returns(new CapabilityCheckResult(IsInProject: true, HasCapability: hasDotNetCoreCSharpCapability));
 
         return projectCapabilityResolverMock.Object;
     }


### PR DESCRIPTION
Makes misc files in VS open with cohosting, when it's on, including the left side of the diff window.

The key here is simply that we can only check for the ".NET Core" capability, but loose files have no capabilities at all, so we have to detect that case specifically.