### PR TITLE
Fix extra character insertion during attribute completion in VS Code

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -78,7 +78,7 @@ internal class RazorCompletionEndpoint(
                 SnippetsSupported: true,
                 AutoInsertAttributeQuotes: options.AutoInsertAttributeQuotes,
                 CommitElementsWithSpace: options.CommitElementsWithSpace,
-                UseVsCodeCompletionTriggerCharacters: _featureOptions.UseVsCodeCompletionTriggerCharacters);
+                UseVsCodeCompletionCommitCharacters: _featureOptions.UseVsCodeCompletionCommitCharacters);
 
             var result = await _completionListProvider
                 .GetCompletionListAsync(

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -19,13 +19,15 @@ internal class RazorCompletionEndpoint(
     CompletionListProvider completionListProvider,
     CompletionTriggerAndCommitCharacters triggerAndCommitCharacters,
     ITelemetryReporter telemetryReporter,
-    RazorLSPOptionsMonitor optionsMonitor)
+    RazorLSPOptionsMonitor optionsMonitor,
+    LanguageServerFeatureOptions featureOptions)
     : IRazorRequestHandler<CompletionParams, RazorVSInternalCompletionList?>, ICapabilitiesProvider
 {
     private readonly CompletionListProvider _completionListProvider = completionListProvider;
     private readonly CompletionTriggerAndCommitCharacters _triggerAndCommitCharacters = triggerAndCommitCharacters;
     private readonly ITelemetryReporter _telemetryReporter = telemetryReporter;
     private readonly RazorLSPOptionsMonitor _optionsMonitor = optionsMonitor;
+    private readonly LanguageServerFeatureOptions _featureOptions = featureOptions;
 
     private VSInternalClientCapabilities? _clientCapabilities;
 
@@ -75,7 +77,8 @@ internal class RazorCompletionEndpoint(
             var razorCompletionOptions = new RazorCompletionOptions(
                 SnippetsSupported: true,
                 AutoInsertAttributeQuotes: options.AutoInsertAttributeQuotes,
-                CommitElementsWithSpace: options.CommitElementsWithSpace);
+                CommitElementsWithSpace: options.CommitElementsWithSpace,
+                UseVsCodeCompletionTriggerCharacters: _featureOptions.UseVsCodeCompletionTriggerCharacters);
 
             var result = await _completionListProvider
                 .GetCompletionListAsync(

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
@@ -35,7 +35,7 @@ internal class DefaultLanguageServerFeatureOptions : LanguageServerFeatureOption
 
     public override bool SupportsSoftSelectionInCompletion => true;
 
-    public override bool UseVsCodeCompletionTriggerCharacters => false;
+    public override bool UseVsCodeCompletionCommitCharacters => false;
 
     public override bool DoNotInitializeMiscFilesProjectFromWorkspace => false;
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hosting/ConfigurableLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hosting/ConfigurableLanguageServerFeatureOptions.cs
@@ -33,7 +33,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     public override bool IncludeProjectKeyInGeneratedFilePath => _includeProjectKeyInGeneratedFilePath ?? _defaults.IncludeProjectKeyInGeneratedFilePath;
     public override bool UseRazorCohostServer => _useRazorCohostServer ?? _defaults.UseRazorCohostServer;
     public override bool SupportsSoftSelectionInCompletion => false;
-    public override bool UseVsCodeCompletionTriggerCharacters => true;
+    public override bool UseVsCodeCompletionCommitCharacters => true;
 
     // Note: This option is defined in the negative because the default behavior should be to add documents to misc files project
     // when the language server is initialized. Adding the option at the command-line should disable that behavior.

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
@@ -53,6 +53,7 @@ internal sealed class CohostDocumentCompletionEndpoint(
     private readonly IClientCapabilitiesService _clientCapabilitiesService = clientCapabilitiesService;
     private readonly ISnippetCompletionItemProvider? _snippetCompletionItemProvider = snippetCompletionItemProvider;
     private readonly CompletionTriggerAndCommitCharacters _triggerAndCommitCharacters = new(languageServerFeatureOptions);
+    private readonly LanguageServerFeatureOptions _languageServerFeatureOptions = languageServerFeatureOptions;
     private readonly IHtmlRequestInvoker _requestInvoker = requestInvoker;
     private readonly CompletionListCache _completionListCache = completionListCache;
     private readonly ITelemetryReporter _telemetryReporter = telemetryReporter;
@@ -142,7 +143,8 @@ internal sealed class CohostDocumentCompletionEndpoint(
         var razorCompletionOptions = new RazorCompletionOptions(
             SnippetsSupported: true, // always true in non-legacy Razor, always false in legacy Razor
             AutoInsertAttributeQuotes: clientSettings.AdvancedSettings.AutoInsertAttributeQuotes,
-            CommitElementsWithSpace: clientSettings.AdvancedSettings.CommitElementsWithSpace);
+            CommitElementsWithSpace: clientSettings.AdvancedSettings.CommitElementsWithSpace,
+            UseVsCodeCompletionTriggerCharacters: _languageServerFeatureOptions.UseVsCodeCompletionTriggerCharacters);
         using var _ = HashSetPool<string>.GetPooledObject(out var existingHtmlCompletions);
 
         if (_triggerAndCommitCharacters.IsValidHtmlTrigger(completionContext))

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
@@ -144,7 +144,7 @@ internal sealed class CohostDocumentCompletionEndpoint(
             SnippetsSupported: true, // always true in non-legacy Razor, always false in legacy Razor
             AutoInsertAttributeQuotes: clientSettings.AdvancedSettings.AutoInsertAttributeQuotes,
             CommitElementsWithSpace: clientSettings.AdvancedSettings.CommitElementsWithSpace,
-            UseVsCodeCompletionTriggerCharacters: _languageServerFeatureOptions.UseVsCodeCompletionTriggerCharacters);
+            UseVsCodeCompletionCommitCharacters: _languageServerFeatureOptions.UseVsCodeCompletionCommitCharacters);
         using var _ = HashSetPool<string>.GetPooledObject(out var existingHtmlCompletions);
 
         if (_triggerAndCommitCharacters.IsValidHtmlTrigger(completionContext))

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionTriggerAndCommitCharacters.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionTriggerAndCommitCharacters.cs
@@ -44,7 +44,9 @@ internal class CompletionTriggerAndCommitCharacters
         // HTML trigger characters (include '@' + HTML trigger characters)
         var htmlTriggerCharacters = new HashSet<char>() { TransitionCharacter };
 
-        if (languageServerFeatureOptions.UseVsCodeCompletionTriggerCharacters)
+        // In VS Code we want to use a smaller set of Html trigger characters, and rather than have another
+        // flag for it, we can just re-use the flag we have for commit characters
+        if (languageServerFeatureOptions.UseVsCodeCompletionCommitCharacters)
         {
             htmlTriggerCharacters.UnionWith(s_vsCodeHtmlTriggerCharacters);
         }
@@ -75,7 +77,7 @@ internal class CompletionTriggerAndCommitCharacters
         // We shouldn't specify commit characters for VSCode.
         // It doesn't appear to need them and they interfere with normal item commit.
         // E.g. see https://github.com/dotnet/vscode-csharp/issues/7678
-        AllCommitCharacters = languageServerFeatureOptions.UseVsCodeCompletionTriggerCharacters ? [] : s_commitCharacters;
+        AllCommitCharacters = languageServerFeatureOptions.UseVsCodeCompletionCommitCharacters ? [] : s_commitCharacters;
         AllTriggerCharacters = allTriggerCharacters.SelectAsArray(static c => c.ToString());
     }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
@@ -232,7 +232,7 @@ internal class DirectiveAttributeCompletionItemProvider : DirectiveAttributeComp
                 return;
             }
 
