### PR TITLE
Perf: Cache IsViewComponent results

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/INamedTypeSymbolExtensions.Cache.IsViewComponentResult.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/INamedTypeSymbolExtensions.Cache.IsViewComponentResult.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.AspNetCore.Mvc.Razor.Extensions;
+
+namespace Microsoft.CodeAnalysis.Razor.Compiler.Language.Extensions;
+
+internal static partial class INamedTypeSymbolExtensions
+{
+    private sealed partial class Cache
+    {
+        private sealed class IsViewComponentResult
+        {
+            public bool IsViewComponent { get; }
+            public INamedTypeSymbol ViewComponentAttribute { get; }
+            public INamedTypeSymbol? NonViewComponentAttribute { get; }
+
+            public IsViewComponentResult(INamedTypeSymbol symbol, INamedTypeSymbol viewComponentAttribute, INamedTypeSymbol? nonViewComponentAttribute)
+            {
+                ViewComponentAttribute = viewComponentAttribute;
+                NonViewComponentAttribute = nonViewComponentAttribute;
+
+                if (symbol.DeclaredAccessibility != Accessibility.Public ||
+                    symbol.IsAbstract ||
+                    symbol.IsGenericType ||
+                    AttributeIsDefined(symbol, nonViewComponentAttribute))
+                {
+                    IsViewComponent = false;
+                }
+                else
+                {
+                    IsViewComponent = symbol.Name.EndsWith(ViewComponentTypes.ViewComponentSuffix, StringComparison.Ordinal) ||
+                        AttributeIsDefined(symbol, viewComponentAttribute);
+                }
+            }
+
+            public bool IsMatchingCache(INamedTypeSymbol viewComponentAttribute, INamedTypeSymbol? nonViewComponentAttribute)
+            {
+                return SymbolEqualityComparer.Default.Equals(ViewComponentAttribute, viewComponentAttribute)
+                    && SymbolEqualityComparer.Default.Equals(NonViewComponentAttribute, nonViewComponentAttribute);
+            }
+
+            private static bool AttributeIsDefined(INamedTypeSymbol type, INamedTypeSymbol? queryAttribute)
+            {
+                if (queryAttribute == null)
+                {
+                    return false;
+                }
+
+                var currentType = type;
+                while (currentType != null)
+                {
+                    foreach (var attribute in currentType.GetAttributes())
+                    {
+                        if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, queryAttribute))
+                        {
+                            return true;
+                        }
+                    }
+
+                    currentType = currentType.BaseType;
+                }
+
+                return false;
+            }
+        }
+    }
+}

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/INamedTypeSymbolExtensions.Cache.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/INamedTypeSymbolExtensions.Cache.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.CodeAnalysis.Razor.Compiler.Language.Extensions;
+
+internal static partial class INamedTypeSymbolExtensions
+{
+    private sealed partial class Cache(INamedTypeSymbol symbol)
+    {
+        private readonly INamedTypeSymbol _symbol = symbol;
+        private IsViewComponentResult? _isViewComponentResult;
+
+        public bool IsViewComponent(INamedTypeSymbol viewComponentAttribute, INamedTypeSymbol? nonViewComponentAttribute)
+        {
+            var isViewComponentResult = _isViewComponentResult;
+            if (isViewComponentResult is null
+                || !isViewComponentResult.IsMatchingCache(viewComponentAttribute, nonViewComponentAttribute))
+            {
+                isViewComponentResult = new IsViewComponentResult(_symbol, viewComponentAttribute, nonViewComponentAttribute);
+                _isViewComponentResult = isViewComponentResult;
+            }
+
+            return isViewComponentResult.IsViewComponent;
+        }
+    }
+}

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/INamedTypeSymbolExtensions.cs
@@ -1,0 +1,73 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Mvc.Razor.Extensions;
+
+namespace Microsoft.CodeAnalysis.Razor.Compiler.Language.Extensions;
+
+internal static class INamedTypeSymbolExtensions
+{
+    private static readonly ConditionalWeakTable<INamedTypeSymbol, NamedTypeSymbolCache> s_instance = new();
+
+    public static bool IsViewComponent(this INamedTypeSymbol symbol, INamedTypeSymbol viewComponentAttribute, INamedTypeSymbol? nonViewComponentAttribute)
+    {
+        var cache = s_instance.GetValue(symbol, static s => new NamedTypeSymbolCache(s));
+
+        return cache.IsViewComponent(viewComponentAttribute, nonViewComponentAttribute);
+    }
+
+    private sealed class NamedTypeSymbolCache(INamedTypeSymbol symbol)
+    {
+        private IsViewComponentResult? _isViewComponentResult;
+
+        public bool IsViewComponent(INamedTypeSymbol viewComponentAttribute, INamedTypeSymbol? nonViewComponentAttribute)
+        {
+            var isViewComponentResult = _isViewComponentResult;
+            if (isViewComponentResult is null
+                || !SymbolEqualityComparer.Default.Equals(isViewComponentResult.viewComponentAttribute, viewComponentAttribute)
+                || !SymbolEqualityComparer.Default.Equals(isViewComponentResult.nonViewComponentAttribute, nonViewComponentAttribute))
+            {
+                bool isViewComponent;
+                if (symbol.DeclaredAccessibility != Accessibility.Public ||
+                    symbol.IsAbstract ||
+                    symbol.IsGenericType ||
+                    attributeIsDefined(symbol, nonViewComponentAttribute))
+                {
+                    isViewComponent = false;
+                }
+                else
+                {
+                    isViewComponent = symbol.Name.EndsWith(ViewComponentTypes.ViewComponentSuffix, StringComparison.Ordinal) ||
+                        attributeIsDefined(symbol, viewComponentAttribute);
+                }
+
+                isViewComponentResult = new(isViewComponent, viewComponentAttribute, nonViewComponentAttribute);
+                _isViewComponentResult = isViewComponentResult;
+            }
+
+            return isViewComponentResult.isViewComponent;
+
+            static bool attributeIsDefined(INamedTypeSymbol? type, INamedTypeSymbol? queryAttribute)
+            {
+                if (type == null || queryAttribute == null)
+                {
+                    return false;
+                }
+
+                foreach (var attribute in type.GetAttributes())
+                {
+                    if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, queryAttribute))
+                    {
+                        return true;
+                    }
+                }
+
+                return attributeIsDefined(type.BaseType, queryAttribute);
+            }
+        }
+
+        private sealed record class IsViewComponentResult(bool isViewComponent, INamedTypeSymbol viewComponentAttribute, INamedTypeSymbol? nonViewComponentAttribute);
+    }
+}

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/INamedTypeSymbolExtensions.cs
@@ -1,73 +1,18 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.CompilerServices;
-using Microsoft.AspNetCore.Mvc.Razor.Extensions;
 
 namespace Microsoft.CodeAnalysis.Razor.Compiler.Language.Extensions;
 
