### PR TITLE
Optimize GreenNode.ToString to not potentially not allocate when it has only a single non-null slot value.

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/GreenNode.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/GreenNode.cs
@@ -266,13 +266,16 @@ internal abstract class GreenNode
             for (var i = 0; i < slotCount; i++)
             {
                 var slotValue = GetSlot(i);
-                if (slotValue is not null && result is not null)
+                if (slotValue is not null)
                 {
-                    result = null;
-                    return false;
-                }
+                    if (result is not null)
+                    {
+                        result = null;
+                        return false;
+                    }
 
-                result = slotValue;
+                    result = slotValue;
+                }
             }
 
             return result is not null;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/GreenNode.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/GreenNode.cs
@@ -260,8 +260,6 @@ internal abstract class GreenNode
         {
             result = null;
 
-            // Reverse iteration to avoid hitting the SlotCount property multiple times
-            // We're just as likely to hit a non-null slot at the end as at the beginning
             var slotCount = SlotCount;
             for (var i = 0; i < slotCount; i++)
             {

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/GreenNode.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/GreenNode.cs
@@ -258,6 +258,9 @@ internal abstract class GreenNode
         GreenNode GetSingleSlotValueOrDefault()
         {
             GreenNode loneSlotValue = null;
+
+            // Reverse iteration to avoid hitting the SlotCount property multiple times
+            // We're just as likely to hit a non-null slot at the end as at the beginning
             for (var i = SlotCount - 1; i >= 0; i--)
             {
                 var slotValue = GetSlot(i);


### PR DESCRIPTION
I see a lot of calls to this where the only non-null slot value is a token, which has a non-allocating ToString implementation.

The numbers from the test insertion were a little hard to decipher. The cohosting test has huge variances in general (which we should try to fix). Of the runs that didn't have the extremely high numbers, it looked like this change reduced allocations under GreenNode.ToString by about 50% while not adding any CPU cost (again, hard to read, but GetSingleSlotValueOrDefault looked like it was an insignificant CPU cost wrt the rest of the ToString impelementation).

Test insertion: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/670195