-            if (!razorCompletionOptions.UseVsCodeCompletionTriggerCharacters)
+            if (!razorCompletionOptions.UseVsCodeCompletionCommitCharacters)
             {
                 // We don't add "=" as a commit character when using VSCode trigger characters.
                 commitCharacters.Add("=");

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
@@ -95,7 +95,7 @@ internal class DirectiveAttributeCompletionItemProvider : DirectiveAttributeComp
                     continue;
                 }
 
-                if (!TryAddCompletion(attributeDescriptor.Name, attributeDescriptor, descriptor) && attributeDescriptor.Parameters.Length > 0)
+                if (!TryAddCompletion(attributeDescriptor.Name, attributeDescriptor, descriptor, razorCompletionOptions) && attributeDescriptor.Parameters.Length > 0)
                 {
                     // This attribute has parameters and the base attribute name (@bind) is already satisfied. We need to check if there are any valid
                     // parameters left to be provided, if so, we need to still represent the base attribute name in the completion list.
@@ -105,7 +105,7 @@ internal class DirectiveAttributeCompletionItemProvider : DirectiveAttributeComp
                         if (!attributes.Any(name => TagHelperMatchingConventions.SatisfiesBoundAttributeWithParameter(parameterDescriptor, name, attributeDescriptor)))
                         {
                             // This bound attribute parameter has not had a completion entry added for it, re-represent the base attribute name in the completion list
-                            AddCompletion(attributeDescriptor.Name, attributeDescriptor, descriptor);
+                            AddCompletion(attributeDescriptor.Name, attributeDescriptor, descriptor, razorCompletionOptions);
                             break;
                         }
                     }
@@ -113,7 +113,7 @@ internal class DirectiveAttributeCompletionItemProvider : DirectiveAttributeComp
 
                 if (!attributeDescriptor.IndexerNamePrefix.IsNullOrEmpty())
                 {
-                    TryAddCompletion(attributeDescriptor.IndexerNamePrefix + "...", attributeDescriptor, descriptor);
+                    TryAddCompletion(attributeDescriptor.IndexerNamePrefix + "...", attributeDescriptor, descriptor, razorCompletionOptions);
                 }
             }
         }
