### PR TITLE
Reference a patched version of Microsoft.Build.Tasks.Core

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,6 +29,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.App.Runtime.$(NetCoreSDKRuntimeIdentifier)" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="$(_MicrosoftBuildPackageVersion)" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.4.1" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="$(_MicrosoftBuildPackageVersion)" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="$(_MicrosoftBuildPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="1.1.3-beta1.24423.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersPackageVersion)" />


### PR DESCRIPTION
Fixes https://dev.azure.com/dnceng/internal/_componentGovernance/dotnet-razor/alert/11494973?typeId=6437374

We were getting this dependency transitively through the project system SDK, but I couldn't find which version of that referenced the patched MSBuild dll, and since we were already referencing other MSBuild packages which are new enough, this seemed like the easiest change.