-internal static class INamedTypeSymbolExtensions
+internal static partial class INamedTypeSymbolExtensions
 {
-    private static readonly ConditionalWeakTable<INamedTypeSymbol, NamedTypeSymbolCache> s_instance = new();
+    private static readonly ConditionalWeakTable<INamedTypeSymbol, Cache> s_instance = new();
 
     public static bool IsViewComponent(this INamedTypeSymbol symbol, INamedTypeSymbol viewComponentAttribute, INamedTypeSymbol? nonViewComponentAttribute)
     {
-        var cache = s_instance.GetValue(symbol, static s => new NamedTypeSymbolCache(s));
+        var cache = s_instance.GetValue(symbol, static s => new Cache(s));
 
         return cache.IsViewComponent(viewComponentAttribute, nonViewComponentAttribute);
-    }
-
-    private sealed class NamedTypeSymbolCache(INamedTypeSymbol symbol)
-    {
-        private IsViewComponentResult? _isViewComponentResult;
-
-        public bool IsViewComponent(INamedTypeSymbol viewComponentAttribute, INamedTypeSymbol? nonViewComponentAttribute)
-        {
-            var isViewComponentResult = _isViewComponentResult;
-            if (isViewComponentResult is null
-                || !SymbolEqualityComparer.Default.Equals(isViewComponentResult.viewComponentAttribute, viewComponentAttribute)
-                || !SymbolEqualityComparer.Default.Equals(isViewComponentResult.nonViewComponentAttribute, nonViewComponentAttribute))
-            {
-                bool isViewComponent;
-                if (symbol.DeclaredAccessibility != Accessibility.Public ||
-                    symbol.IsAbstract ||
-                    symbol.IsGenericType ||
-                    attributeIsDefined(symbol, nonViewComponentAttribute))
-                {
-                    isViewComponent = false;
-                }
-                else
-                {
-                    isViewComponent = symbol.Name.EndsWith(ViewComponentTypes.ViewComponentSuffix, StringComparison.Ordinal) ||
-                        attributeIsDefined(symbol, viewComponentAttribute);
-                }
-
-                isViewComponentResult = new(isViewComponent, viewComponentAttribute, nonViewComponentAttribute);
-                _isViewComponentResult = isViewComponentResult;
-            }
-
-            return isViewComponentResult.isViewComponent;
-
-            static bool attributeIsDefined(INamedTypeSymbol? type, INamedTypeSymbol? queryAttribute)
-            {
-                if (type == null || queryAttribute == null)
-                {
-                    return false;
-                }
-
-                foreach (var attribute in type.GetAttributes())
-                {
-                    if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, queryAttribute))
-                    {
-                        return true;
-                    }
-                }
-
-                return attributeIsDefined(type.BaseType, queryAttribute);
-            }
-        }
-
-        private sealed record class IsViewComponentResult(bool isViewComponent, INamedTypeSymbol viewComponentAttribute, INamedTypeSymbol? nonViewComponentAttribute);
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Mvc/ViewComponentTypeVisitor.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Mvc/ViewComponentTypeVisitor.cs
@@ -3,8 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor.Compiler.Language.Extensions;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.Extensions;
 
