### PR TITLE
Further reduce allocations in SemanticToken calculations

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensBenchmark.cs
@@ -4,13 +4,14 @@
 #nullable disable
 
 using System;
-using System.Collections.Immutable;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
+using Microsoft.AspNetCore.Razor.Threading;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -102,7 +103,8 @@ public class RazorSemanticTokensBenchmark : RazorLanguageServerBenchmarkBase
         }
 
         // We can't get C# responses without significant amounts of extra work, so let's just shim it for now, any non-Null result is fine.
-        protected override Task<ImmutableArray<SemanticRange>?> GetCSharpSemanticRangesAsync(
+        protected override Task<bool> AddCSharpSemanticRangesAsync(
+            List<SemanticRange> ranges,
             DocumentContext documentContext,
             RazorCodeDocument codeDocument,
             LinePositionSpan razorRange,
@@ -110,7 +112,7 @@ public class RazorSemanticTokensBenchmark : RazorLanguageServerBenchmarkBase
             Guid correlationId,
             CancellationToken cancellationToken)
         {
-            return Task.FromResult<ImmutableArray<SemanticRange>?>(ImmutableArray<SemanticRange>.Empty);
+            return SpecializedTasks.True;
         }
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/SemanticTokens/SemanticTokensVisitor.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/SemanticTokens/SemanticTokensVisitor.cs
@@ -2,19 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Razor.SemanticTokens;
 
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 
 internal sealed class SemanticTokensVisitor : SyntaxWalker
 {
-    private readonly ImmutableArray<SemanticRange>.Builder _semanticRanges;
+    private readonly List<SemanticRange> _semanticRanges;
     private readonly RazorCodeDocument _razorCodeDocument;
     private readonly TextSpan _range;
     private readonly ISemanticTokensLegendService _semanticTokensLegend;
@@ -22,7 +20,7 @@ internal sealed class SemanticTokensVisitor : SyntaxWalker
 
     private bool _addRazorCodeModifier;
 
-    private SemanticTokensVisitor(ImmutableArray<SemanticRange>.Builder semanticRanges, RazorCodeDocument razorCodeDocument, TextSpan range, ISemanticTokensLegendService semanticTokensLegend, bool colorCodeBackground)
+    private SemanticTokensVisitor(List<SemanticRange> semanticRanges, RazorCodeDocument razorCodeDocument, TextSpan range, ISemanticTokensLegendService semanticTokensLegend, bool colorCodeBackground)
     {
         _semanticRanges = semanticRanges;
         _razorCodeDocument = razorCodeDocument;
@@ -31,15 +29,11 @@ internal sealed class SemanticTokensVisitor : SyntaxWalker
         _colorCodeBackground = colorCodeBackground;
     }
 
-    public static ImmutableArray<SemanticRange> GetSemanticRanges(RazorCodeDocument razorCodeDocument, TextSpan textSpan, ISemanticTokensLegendService razorSemanticTokensLegendService, bool colorCodeBackground)
+    public static void AddSemanticRanges(List<SemanticRange> ranges, RazorCodeDocument razorCodeDocument, TextSpan textSpan, ISemanticTokensLegendService razorSemanticTokensLegendService, bool colorCodeBackground)
     {
-        using var _ = ArrayBuilderPool<SemanticRange>.GetPooledObject(out var builder);
-
-        var visitor = new SemanticTokensVisitor(builder, razorCodeDocument, textSpan, razorSemanticTokensLegendService, colorCodeBackground);
+        var visitor = new SemanticTokensVisitor(ranges, razorCodeDocument, textSpan, razorSemanticTokensLegendService, colorCodeBackground);
 
         visitor.Visit(razorCodeDocument.GetRequiredSyntaxRoot());
-
-        return builder.ToImmutableAndClear();
     }
 
     private void Visit(SyntaxList<RazorSyntaxNode> syntaxNodes)


### PR DESCRIPTION
Instead of realizing ImmutableArrays in several codepaths, we can instead just have the calculations append items to an existing list.

Also, in ConvertSemanticRangesToSemanticTokensData, switches to optimistically allocating an int[] instead of a pooled list for two reasons:

1) In almost all cases, the correct size is calculated before population 
2) The pooled list that was being created commonly ended up being too large to be placed back in the pool, so we would end up losing both that list and it's backing array to GC.

This wasn't a huge memory hitter for me in the profile I'm looking at, but still is ~0.6% of allocations in the RoslynCodeAnalysisService process during the C#/html completions in the razor cohosting speedometer test.

Test insertion pipeline run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2789884&view=results