### PR TITLE
Make sure we report no diagnostics where there are no diagnostics

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Diagnostics/CohostDocumentPullDiagnosticsEndpointBase.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Diagnostics/CohostDocumentPullDiagnosticsEndpointBase.cs
@@ -92,7 +92,7 @@ internal abstract class CohostDocumentPullDiagnosticsEndpointBase<TRequest, TRes
             (service, solutionInfo, cancellationToken) => service.GetDiagnosticsAsync(solutionInfo, razorDocument.Id, csharpDiagnostics, htmlDiagnostics, cancellationToken),
             cancellationToken).ConfigureAwait(false);
 
-        if (diagnostics.IsDefaultOrEmpty)
+        if (cancellationToken.IsCancellationRequested)
         {
             return null;
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentPullDiagnosticsEndpoint.cs
@@ -81,7 +81,7 @@ internal sealed class CohostDocumentPullDiagnosticsEndpoint(
 
         if (results is null)
         {
-            return [];
+            return null;
         }
 
         return [new()


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2566865

If we don't return a report with no diagnostics, VS will assume the last report was correct, so the error list never cleared.