@@ -197,7 +197,7 @@ internal class DirectiveAttributeCompletionItemProvider : DirectiveAttributeComp
             return false;
         }
 
-        bool TryAddCompletion(string attributeName, BoundAttributeDescriptor boundAttributeDescriptor, TagHelperDescriptor tagHelperDescriptor)
+        bool TryAddCompletion(string attributeName, BoundAttributeDescriptor boundAttributeDescriptor, TagHelperDescriptor tagHelperDescriptor, RazorCompletionOptions razorCompletionOptions)
         {
             if (selectedAttributeName != attributeName &&
                 attributes.Any(attributeName, static (name, attributeName) => name == attributeName))
@@ -207,11 +207,11 @@ internal class DirectiveAttributeCompletionItemProvider : DirectiveAttributeComp
                 return false;
             }
 
-            AddCompletion(attributeName, boundAttributeDescriptor, tagHelperDescriptor);
+            AddCompletion(attributeName, boundAttributeDescriptor, tagHelperDescriptor, razorCompletionOptions);
             return true;
         }
 
-        void AddCompletion(string attributeName, BoundAttributeDescriptor boundAttributeDescriptor, TagHelperDescriptor tagHelperDescriptor)
+        void AddCompletion(string attributeName, BoundAttributeDescriptor boundAttributeDescriptor, TagHelperDescriptor tagHelperDescriptor, RazorCompletionOptions razorCompletionOptions)
         {
             if (!attributeCompletions.TryGetValue(attributeName, out var attributeDetails))
             {
@@ -232,7 +232,11 @@ internal class DirectiveAttributeCompletionItemProvider : DirectiveAttributeComp
                 return;
             }
 
-            commitCharacters.Add("=");
+            if (!razorCompletionOptions.UseVsCodeCompletionTriggerCharacters)
+            {
+                // We don't add "=" as a commit character when using VSCode trigger characters.
+                commitCharacters.Add("=");
+            }
 
             var spaceAdded = commitCharacters.Contains(" ");
             var colonAdded = commitCharacters.Contains(":");

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionOptions.cs
@@ -6,4 +6,5 @@ namespace Microsoft.CodeAnalysis.Razor.Completion;
 internal record struct RazorCompletionOptions(
     bool SnippetsSupported,
     bool AutoInsertAttributeQuotes,
-    bool CommitElementsWithSpace);
+    bool CommitElementsWithSpace,
+    bool UseVsCodeCompletionTriggerCharacters);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionOptions.cs
@@ -7,4 +7,4 @@ internal record struct RazorCompletionOptions(
     bool SnippetsSupported,
     bool AutoInsertAttributeQuotes,
     bool CommitElementsWithSpace,
-    bool UseVsCodeCompletionTriggerCharacters);
+    bool UseVsCodeCompletionCommitCharacters);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionProvider.cs
@@ -152,7 +152,7 @@ internal class TagHelperCompletionProvider(ITagHelperCompletionService tagHelper
             }
 
             var attributeContext = ResolveAttributeContext(boundAttributes, isIndexer, options.SnippetsSupported);
-            var attributeCommitCharacters = options.UseVsCodeCompletionTriggerCharacters ? [] : ResolveAttributeCommitCharacters(attributeContext);
+            var attributeCommitCharacters = options.UseVsCodeCompletionCommitCharacters ? [] : ResolveAttributeCommitCharacters(attributeContext);
             var isSnippet = false;
             var insertText = filterText;
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionProvider.cs
@@ -152,7 +152,7 @@ internal class TagHelperCompletionProvider(ITagHelperCompletionService tagHelper
             }
 
             var attributeContext = ResolveAttributeContext(boundAttributes, isIndexer, options.SnippetsSupported);
-            var attributeCommitCharacters = ResolveAttributeCommitCharacters(attributeContext);
+            var attributeCommitCharacters = options.UseVsCodeCompletionTriggerCharacters ? [] : ResolveAttributeCommitCharacters(attributeContext);
             var isSnippet = false;
             var insertText = filterText;
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -40,7 +40,7 @@ internal abstract class LanguageServerFeatureOptions
     /// <summary>
     /// Indicates that VSCode-compatible completion trigger character set should be used
     /// </summary>
-    public abstract bool UseVsCodeCompletionTriggerCharacters { get; }
+    public abstract bool UseVsCodeCompletionCommitCharacters { get; }
 
     /// <summary>
     /// Indicates whether the language server's miscellanous files project will be initialized with

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteClientInitializationOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteClientInitializationOptions.cs
@@ -25,6 +25,6 @@ internal struct RemoteClientInitializationOptions
     [JsonPropertyName("supportsSoftSelectionInCompletion")]
     public required bool SupportsSoftSelectionInCompletion { get; set; }
 
