### PR TITLE
Small allocation improvement to GreenNodeExtensions.WithAnnotationsGreen

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/GreenNodeExtensions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/GreenNodeExtensions.cs
@@ -3,9 +3,9 @@
 
 #nullable disable
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Runtime.InteropServices;
+using Microsoft.AspNetCore.Razor.PooledObjects;
 
 namespace Microsoft.AspNetCore.Razor.Language.Syntax;
 
@@ -25,7 +25,18 @@ internal static class GreenNodeExtensions
 
     public static TNode WithAnnotationsGreen<TNode>(this TNode node, params SyntaxAnnotation[] annotations) where TNode : GreenNode
     {
-        var newAnnotations = new List<SyntaxAnnotation>();
+        if (annotations.Length == 0)
+        {
+            var existingAnnotations = node.GetAnnotations();
+            if (existingAnnotations != null && existingAnnotations.Length > 0)
+            {
+                node = (TNode)node.SetAnnotations(null);
+            }
+
+            return node;
+        }
+
+        using var newAnnotations = new PooledArrayBuilder<SyntaxAnnotation>(annotations.Length);
         foreach (var candidate in annotations)
         {
             if (!newAnnotations.Contains(candidate))
@@ -34,22 +45,7 @@ internal static class GreenNodeExtensions
             }
         }
 
-        if (newAnnotations.Count == 0)
-        {
-            var existingAnnotations = node.GetAnnotations();
-            if (existingAnnotations == null || existingAnnotations.Length == 0)
-            {
-                return node;
-            }
-            else
-            {
-                return (TNode)node.SetAnnotations(null);
-            }
-        }
-        else
-        {
-            return (TNode)node.SetAnnotations(newAnnotations.ToArray());
-        }
+        return (TNode)node.SetAnnotations(newAnnotations.ToArray());
     }
 
     public static TNode WithDiagnosticsGreen<TNode>(this TNode node, RazorDiagnostic[] diagnostics)

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledArrayBuilder`1.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledArrayBuilder`1.cs
@@ -833,6 +833,51 @@ internal partial struct PooledArrayBuilder<T> : IDisposable
     }
 
     /// <summary>
+    /// Searches for the specified item.
+    /// </summary>
+    /// <param name="item">The item to search for.</param>
+    /// <returns>The 0-based index where the item was found; or -1 if it could not be found.</returns>
+    public readonly int IndexOf(T item)
+        => IndexOf(item, EqualityComparer<T>.Default);
+
+    /// <summary>
+    /// Searches for the specified item.
+    /// </summary>
+    /// <param name="item">The item to search for.</param>
+    /// <param name="comparer">The equality comparer to use in the search.</param>
+    /// <returns>The 0-based index where the item was found; or -1 if it could not be found.</returns>
+    public readonly int IndexOf(T item, IEqualityComparer<T> comparer)
+    {
+        var n = Count;
+        for (var i = 0; i < n; i++)
+        {
+            if (comparer.Equals(this[i], item))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Determines whether the specified item exists in this collection.
+    /// </summary>
+    /// <param name="item">The item to search for.</param>
+    /// <returns><c>true</c> if an equal value was found in this collection; <c>false</c> otherwise.</returns>
+    public readonly bool Contains(T item)
+        => Contains(item, EqualityComparer<T>.Default);
+
+    /// <summary>
+    /// Determines whether the specified item exists in this collection.
+    /// </summary>
+    /// <param name="item">The item to search for.</param>
+    /// <param name="comparer">The equality comparer to use in the search.</param>
+    /// <returns><c>true</c> if an equal value was found in this collection; <c>false</c> otherwise.</returns>
+    public readonly bool Contains(T item, IEqualityComparer<T> comparer)
+        => IndexOf(item, comparer) >= 0;
+
+    /// <summary>
     ///  Returns the first element in this builder.
     /// </summary>
     /// <returns>


### PR DESCRIPTION
The WithAnnotationsGreen method shows up as about 0.7% of allocations in the RoslynCodeAnalysisService process during the C# completions scenario in the razor cohosting completion test.

These changes should get rid of about 0.2% of that (The top two blue highlighted lines in the profile image).

﻿<img width="1369" height="448" alt="image" src="https://github.com/user-attachments/assets/f5531bfb-655a-4df8-b01c-de91f131a53b" />