### PR TITLE
Filter CSS024 when caused by C# code in an attribute

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Diagnostics/CSSErrorCodes.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Diagnostics/CSSErrorCodes.cs
@@ -9,6 +9,7 @@ internal static class CSSErrorCodes
     public const string UnrecognizedBlockType = "CSS002";
     public const string MissingClassNameAfterDot = "CSS008";
     public const string MissingOpeningBrace = "CSS023";
+    public const string MissingPropertyName = "CSS024";
     public const string MissingPropertyValue = "CSS025";
     public const string MissingSelectorAfterCombinator = "CSS029";
     public const string MissingSelectorBeforeCombinatorCode = "CSS031";

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Diagnostics/RazorTranslateDiagnosticsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Diagnostics/RazorTranslateDiagnosticsService.cs
@@ -99,7 +99,7 @@ internal class RazorTranslateDiagnosticsService(IDocumentMappingService document
         var syntaxTree = codeDocument.GetRequiredSyntaxTree();
         var sourceText = codeDocument.Source.Text;
 
-        var processedAttributes = new Dictionary<TextSpan, bool>();
+        using var _ = DictionaryPool<TextSpan, bool>.GetPooledObject(out var processedAttributes);
 
         var filteredDiagnostics = unmappedDiagnostics
             .Where(d =>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Diagnostics/RazorTranslateDiagnosticsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Diagnostics/RazorTranslateDiagnosticsService.cs
@@ -244,6 +244,7 @@ internal class RazorTranslateDiagnosticsService(IDocumentMappingService document
             CSSErrorCodes.MissingOpeningBrace or
             CSSErrorCodes.MissingClassNameAfterDot or
             CSSErrorCodes.MissingSelectorAfterCombinator or
+            CSSErrorCodes.MissingPropertyName or
             CSSErrorCodes.MissingPropertyValue or
             CSSErrorCodes.MissingSelectorBeforeCombinatorCode => IsAtCSharpTransitionInStyleBlock(diagnostic, sourceText, syntaxTree),
             HtmlErrorCodes.UnexpectedEndTagErrorCode => IsHtmlWithBangAndMatchingTags(diagnostic, sourceText, syntaxTree),

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentPullDiagnosticsTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentPullDiagnosticsTest.cs
@@ -376,6 +376,40 @@ public class CohostDocumentPullDiagnosticsTest(ITestOutputHelper testOutputHelpe
     }
 
     [Fact]
+    public Task FilterPropertyNameInCss()
+    {
+        TestCode input = """
+            <div style="{|CSS024:/|}****/"></div>
+            <div style="@(someBool ? "width: 100%" : "width: 50%")">
+
+            </div>
+
+            @code
+            {
+                private bool someBool = false;
+            }
+            """;
+
+        return VerifyDiagnosticsAsync(input,
+            htmlResponse: [new VSInternalDiagnosticReport
+            {
+                Diagnostics =
+                [
+                    new LspDiagnostic
+                    {
+                        Code = CSSErrorCodes.MissingPropertyName,
+                        Range = SourceText.From(input.Text).GetRange(new TextSpan(input.Text.IndexOf("/"), 1))
+                    },
+                    new LspDiagnostic
+                    {
+                        Code = CSSErrorCodes.MissingPropertyName,
+                        Range = SourceText.From(input.Text).GetRange(new TextSpan(input.Text.IndexOf("@"), 1))
+                    },
+                ]
+            }]);
+    }
+
+    [Fact]
     public Task CombinedAndNestedDiagnostics()
         => VerifyDiagnosticsAsync("""
             @using System.Threading.Tasks;


### PR DESCRIPTION
Fixes [a report on reddit](https://www.reddit.com/r/Blazor/comments/1ncz7n0/vs_2026_insiders_razor_editor/ndeu1n9/).

We were filtering CSS023 and CSS025 but not CSS024. So there is this. But then everything got more complicated because at some point we regressed things and just filtered all Html diagnostics from Html attributes it seems. Clearly test coverage for this wasn't great, so there is a chance this causes us to report more Html diagnostics and therefore regress things for users, but at least we'll find out and be able to fix them.