-    [JsonPropertyName("useVSCodeCompletionTriggerCharacters")]
-    public required bool UseVsCodeCompletionTriggerCharacters { get; set; }
+    [JsonPropertyName("UseVsCodeCompletionCommitCharacters")]
+    public required bool UseVsCodeCompletionCommitCharacters { get; set; }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/SemanticTokens/AbstractRazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/SemanticTokens/AbstractRazorSemanticTokensInfoService.cs
@@ -43,7 +43,7 @@ internal abstract class AbstractRazorSemanticTokensInfoService(
 
         var amount = semanticTokens is null ? "no" : (semanticTokens.Length / TokenSize).ToString(Thread.CurrentThread.CurrentCulture);
 
-        _logger.LogInformation($"Returned {amount} semantic tokens for span {span} in {documentContext.Uri}.");
+        _logger.LogDebug($"Returned {amount} semantic tokens for span {span} in {documentContext.Uri}.");
 
         if (semanticTokens is not null)
         {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Initialization/RemoteLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Initialization/RemoteLanguageServerFeatureOptions.cs
@@ -46,7 +46,7 @@ internal class RemoteLanguageServerFeatureOptions : LanguageServerFeatureOptions
 
     public override bool SupportsSoftSelectionInCompletion => _options.SupportsSoftSelectionInCompletion;
 
-    public override bool UseVsCodeCompletionTriggerCharacters => _options.UseVsCodeCompletionTriggerCharacters;
+    public override bool UseVsCodeCompletionCommitCharacters => _options.UseVsCodeCompletionCommitCharacters;
 
     public override bool DoNotInitializeMiscFilesProjectFromWorkspace => throw new NotImplementedException("This option has not been synced to OOP.");
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceInvoker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceInvoker.cs
@@ -185,7 +185,7 @@ internal sealed class RemoteServiceInvoker(
                     SupportsFileManipulation = _languageServerFeatureOptions.SupportsFileManipulation,
                     ShowAllCSharpCodeActions = _languageServerFeatureOptions.ShowAllCSharpCodeActions,
                     SupportsSoftSelectionInCompletion = _languageServerFeatureOptions.SupportsSoftSelectionInCompletion,
-                    UseVsCodeCompletionTriggerCharacters = _languageServerFeatureOptions.UseVsCodeCompletionTriggerCharacters,
+                    UseVsCodeCompletionCommitCharacters = _languageServerFeatureOptions.UseVsCodeCompletionCommitCharacters,
                 };
 
                 _logger.LogDebug($"First OOP call, so initializing OOP service.");

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioLanguageServerFeatureOptions.cs
@@ -75,7 +75,7 @@ internal class VisualStudioLanguageServerFeatureOptions : LanguageServerFeatureO
     // VS actually needs explicit commit characters so don't avoid them.
     public override bool SupportsSoftSelectionInCompletion => true;
 
-    public override bool UseVsCodeCompletionTriggerCharacters => false;
+    public override bool UseVsCodeCompletionCommitCharacters => false;
 
     // In VS, we do not want the language server to add all documents in the workspace root path
     // to the misc-files project when initialized.

--- a/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Services/VSCodeLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Services/VSCodeLanguageServerFeatureOptions.cs
@@ -39,7 +39,7 @@ internal class VSCodeLanguageServerFeatureOptions(RazorClientServerManagerProvid
     public override bool UpdateBuffersForClosedDocuments => true;
     public override bool DelegateToCSharpOnDiagnosticPublish => true;
     public override bool SupportsSoftSelectionInCompletion => false;
-    public override bool UseVsCodeCompletionTriggerCharacters => true;
+    public override bool UseVsCodeCompletionCommitCharacters => true;
 
     // User configurable options
     public override bool UseRazorCohostServer => _useRazorCohostServer;

--- a/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Services/VSCodeRemoteServicesInitializer.cs
+++ b/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Services/VSCodeRemoteServicesInitializer.cs
@@ -59,7 +59,7 @@ internal class VSCodeRemoteServicesInitializer(
             SupportsFileManipulation = _featureOptions.SupportsFileManipulation,
             ShowAllCSharpCodeActions = _featureOptions.ShowAllCSharpCodeActions,
             SupportsSoftSelectionInCompletion = _featureOptions.SupportsSoftSelectionInCompletion,
-            UseVsCodeCompletionTriggerCharacters = _featureOptions.UseVsCodeCompletionTriggerCharacters,
+            UseVsCodeCompletionCommitCharacters = _featureOptions.UseVsCodeCompletionCommitCharacters,
         }, cancellationToken).ConfigureAwait(false);
 
         await service.InitializeLSPAsync(new RemoteClientLSPInitializationOptions

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/CompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/CompletionListProviderTest.cs
@@ -41,7 +41,7 @@ public class CompletionListProviderTest : LanguageServerTestBase
         _completionContext = new VSInternalCompletionContext();
         _documentContext = TestDocumentContext.Create("C:/path/to/file.cshtml");
         _clientCapabilities = new VSInternalClientCapabilities();
-        _razorCompletionOptions = new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, UseVsCodeCompletionTriggerCharacters: false);
+        _razorCompletionOptions = new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, UseVsCodeCompletionCommitCharacters: false);
         _triggerAndCommitCharacters = new(TestLanguageServerFeatureOptions.Instance);
     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/CompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/CompletionListProviderTest.cs
@@ -41,7 +41,7 @@ public class CompletionListProviderTest : LanguageServerTestBase
         _completionContext = new VSInternalCompletionContext();
         _documentContext = TestDocumentContext.Create("C:/path/to/file.cshtml");
         _clientCapabilities = new VSInternalClientCapabilities();
-        _razorCompletionOptions = new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true);
+        _razorCompletionOptions = new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, UseVsCodeCompletionTriggerCharacters: false);
         _triggerAndCommitCharacters = new(TestLanguageServerFeatureOptions.Instance);
     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.NetFx.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.NetFx.cs
