### PR TITLE
Improve TagHelperObjectBuilderCollection.ToImmutable perf in a specific case

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperObjectBuilderCollection`2.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperObjectBuilderCollection`2.cs
@@ -62,6 +62,10 @@ public sealed partial class TagHelperObjectBuilderCollection<TObject, TBuilder> 
         {
             return ImmutableArray<TObject>.Empty;
         }
+        else if (builders.Count == 1)
+        {
+            return [builders[0].Build()];
+        }
 
         using var result = new PooledArrayBuilder<TObject>(capacity: builders.Count);
         using var set = new PooledHashSet<TObject>(capacity: builders.Count);


### PR DESCRIPTION
Locally, I see about 2/3 of the non-empty ToImmutable calls be of size 1. This just handles that case directly without the need for the pooled data structures or adding to a hashset.

The ToImmutable call shows up as 2.7% of CPU samples during the html completion scenario in the razor cohosting completion speedometer test.

Test insertion: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/668320

A sample old result is in the image below. Generally, the numbers vary a bit from run to run, so I looked at 5 runs with and without this change. As the Build call count did not change, I compared the Build call time vs the total TagHelperObjectBuilderCollection.ToImmutable execution time. If this % increased, then it should be safe to say that the total time spent in TagHelperObjectBuilderCollection.ToImmutable decreased.

Over the speedometer runs, the average % of time spent in the Build call went from 28% to 33%, indicating a small net positive impact.

*** old CPU ***
<img width="1248" height="484" alt="image" src="https://github.com/user-attachments/assets/e43a1157-9e57-4c20-b1ad-5c3c5a59acbb" />