### PR TITLE
Improve PooledArrayBuilder<T>.ToArray() and ToArrayAndClear()

### DIFF
--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledArrayBuilder`1.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledArrayBuilder`1.cs
@@ -670,29 +670,10 @@ internal partial struct PooledArrayBuilder<T> : IDisposable
     }
 
     public readonly T[] ToArray()
-    {
-        if (TryGetBuilder(out var builder))
-        {
-            return builder.ToArray();
-        }
-
-        return _inlineCount switch
-        {
-            0 => [],
-            1 => [_element0],
-            2 => [_element0, _element1],
-            3 => [_element0, _element1, _element2],
-            _ => [_element0, _element1, _element2, _element3]
-        };
-    }
+        => ImmutableCollectionsMarshal.AsArray(ToImmutable()).AssumeNotNull();
 
     public T[] ToArrayAndClear()
-    {
-        var result = ToArray();
-        Clear();
-
-        return result;
-    }
+        => ImmutableCollectionsMarshal.AsArray(ToImmutableAndClear()).AssumeNotNull();
 
     public void Push(T item)
     {


### PR DESCRIPTION
Instead of providing separate implementations, `ToArray()` and `ToArrayAndClear()` should just call `ToImmutable()` and `ToImmutableAndClear()` and return the underlying array. This ensures that we get the benefit of returning the builder's array when the capacity matches the count.