@@ -60,7 +60,8 @@ public class DelegatedCompletionItemResolverTest : CompletionTestBase
     private static readonly RazorCompletionOptions s_defaultRazorCompletionOptions = new(
         SnippetsSupported: true,
         AutoInsertAttributeQuotes: true,
-        CommitElementsWithSpace: true);
+        CommitElementsWithSpace: true,
+        UseVsCodeCompletionTriggerCharacters: false);
 
     private readonly DelegatedCompletionParams _csharpCompletionParams;
     private readonly DelegatedCompletionParams _htmlCompletionParams;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.NetFx.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.NetFx.cs
@@ -61,7 +61,7 @@ public class DelegatedCompletionItemResolverTest : CompletionTestBase
         SnippetsSupported: true,
         AutoInsertAttributeQuotes: true,
         CommitElementsWithSpace: true,
-        UseVsCodeCompletionTriggerCharacters: false);
+        UseVsCodeCompletionCommitCharacters: false);
 
     private readonly DelegatedCompletionParams _csharpCompletionParams;
     private readonly DelegatedCompletionParams _htmlCompletionParams;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
@@ -22,7 +22,8 @@ public class DelegatedCompletionListProviderTest : CompletionTestBase
     private static readonly RazorCompletionOptions s_defaultRazorCompletionOptions = new(
         SnippetsSupported: true,
         AutoInsertAttributeQuotes: true,
-        CommitElementsWithSpace: true);
+        CommitElementsWithSpace: true,
+        UseVsCodeCompletionTriggerCharacters: false);
 
     private static readonly VSInternalClientCapabilities s_clientCapabilities = new();
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
@@ -23,7 +23,7 @@ public class DelegatedCompletionListProviderTest : CompletionTestBase
         SnippetsSupported: true,
         AutoInsertAttributeQuotes: true,
         CommitElementsWithSpace: true,
-        UseVsCodeCompletionTriggerCharacters: false);
+        UseVsCodeCompletionCommitCharacters: false);
 
     private static readonly VSInternalClientCapabilities s_clientCapabilities = new();
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/HtmlCommitCharacterResponseRewriterTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/HtmlCommitCharacterResponseRewriterTest.cs
@@ -70,7 +70,7 @@ public class HtmlCommitCharacterResponseRewriterTest(ITestOutputHelper testOutpu
                 SnippetsSupported: true,
                 AutoInsertAttributeQuotes: true,
                 CommitElementsWithSpace: false,
-                UseVsCodeCompletionTriggerCharacters: false);
+                UseVsCodeCompletionCommitCharacters: false);
 
         // Act
         var rewrittenCompletionList = await GetRewrittenCompletionListAsync(
@@ -121,7 +121,7 @@ public class HtmlCommitCharacterResponseRewriterTest(ITestOutputHelper testOutpu
             SnippetsSupported: true,
             AutoInsertAttributeQuotes: true,
             CommitElementsWithSpace: false,
-            UseVsCodeCompletionTriggerCharacters: false);
+            UseVsCodeCompletionCommitCharacters: false);
         var rewriter = new HtmlCommitCharacterResponseRewriter();
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/HtmlCommitCharacterResponseRewriterTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/HtmlCommitCharacterResponseRewriterTest.cs
@@ -69,7 +69,8 @@ public class HtmlCommitCharacterResponseRewriterTest(ITestOutputHelper testOutpu
         var razorCompletionOptions = new RazorCompletionOptions(
                 SnippetsSupported: true,
                 AutoInsertAttributeQuotes: true,
-                CommitElementsWithSpace: false);
+                CommitElementsWithSpace: false,
+                UseVsCodeCompletionTriggerCharacters: false);
 
         // Act
         var rewrittenCompletionList = await GetRewrittenCompletionListAsync(
@@ -119,7 +120,8 @@ public class HtmlCommitCharacterResponseRewriterTest(ITestOutputHelper testOutpu
         var razorCompletionOptions = new RazorCompletionOptions(
             SnippetsSupported: true,
             AutoInsertAttributeQuotes: true,
-            CommitElementsWithSpace: false);
+            CommitElementsWithSpace: false,
+            UseVsCodeCompletionTriggerCharacters: false);
         var rewriter = new HtmlCommitCharacterResponseRewriter();
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/ResponseRewriterTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/ResponseRewriterTestBase.cs
@@ -19,7 +19,8 @@ public abstract class ResponseRewriterTestBase(ITestOutputHelper testOutput) : C
         var razorCompletionOptions = new RazorCompletionOptions(
             SnippetsSupported: true,
             AutoInsertAttributeQuotes: true,
-            CommitElementsWithSpace: true);
+            CommitElementsWithSpace: true,
+            UseVsCodeCompletionTriggerCharacters: false);
 
         return GetRewrittenCompletionListAsync(absoluteIndex, documentContent, initialCompletionList, razorCompletionOptions);
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/ResponseRewriterTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/ResponseRewriterTestBase.cs
@@ -20,7 +20,7 @@ public abstract class ResponseRewriterTestBase(ITestOutputHelper testOutput) : C
             SnippetsSupported: true,
             AutoInsertAttributeQuotes: true,
             CommitElementsWithSpace: true,