@@ -62,53 +63,6 @@ internal class ViewComponentTypeVisitor : SymbolVisitor
             return false;
         }
 
-        var cache = Cache.Instance.GetValue(symbol, static symbol => new Cache(symbol));
-        return cache.IsViewComponent(_viewComponentAttribute, _nonViewComponentAttribute);
-    }
-
-    private static bool AttributeIsDefined(INamedTypeSymbol? type, INamedTypeSymbol? queryAttribute)
-    {
-        if (type == null || queryAttribute == null)
-        {
-            return false;
-        }
-
-        foreach (var attribute in type.GetAttributes())
-        {
-            if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, queryAttribute))
-            {
-                return true;
-            }
-        }
-
-        return AttributeIsDefined(type.BaseType, queryAttribute);
-    }
-
-    private sealed class Cache(INamedTypeSymbol symbol)
-    {
-        public static readonly ConditionalWeakTable<INamedTypeSymbol, Cache> Instance = new();
-
-        private bool? _isViewComponent;
-
-        public bool IsViewComponent(INamedTypeSymbol viewComponentAttribute, INamedTypeSymbol? nonViewComponentAttribute)
-        {
-            if (!_isViewComponent.HasValue)
-            {
-                if (symbol.DeclaredAccessibility != Accessibility.Public ||
-                    symbol.IsAbstract ||
-                    symbol.IsGenericType ||
-                    AttributeIsDefined(symbol, nonViewComponentAttribute))
-                {
-                    _isViewComponent = false;
-                }
-                else
-                {
-                    _isViewComponent = symbol.Name.EndsWith(ViewComponentTypes.ViewComponentSuffix, StringComparison.Ordinal) ||
-                        AttributeIsDefined(symbol, viewComponentAttribute);
-                }
-            }
-
-            return _isViewComponent.Value;
-        }
+        return symbol.IsViewComponent(_viewComponentAttribute, _nonViewComponentAttribute);
     }
 }


### PR DESCRIPTION
Cache calculation of whether an INamedTypeSymbol represents a view component. Over the 5 speedometer runs I looked at, the existing calculation averaged 2200 ms of total CPU in the Razor cohosting completion speedometer test. A speedometer run with a CWT cache around this calculation, cut the average cost down to 900 ms.

Test insertion: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/668281

*** example old CPU ***
<img width="1244" height="406" alt="image" src="https://github.com/user-attachments/assets/3cb60a1b-6c78-4eb7-b7de-3d792acc69a2" />

*** example new CPU ***
<img width="1284" height="463" alt="image" src="https://github.com/user-attachments/assets/e02da99c-2b89-4810-82de-18d1b2d7e9d1" />