-            UseVsCodeCompletionTriggerCharacters: false);
+            UseVsCodeCompletionCommitCharacters: false);
 
         return GetRewrittenCompletionListAsync(absoluteIndex, documentContent, initialCompletionList, razorCompletionOptions);
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -7,6 +7,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
+using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.CodeAnalysis.Razor.Telemetry;
 using Xunit;
 using Xunit.Abstractions;
@@ -21,7 +22,7 @@ public class RazorCompletionEndpointTest(ITestOutputHelper testOutput) : Languag
         // Arrange
         var documentPath = "C:/path/to/document.cshtml";
         var optionsMonitor = GetOptionsMonitor();
-        var completionEndpoint = new RazorCompletionEndpoint(completionListProvider: null, triggerAndCommitCharacters: null, NoOpTelemetryReporter.Instance, optionsMonitor);
+        var completionEndpoint = new RazorCompletionEndpoint(completionListProvider: null, triggerAndCommitCharacters: null, NoOpTelemetryReporter.Instance, optionsMonitor, TestLanguageServerFeatureOptions.Instance);
         var request = new CompletionParams()
         {
             TextDocument = new TextDocumentIdentifier()
@@ -49,7 +50,7 @@ public class RazorCompletionEndpointTest(ITestOutputHelper testOutput) : Languag
         var uri = new Uri(documentPath);
         var documentContext = CreateDocumentContext(uri, codeDocument);
         var optionsMonitor = GetOptionsMonitor(autoShowCompletion: false);
-        var completionEndpoint = new RazorCompletionEndpoint(completionListProvider: null, triggerAndCommitCharacters: null, NoOpTelemetryReporter.Instance, optionsMonitor);
+        var completionEndpoint = new RazorCompletionEndpoint(completionListProvider: null, triggerAndCommitCharacters: null, NoOpTelemetryReporter.Instance, optionsMonitor, TestLanguageServerFeatureOptions.Instance);
         var request = new CompletionParams()
         {
             TextDocument = new TextDocumentIdentifier()

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
@@ -348,7 +348,7 @@ public class TagHelperCompletionProviderTest(ITestOutputHelper testOutput) : Tag
     {
         // Arrange
         var service = CreateTagHelperCompletionProvider();
-        var options = new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, UseVsCodeCompletionTriggerCharacters: false);
+        var options = new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, UseVsCodeCompletionCommitCharacters: false);
         var context = CreateRazorCompletionContext(
             """
                 @addTagHelper *, TestAssembly
@@ -442,7 +442,7 @@ public class TagHelperCompletionProviderTest(ITestOutputHelper testOutput) : Tag
     public void GetCompletionAt_InBody_WithoutSpace_ReturnsCompletions()
     {
         // Arrange
-        var options = new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: false, UseVsCodeCompletionTriggerCharacters: false);
+        var options = new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: false, UseVsCodeCompletionCommitCharacters: false);
         var service = new TagHelperCompletionProvider(CreateTagHelperCompletionService());
 
         var context = CreateRazorCompletionContext(
@@ -840,7 +840,7 @@ public class TagHelperCompletionProviderTest(ITestOutputHelper testOutput) : Tag
                 <test2 int-$$val=''>
                 """,
             isRazorFile: false,
-            options: new(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, UseVsCodeCompletionTriggerCharacters: false),
+            options: new(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, UseVsCodeCompletionCommitCharacters: false),
             tagHelpers: DefaultTagHelpers);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
@@ -348,7 +348,7 @@ public class TagHelperCompletionProviderTest(ITestOutputHelper testOutput) : Tag
     {
         // Arrange
         var service = CreateTagHelperCompletionProvider();
-        var options = new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true);
+        var options = new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, UseVsCodeCompletionTriggerCharacters: false);
         var context = CreateRazorCompletionContext(
             """
                 @addTagHelper *, TestAssembly
@@ -442,7 +442,7 @@ public class TagHelperCompletionProviderTest(ITestOutputHelper testOutput) : Tag
     public void GetCompletionAt_InBody_WithoutSpace_ReturnsCompletions()
     {
         // Arrange
-        var options = new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: false);
+        var options = new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: false, UseVsCodeCompletionTriggerCharacters: false);
         var service = new TagHelperCompletionProvider(CreateTagHelperCompletionService());
 
         var context = CreateRazorCompletionContext(
@@ -840,7 +840,7 @@ public class TagHelperCompletionProviderTest(ITestOutputHelper testOutput) : Tag
                 <test2 int-$$val=''>
                 """,
             isRazorFile: false,
-            options: new(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true),
+            options: new(SnippetsSupported: true, AutoInsertAttributeQuotes: true, CommitElementsWithSpace: true, UseVsCodeCompletionTriggerCharacters: false),
             tagHelpers: DefaultTagHelpers);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Cohosting/CohostTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Cohosting/CohostTestBase.cs
@@ -85,7 +85,7 @@ public abstract class CohostTestBase(ITestOutputHelper testOutputHelper) : Tooli
             SupportsFileManipulation = true,
             ShowAllCSharpCodeActions = false,
             SupportsSoftSelectionInCompletion = true,
-            UseVsCodeCompletionTriggerCharacters = false,
+            UseVsCodeCompletionCommitCharacters = false,
         };
         UpdateClientInitializationOptions(c => c);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
@@ -36,7 +36,7 @@ internal class TestLanguageServerFeatureOptions(
 
     public override bool SupportsSoftSelectionInCompletion => supportsSoftSelectionInCompletion;
 
-    public override bool UseVsCodeCompletionTriggerCharacters => vsCodeCompletionTriggerCharacters;
+    public override bool UseVsCodeCompletionCommitCharacters => vsCodeCompletionTriggerCharacters;
 
     public override bool DoNotInitializeMiscFilesProjectFromWorkspace => doNotInitializeMiscFilesProjectWithWorkspaceFiles;
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/Shared/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/Shared/CohostDocumentCompletionEndpointTest.cs
@@ -697,7 +697,37 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
             autoInsertAttributeQuotes: false);
     }
 
-    private async Task VerifyCompletionListAsync(
+    [Fact]
+    public async Task TagHelperAttributes_NoCommitChars_VSCode()
+    {
+        UpdateClientInitializationOptions(c =>
+        {
+            c.UseVsCodeCompletionTriggerCharacters = true;
+            return c;
+        });
+
+        var list = await VerifyCompletionListAsync(
+            input: """
+                This is a Razor document.
+
+                <EditForm $$></EditForm>
+
+                The end.
+                """,
+            completionContext: new VSInternalCompletionContext()
+            {
+                InvokeKind = VSInternalCompletionInvokeKind.Explicit,
+                TriggerKind = CompletionTriggerKind.Invoked
+            },
+            expectedItemLabels: ["FormName", "OnValidSubmit", "@...", "style"],
+            htmlItemLabels: ["style"],
+            autoInsertAttributeQuotes: false,
+            useVsCodeCompletionTriggerCharacters: true);
+
+        Assert.All(list.Items, item => Assert.DoesNotContain("=", item.CommitCharacters ?? []));
+    }
+
+    private async Task<RazorVSInternalCompletionList> VerifyCompletionListAsync(
         TestCode input,
         VSInternalCompletionContext completionContext,
         string[] expectedItemLabels,
@@ -710,6 +740,7 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
         string? expectedResolvedItemDescription = null,
         bool autoInsertAttributeQuotes = true,
         bool commitElementsWithSpace = true,
+        bool useVsCodeCompletionTriggerCharacters = false,
         RazorFileKind? fileKind = null)
     {
         var document = CreateProjectAndRazorDocument(input.Text, fileKind);
@@ -746,6 +777,8 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
         snippetCompletionItemProvider.SnippetCache.Update(SnippetLanguage.Html, snippetInfos);
 #endif
 
+        var languageServerFeatureOptions = new TestLanguageServerFeatureOptions(vsCodeCompletionTriggerCharacters: useVsCodeCompletionTriggerCharacters);
+
         var completionListCache = new CompletionListCache();
         var endpoint = new CohostDocumentCompletionEndpoint(
             IncompatibleProjectService,
@@ -753,7 +786,7 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
             ClientSettingsManager,
             ClientCapabilitiesService,
             snippetCompletionItemProvider,
-            TestLanguageServerFeatureOptions.Instance,
+            languageServerFeatureOptions,
             requestInvoker,
             completionListCache,
             NoOpTelemetryReporter.Instance,
@@ -805,21 +838,21 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
             Assert.False(result.Items.Any(item => item.InsertText?.Contains("\"$0\"") ?? false));
         }
 
-        if (itemToResolve is null)
+        if (itemToResolve is not null)
         {
-            return;
+            // In the real world the client will send us back the data for the item to resolve, but in tests its easier if we just set it here.
+            // We clone the item first though, to ensure us setting the data doesn't hide a bug in our caching logic, around wrapping" the data.
+            var item = Assert.Single(result.Items.Where(i => i.Label == itemToResolve));
+            item = JsonSerializer.Deserialize<VSInternalCompletionItem>(JsonSerializer.SerializeToElement(item, JsonHelpers.JsonSerializerOptions), JsonHelpers.JsonSerializerOptions)!;
+            item.Data ??= result.Data ?? result.ItemDefaults?.Data;
+
+            Assert.NotNull(item);
+            Assert.NotNull(expectedResolvedItemDescription);
+
+            await VerifyCompletionResolveAsync(document, completionListCache, item, expected, expectedResolvedItemDescription);
         }
 
-        // In the real world the client will send us back the data for the item to resolve, but in tests its easier if we just set it here.
-        // We clone the item first though, to ensure us setting the data doesn't hide a bug in our caching logic, around wrapping" the data.
-        var item = Assert.Single(result.Items.Where(i => i.Label == itemToResolve));
-        item = JsonSerializer.Deserialize<VSInternalCompletionItem>(JsonSerializer.SerializeToElement(item, JsonHelpers.JsonSerializerOptions), JsonHelpers.JsonSerializerOptions)!;
-        item.Data ??= result.Data ?? result.ItemDefaults?.Data;
-
-        Assert.NotNull(item);
-        Assert.NotNull(expectedResolvedItemDescription);
-
-        await VerifyCompletionResolveAsync(document, completionListCache, item, expected, expectedResolvedItemDescription);
+        return result;
     }
 
     private async Task VerifyCompletionResolveAsync(CodeAnalysis.TextDocument document, CompletionListCache completionListCache, VSInternalCompletionItem item, string? expected, string expectedResolvedItemDescription)

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/Shared/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/Shared/CohostDocumentCompletionEndpointTest.cs
@@ -702,7 +702,7 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
     {
         UpdateClientInitializationOptions(c =>
         {
-            c.UseVsCodeCompletionTriggerCharacters = true;
+            c.UseVsCodeCompletionCommitCharacters = true;
             return c;
         });
 
@@ -722,7 +722,7 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
             expectedItemLabels: ["FormName", "OnValidSubmit", "@...", "style"],
             htmlItemLabels: ["style"],
             autoInsertAttributeQuotes: false,
-            useVsCodeCompletionTriggerCharacters: true);
+            UseVsCodeCompletionCommitCharacters: true);
 
         Assert.All(list.Items, item => Assert.DoesNotContain("=", item.CommitCharacters ?? []));
     }
@@ -740,7 +740,7 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
         string? expectedResolvedItemDescription = null,
         bool autoInsertAttributeQuotes = true,
         bool commitElementsWithSpace = true,
-        bool useVsCodeCompletionTriggerCharacters = false,
+        bool UseVsCodeCompletionCommitCharacters = false,
         RazorFileKind? fileKind = null)
     {
         var document = CreateProjectAndRazorDocument(input.Text, fileKind);
@@ -777,7 +777,7 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
         snippetCompletionItemProvider.SnippetCache.Update(SnippetLanguage.Html, snippetInfos);
 #endif
 
-        var languageServerFeatureOptions = new TestLanguageServerFeatureOptions(vsCodeCompletionTriggerCharacters: useVsCodeCompletionTriggerCharacters);
+        var languageServerFeatureOptions = new TestLanguageServerFeatureOptions(vsCodeCompletionTriggerCharacters: UseVsCodeCompletionCommitCharacters);
 
         var completionListCache = new CompletionListCache();
         var endpoint = new CohostDocumentCompletionEndpoint(


### PR DESCRIPTION
Bug: https://github.com/microsoft/vscode-dotnettools/issues/2296
Seems to fix https://github.com/dotnet/vscode-csharp/issues/7678 but there might be a reason @alexgav didn't close it, so I'm leaving it open.

In https://github.com/dotnet/razor/pull/11681 Alex made it so we didn't advertise broadly applicable commit characters in VS Code, which fixed the above issues for Html attributes, but we were still adding explicit commit characters to Razor completion items. This fixes that.This is not relevant to the issue, just annoyed me today :)

First commit is irrelevant, just something I noticed filled up our logs. Last commit is a rename of a flag that was already used for two purposes, but now its at least 99% used for commit characters, and only once used for trigger characters. Logged https://github.com/dotnet/razor/issues/12176 for a bit of a follow up there.