### PR TITLE
Retry running generators if the project config looks good, but the source generator doesn't produce host outputs

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/GeneratorRunResult.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/GeneratorRunResult.cs
@@ -1,0 +1,115 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.NET.Sdk.Razor.SourceGenerators;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
+
+/// <summary>
+/// Wraps the host outputs of the Razor source generator, and the <see cref="CodeAnalysis.Project"/> that produced them.
+/// </summary>
+internal record struct GeneratorRunResult(RazorGeneratorResult GeneratorResult, Project Project)
+{
+    public bool IsDefault => GeneratorResult is null && Project is null;
+
+    public IReadOnlyList<TagHelperDescriptor> TagHelpers => GeneratorResult.TagHelpers;
+
+    public RazorCodeDocument? GetCodeDocument(string filePath) => GeneratorResult.GetCodeDocument(filePath);
+    public RazorCodeDocument GetRequiredCodeDocument(string filePath) => GeneratorResult.GetCodeDocument(filePath)
+        ?? throw new InvalidOperationException(SR.FormatGenerator_run_result_did_not_contain_a_code_document(filePath));
+
+    public string? GetRazorFilePathFromHintName(string generatedDocumentHintName)
+        => GeneratorResult.GetFilePath(generatedDocumentHintName);
+
+    public bool TryGetRazorDocument(string razorFilePath, out TextDocument? document)
+        => Project.Solution.TryGetRazorDocument(razorFilePath, out document);
+
+    public async Task<SourceGeneratedDocument> GetRequiredSourceGeneratedDocumentForRazorFilePathAsync(string filePath, CancellationToken cancellationToken)
+    {
+        var hintName = GeneratorResult.GetHintName(filePath);
+
+        var generatedDocument = await Project.TryGetSourceGeneratedDocumentFromHintNameAsync(hintName, cancellationToken).ConfigureAwait(false);
+
+        return generatedDocument
+            ?? throw new InvalidOperationException(SR.FormatCouldnt_get_the_source_generated_document_for_hint_name(hintName));
+    }
+
+    public static async Task<GeneratorRunResult> CreateAsync(bool throwIfNotFound, Project project, RemoteSnapshotManager snapshotManager, CancellationToken cancellationToken)
+    {
+        var result = await project.GetSourceGeneratorRunResultAsync(cancellationToken).ConfigureAwait(false);
+        if (result is null)
+        {
+            if (throwIfNotFound)
+            {
+                throw new InvalidOperationException(SR.FormatCouldnt_get_a_source_generator_run_result(project.Name));
+            }
+
+            return default;
+        }
+
+        var runResult = result.Results.SingleOrDefault(r => r.Generator.GetGeneratorType().Assembly.Location == typeof(RazorSourceGenerator).Assembly.Location);
+        if (runResult.Generator is null)
+        {
+            if (throwIfNotFound)
+            {
+                if (result.Results.SingleOrDefault(r => r.Generator.GetGeneratorType().Name == "Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator").Generator is { } wrongGenerator)
+                {
+                    // Wrong ALC?
+                    throw new InvalidOperationException(SR.FormatRazor_source_generator_reference_incorrect(wrongGenerator.GetGeneratorType().Assembly.Location, typeof(RazorSourceGenerator).Assembly.Location, project.Name));
+                }
+                else
+                {
+                    throw new InvalidOperationException(SR.FormatRazor_source_generator_is_not_referenced(project.Name));
+                }
+            }
+
+            return default;
+        }
+
+#pragma warning disable RSEXPERIMENTAL004 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        if (!runResult.HostOutputs.TryGetValue(nameof(RazorGeneratorResult), out var objectResult))
+#pragma warning restore RSEXPERIMENTAL004 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        {
+            // We know the generator is referenced, or we wouldn't have gotten past the above checks. We also know cohosting is turned on, since we got here.
+            // There is a race condition that can happen where if Roslyn runs the generator before Razor has a chance to initialize, then Roslyn will have
+            // cached the fact that cohosting was off, and any subsequent runs of the generator will not produce a host output. We can work around this by
+            // making an innocuous change to the project, and trying again.
+            if (snapshotManager.TryGetRetryProject(project) is { } retryProject)
+            {
+                // For subsequent requests for this project, the solution snapshot will have updated its view of the world and everything
+                // will be fine. For this request though, the caller of this method is just going to keep querying _project so we need to
+                // update it.
+                //_project = retryProject;
+                return await CreateAsync(throwIfNotFound, retryProject, snapshotManager, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (throwIfNotFound)
+            {
+                throw new InvalidOperationException(SR.FormatRazor_source_generator_did_not_produce_a_host_output(project.Name, string.Join(Environment.NewLine, runResult.Diagnostics)));
+            }
+
+            return default;
+        }
+
+        if (objectResult is not RazorGeneratorResult generatorResult)
+        {
+            if (throwIfNotFound)
+            {
+                // Wrong ALC?
+                throw new InvalidOperationException(SR.FormatRazor_source_generator_host_output_is_not_RazorGeneratorResult(project.Name, string.Join(Environment.NewLine, runResult.Diagnostics)));
+            }
+
+            return default;
+        }
+
+        return new(generatorResult, project);
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/GeneratorRunResult.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/GeneratorRunResult.cs
@@ -16,15 +16,18 @@ namespace Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
 /// <summary>
 /// Wraps the host outputs of the Razor source generator, and the <see cref="CodeAnalysis.Project"/> that produced them.
 /// </summary>
-internal record struct GeneratorRunResult(RazorGeneratorResult GeneratorResult, Project Project)
+internal readonly record struct GeneratorRunResult(RazorGeneratorResult GeneratorResult, Project Project)
 {
     public bool IsDefault => GeneratorResult is null && Project is null;
 
     public IReadOnlyList<TagHelperDescriptor> TagHelpers => GeneratorResult.TagHelpers;
 
-    public RazorCodeDocument? GetCodeDocument(string filePath) => GeneratorResult.GetCodeDocument(filePath);
-    public RazorCodeDocument GetRequiredCodeDocument(string filePath) => GeneratorResult.GetCodeDocument(filePath)
-        ?? throw new InvalidOperationException(SR.FormatGenerator_run_result_did_not_contain_a_code_document(filePath));
+    public RazorCodeDocument? GetCodeDocument(string filePath)
+        => GeneratorResult.GetCodeDocument(filePath);
+
+    public RazorCodeDocument GetRequiredCodeDocument(string filePath)
+        => GeneratorResult.GetCodeDocument(filePath)
+           ?? throw new InvalidOperationException(SR.FormatGenerator_run_result_did_not_contain_a_code_document(filePath));
 
     public string? GetRazorFilePathFromHintName(string generatedDocumentHintName)
         => GeneratorResult.GetFilePath(generatedDocumentHintName);
@@ -81,13 +84,11 @@ internal record struct GeneratorRunResult(RazorGeneratorResult GeneratorResult, 
             // We know the generator is referenced, or we wouldn't have gotten past the above checks. We also know cohosting is turned on, since we got here.
             // There is a race condition that can happen where if Roslyn runs the generator before Razor has a chance to initialize, then Roslyn will have
             // cached the fact that cohosting was off, and any subsequent runs of the generator will not produce a host output. We can work around this by
-            // making an innocuous change to the project, and trying again.
+            // making an innocuous change to the project, and trying again. The snapshot manager makes this change inside a lock, and if we're not the first
+            // ones to try, we'll get the updated project which may have already had generators run on it. We recurse back into ourselves here with the updated
+            // project to try again. TryGetRetryProject also protects against infinite recursion.
             if (snapshotManager.TryGetRetryProject(project) is { } retryProject)
             {
-                // For subsequent requests for this project, the solution snapshot will have updated its view of the world and everything
-                // will be fine. For this request though, the caller of this method is just going to keep querying _project so we need to
-                // update it.
-                //_project = retryProject;
                 return await CreateAsync(throwIfNotFound, retryProject, snapshotManager, cancellationToken).ConfigureAwait(false);
             }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteProjectSnapshot.cs
@@ -12,11 +12,9 @@ using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Utilities;
-using Microsoft.NET.Sdk.Razor.SourceGenerators;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
 
@@ -26,8 +24,7 @@ internal sealed class RemoteProjectSnapshot : IProjectSnapshot
 
     public ProjectKey Key { get; }
 
-    // This is not readonly for ONE specific purpose, and should not generally be mutated
-    private Project _project;
+    private readonly Project _project;
     private readonly Dictionary<TextDocument, RemoteDocumentSnapshot> _documentMap = [];
 
     public RemoteProjectSnapshot(Project project, RemoteSolutionSnapshot solutionSnapshot)
@@ -61,8 +58,8 @@ internal sealed class RemoteProjectSnapshot : IProjectSnapshot
 
     public async ValueTask<ImmutableArray<TagHelperDescriptor>> GetTagHelpersAsync(CancellationToken cancellationToken)
     {
-        var generatorResult = await GetRazorGeneratorResultAsync(throwIfNotFound: false, cancellationToken).ConfigureAwait(false);
-        if (generatorResult is null)
+        var generatorResult = await GeneratorRunResult.CreateAsync(throwIfNotFound: false, _project, SolutionSnapshot.SnapshotManager, cancellationToken).ConfigureAwait(false);
+        if (generatorResult.IsDefault)
             return [];
 
         return [.. generatorResult.TagHelpers];
@@ -149,22 +146,20 @@ internal sealed class RemoteProjectSnapshot : IProjectSnapshot
 
     internal async Task<RazorCodeDocument> GetRequiredCodeDocumentAsync(IDocumentSnapshot documentSnapshot, CancellationToken cancellationToken)
     {
-        var generatorResult = await GetRazorGeneratorResultAsync(throwIfNotFound: true, cancellationToken).ConfigureAwait(false);
+        var generatorResult = await GeneratorRunResult.CreateAsync(throwIfNotFound: true, _project, SolutionSnapshot.SnapshotManager, cancellationToken).ConfigureAwait(false);
 
-        return generatorResult.AssumeNotNull().GetCodeDocument(documentSnapshot.FilePath)
-            ?? throw new InvalidOperationException(SR.FormatGenerator_run_result_did_not_contain_a_code_document(documentSnapshot.FilePath));
+        Assumed.False(generatorResult.IsDefault);
+
+        return generatorResult.GetRequiredCodeDocument(documentSnapshot.FilePath);
     }
 
     internal async Task<SourceGeneratedDocument> GetRequiredGeneratedDocumentAsync(IDocumentSnapshot documentSnapshot, CancellationToken cancellationToken)
     {
-        var generatorResult = await GetRazorGeneratorResultAsync(throwIfNotFound: true, cancellationToken).ConfigureAwait(false);
+        var generatorResult = await GeneratorRunResult.CreateAsync(throwIfNotFound: true, _project, SolutionSnapshot.SnapshotManager, cancellationToken).ConfigureAwait(false);
 
-        var hintName = generatorResult.AssumeNotNull().GetHintName(documentSnapshot.FilePath);
+        Assumed.False(generatorResult.IsDefault);
 
-        var generatedDocument = await _project.TryGetSourceGeneratedDocumentFromHintNameAsync(hintName, cancellationToken).ConfigureAwait(false);
-
-        return generatedDocument
-            ?? throw new InvalidOperationException(SR.FormatCouldnt_get_the_source_generated_document_for_hint_name(hintName));
+        return await generatorResult.GetRequiredSourceGeneratedDocumentForRazorFilePathAsync(documentSnapshot.FilePath, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<RazorCodeDocument?> TryGetCodeDocumentFromGeneratedDocumentUriAsync(Uri generatedDocumentUri, CancellationToken cancellationToken)
@@ -179,99 +174,28 @@ internal sealed class RemoteProjectSnapshot : IProjectSnapshot
 
     public async Task<RazorCodeDocument?> TryGetCodeDocumentFromGeneratedHintNameAsync(string generatedDocumentHintName, CancellationToken cancellationToken)
     {
-        var runResult = await GetRazorGeneratorResultAsync(throwIfNotFound: false, cancellationToken).ConfigureAwait(false);
-        if (runResult is null)
+        var generatorResult = await GeneratorRunResult.CreateAsync(throwIfNotFound: false, _project, SolutionSnapshot.SnapshotManager, cancellationToken).ConfigureAwait(false);
+        if (generatorResult.IsDefault)
         {
             return null;
         }
 
-        return runResult.GetFilePath(generatedDocumentHintName) is { } razorFilePath
-            ? runResult.GetCodeDocument(razorFilePath)
+        return generatorResult.GetRazorFilePathFromHintName(generatedDocumentHintName) is { } razorFilePath
+            ? generatorResult.GetCodeDocument(razorFilePath)
             : null;
     }
 
     public async Task<TextDocument?> TryGetRazorDocumentFromGeneratedHintNameAsync(string generatedDocumentHintName, CancellationToken cancellationToken)
     {
-        var runResult = await GetRazorGeneratorResultAsync(throwIfNotFound: false, cancellationToken).ConfigureAwait(false);
-        if (runResult is null)
+        var generatorResult = await GeneratorRunResult.CreateAsync(throwIfNotFound: false, _project, SolutionSnapshot.SnapshotManager, cancellationToken).ConfigureAwait(false);
+        if (generatorResult.IsDefault)
         {
             return null;
         }
 
-        return runResult.GetFilePath(generatedDocumentHintName) is { } razorFilePath &&
-            _project.Solution.TryGetRazorDocument(razorFilePath, out var razorDocument)
+        return generatorResult.GetRazorFilePathFromHintName(generatedDocumentHintName) is { } razorFilePath &&
+            generatorResult.TryGetRazorDocument(razorFilePath, out var razorDocument)
                 ? razorDocument
                 : null;
-    }
-
-    private async Task<RazorGeneratorResult?> GetRazorGeneratorResultAsync(bool throwIfNotFound, CancellationToken cancellationToken)
-    {
-        var result = await _project.GetSourceGeneratorRunResultAsync(cancellationToken).ConfigureAwait(false);
-        if (result is null)
-        {
-            if (throwIfNotFound)
-            {
-                throw new InvalidOperationException(SR.FormatCouldnt_get_a_source_generator_run_result(_project.Name));
-            }
-
-            return null;
-        }
-
-        var runResult = result.Results.SingleOrDefault(r => r.Generator.GetGeneratorType().Assembly.Location == typeof(RazorSourceGenerator).Assembly.Location);
-        if (runResult.Generator is null)
-        {
-            if (throwIfNotFound)
-            {
-                if (result.Results.SingleOrDefault(r => r.Generator.GetGeneratorType().Name == "Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator").Generator is { } wrongGenerator)
-                {
-                    // Wrong ALC?
-                    throw new InvalidOperationException(SR.FormatRazor_source_generator_reference_incorrect(wrongGenerator.GetGeneratorType().Assembly.Location, typeof(RazorSourceGenerator).Assembly.Location, _project.Name));
-                }
-                else
-                {
-                    throw new InvalidOperationException(SR.FormatRazor_source_generator_is_not_referenced(_project.Name));
-                }
-            }
-
-            return null;
-        }
-
-#pragma warning disable RSEXPERIMENTAL004 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        if (!runResult.HostOutputs.TryGetValue(nameof(RazorGeneratorResult), out var objectResult))
-#pragma warning restore RSEXPERIMENTAL004 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        {
-            // We know the generator is referenced, or we wouldn't have gotten past the above checks. We also know cohosting is turned on, since we got here.
-            // There is a race condition that can happen where if Roslyn runs the generator before Razor has a chance to initialize, then Roslyn will have
-            // cached the fact that cohosting was off, and any subsequent runs of the generator will not produce a host output. We can work around this by
-            // making an innocuous change to the project, and trying again.
-            if (SolutionSnapshot.SnapshotManager.TryGetRetryProject(_project) is { } retryProject)
-            {
-                // For subsequent requests for this project, the solution snapshot will have updated its view of the world and everything
-                // will be fine. For this request though, the caller of this method is just going to keep querying _project so we need to
-                // update it.
-                _project = retryProject;
-                return await GetRazorGeneratorResultAsync(throwIfNotFound, cancellationToken).ConfigureAwait(false);
-            }
-
-            if (throwIfNotFound)
-            {
-                throw new InvalidOperationException(SR.FormatRazor_source_generator_did_not_produce_a_host_output(_project.Name, string.Join(Environment.NewLine, runResult.Diagnostics)));
-            }
-
-            return null;
-        }
-
-        if (objectResult is not RazorGeneratorResult generatorResult)
-        {
-            if (throwIfNotFound)
-            {
-                // Wrong ALC?
-                throw new InvalidOperationException(SR.FormatRazor_source_generator_host_output_is_not_RazorGeneratorResult(_project.Name, string.Join(Environment.NewLine, runResult.Diagnostics)));
-            }
-
-            return null;
-        }
-
-        return generatorResult;
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteSnapshotManager.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteSnapshotManager.cs
@@ -14,13 +14,17 @@ namespace Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
 internal sealed class RemoteSnapshotManager(IFilePathService filePathService, ITelemetryReporter telemetryReporter)
 {
     private static readonly ConditionalWeakTable<Solution, RemoteSolutionSnapshot> s_solutionToSnapshotMap = new();
+    private static readonly object s_gate = new();
 
     public IFilePathService FilePathService { get; } = filePathService;
     public ITelemetryReporter TelemetryReporter { get; } = telemetryReporter;
 
     public RemoteSolutionSnapshot GetSnapshot(Solution solution)
     {
-        return s_solutionToSnapshotMap.GetValue(solution, s => new RemoteSolutionSnapshot(s, this));
+        lock (s_gate)
+        {
+            return s_solutionToSnapshotMap.GetValue(solution, s => new RemoteSolutionSnapshot(s, this));
+        }
     }
 
     public RemoteProjectSnapshot GetSnapshot(Project project)
@@ -31,5 +35,36 @@ internal sealed class RemoteSnapshotManager(IFilePathService filePathService, IT
     public RemoteDocumentSnapshot GetSnapshot(TextDocument document)
     {
         return GetSnapshot(document.Project).GetDocument(document);
+    }
+
+    internal Project? TryGetRetryProject(Project project)
+    {
+        if (project.IsRetryProject())
+        {
+            // If the passed in project is already a retry project, then it means whatever failure the caller had is real
+            return null;
+        }
+
+        lock (s_gate)
+        {
+            // Check if we already have performed a retry for this project. We only expect retry projects to be needed early in the life of a session,
+            // so its highly likely the first few requests will all come in parallel (ie, inlay hints, folding ranges, semantic tokens) and well all
+            // need to retry. This extra check means we don't create multiple retry projects for the same underlying project, and hence only run generators
+            // once. Once almost anything in the project has changed, the source generator cache will be un-stuck, and this method won't be called, and
+            // our retry solution snapshot will be removed from the CWT as normal.
+            if (s_solutionToSnapshotMap.TryGetValue(project.Solution, out var snapshot) &&
+                snapshot.GetProject(project) is { } existingProject &&
+                existingProject.Project.IsRetryProject())
+            {
+                return existingProject.Project;
+            }
+
+            // The passed in project isn't a retry, and we don't have one already, so create one now and replace
+            // our current snapshot. This means future requests will just get the right thing from their first OOP service call.
+            var retryProject = project.ForkToRetryProject();
+            s_solutionToSnapshotMap.Remove(project.Solution);
+            s_solutionToSnapshotMap.Add(project.Solution, new RemoteSolutionSnapshot(retryProject.Solution, this));
+            return retryProject;
+        }
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteSolutionSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteSolutionSnapshot.cs
@@ -28,7 +28,11 @@ internal sealed class RemoteSolutionSnapshot(Solution solution, RemoteSnapshotMa
     {
         if (project.Solution != _solution)
         {
-            throw new ArgumentException(SR.Project_does_not_belong_to_this_solution, nameof(project));
+            // It might look like we don't know about this project, but we might have actually seen it before but been forced
+            // to retry running source generators in it, so we handle that specific case here.
+            project = _solution.GetProject(project.Id) is { } retryProject && retryProject.IsRetryProject()
+                    ? retryProject
+                    : throw new ArgumentException(SR.Project_does_not_belong_to_this_solution, nameof(project));
         }
 
         if (!project.ContainsRazorDocuments())

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Cohosting/CohostTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Cohosting/CohostTestBase.cs
@@ -209,6 +209,9 @@ public abstract class CohostTestBase(ITestOutputHelper testOutputHelper) : Tooli
                     build_property.RazorLangVersion = {FallbackRazorConfiguration.Latest.LanguageVersion}
                     build_property.RazorConfiguration = {FallbackRazorConfiguration.Latest.ConfigurationName}
                     build_property.RootNamespace = {TestProjectData.SomeProject.RootNamespace}
+
+                    # This might suprise you, but by suppressing the source generator here, we're mirroring what happens in the Razor SDK
+                    build_property.SuppressRazorSourceGenerator = true
                     """);
 
             var projectBasePath = Path.GetDirectoryName(projectFilePath).AssumeNotNull();

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/RetryProjectTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/RetryProjectTest.cs
@@ -1,0 +1,176 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Remote.Razor.Resources;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.NET.Sdk.Razor.SourceGenerators;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+public class RetryProjectTest(ITestOutputHelper testOutputHelper) : CohostEndpointTestBase(testOutputHelper)
+{
+    [Fact]
+    public async Task HoverRequest_ReturnsResults()
+    {
+        RazorCohostingOptions.UseRazorCohostServer = false;
+
+        TestCode input = """
+            <div></div>
+            @System.DateTi$$me.Now
+            """;
+        var document = CreateProjectAndRazorDocument(input.Text, RazorFileKind.Component);
+
+        // Make sure the source generator has been run while cohosting is off, to simular Roslyn winning the initialization race
+        //var compilation = await document.Project.GetCompilationAsync(DisposalToken);
+        Assert.Empty(await document.Project.GetSourceGeneratedDocumentsAsync(DisposalToken));
+
+        // Now turn the source generator on, to simulate Razor starting up and initializing OOP
+        RazorCohostingOptions.UseRazorCohostServer = true;
+
+        var snapshotManager = OOPExportProvider.GetExportedValue<RemoteSnapshotManager>();
+        var projectSnapshot = snapshotManager.GetSnapshot(document.Project);
+        var documentSnapshot = projectSnapshot.GetDocument(document);
+
+        await projectSnapshot.GetRequiredCodeDocumentAsync(documentSnapshot, DisposalToken);
+
+        Assert.True(projectSnapshot.Project.IsRetryProject());
+
+        var inputText = await document.GetTextAsync(DisposalToken);
+        var linePosition = inputText.GetLinePosition(input.Position);
+
+        var requestInvoker = new TestHtmlRequestInvoker();
+        var endpoint = new CohostHoverEndpoint(IncompatibleProjectService, RemoteServiceInvoker, requestInvoker);
+
+        var textDocumentPositionParams = new TextDocumentPositionParams
+        {
+            Position = LspFactory.CreatePosition(linePosition),
+            TextDocument = new TextDocumentIdentifier { DocumentUri = document.CreateDocumentUri() },
+        };
+
+        var hoverResult = await endpoint.GetTestAccessor().HandleRequestAsync(textDocumentPositionParams, document, DisposalToken);
+        Assert.NotNull(hoverResult);
+    }
+
+    [Fact]
+    public async Task GetRequiredCodeDocument_SucceedsAndReturnsRetryProject()
+    {
+        RazorCohostingOptions.UseRazorCohostServer = false;
+
+        TestCode input = """
+            <div></div>
+            """;
+        var document = CreateProjectAndRazorDocument(input.Text, RazorFileKind.Component);
+
+        // Make sure the source generator has been run while cohosting is off, to simular Roslyn winning the initialization race
+        //var compilation = await document.Project.GetCompilationAsync(DisposalToken);
+        Assert.Empty(await document.Project.GetSourceGeneratedDocumentsAsync(DisposalToken));
+
+        // Now turn the source generator on, to simulate Razor starting up and initializing OOP
+        RazorCohostingOptions.UseRazorCohostServer = true;
+
+        var snapshotManager = OOPExportProvider.GetExportedValue<RemoteSnapshotManager>();
+        var projectSnapshot = snapshotManager.GetSnapshot(document.Project);
+        var documentSnapshot = projectSnapshot.GetDocument(document);
+
+        await projectSnapshot.GetRequiredCodeDocumentAsync(documentSnapshot, DisposalToken);
+
+        Assert.True(projectSnapshot.Project.IsRetryProject());
+    }
+
+    [Fact]
+    public async Task GetSnapshot_ReturnsDifferentSolutionSnapshots()
+    {
+        RazorCohostingOptions.UseRazorCohostServer = false;
+
+        TestCode input = """
+            <div></div>
+            """;
+        var document = CreateProjectAndRazorDocument(input.Text, RazorFileKind.Component);
+
+        // Make sure the source generator has been run while cohosting is off, to simular Roslyn winning the initialization race
+        //var compilation = await document.Project.GetCompilationAsync(DisposalToken);
+        Assert.Empty(await document.Project.GetSourceGeneratedDocumentsAsync(DisposalToken));
+
+        var snapshotManager = OOPExportProvider.GetExportedValue<RemoteSnapshotManager>();
+
+        var solutionSnapshot = snapshotManager.GetSnapshot(document.Project.Solution);
+
+        // Now turn the source generator on, to simulate Razor starting up and initializing OOP
+        RazorCohostingOptions.UseRazorCohostServer = true;
+
+        var projectSnapshot = snapshotManager.GetSnapshot(document.Project);
+        var documentSnapshot = projectSnapshot.GetDocument(document);
+        await projectSnapshot.GetRequiredCodeDocumentAsync(documentSnapshot, DisposalToken);
+
+        var newSolutionSnapshot = snapshotManager.GetSnapshot(document.Project.Solution);
+
+        Assert.NotSame(solutionSnapshot, newSolutionSnapshot);
+    }
+
+    [Fact]
+    public async Task CohostingOff_Throws()
+    {
+        RazorCohostingOptions.UseRazorCohostServer = false;
+
+        TestCode input = """
+            <div></div>
+            """;
+        var document = CreateProjectAndRazorDocument(input.Text, RazorFileKind.Component);
+
+        // Make sure the source generator has been run while cohosting is off, to simular Roslyn winning the initialization race
+        //var compilation = await document.Project.GetCompilationAsync(DisposalToken);
+        Assert.Empty(await document.Project.GetSourceGeneratedDocumentsAsync(DisposalToken));
+
+        var snapshotManager = OOPExportProvider.GetExportedValue<RemoteSnapshotManager>();
+
+        var projectSnapshot = snapshotManager.GetSnapshot(document.Project);
+        var documentSnapshot = projectSnapshot.GetDocument(document);
+
+        // Make sure we don't infinite loop retrying if cohosting is off
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => projectSnapshot.GetRequiredCodeDocumentAsync(documentSnapshot, DisposalToken));
+        Assert.StartsWith(SR.FormatRazor_source_generator_did_not_produce_a_host_output(projectSnapshot.Project.Name, ""), exception.Message);
+    }
+
+    [Fact]
+    public async Task ProjectChanges_NotRetryProject()
+    {
+        RazorCohostingOptions.UseRazorCohostServer = false;
+
+        TestCode input = """
+            <div></div>
+            """;
+        var document = CreateProjectAndRazorDocument(input.Text, RazorFileKind.Component);
+
+        // Make sure the source generator has been run while cohosting is off, to simular Roslyn winning the initialization race
+        //var compilation = await document.Project.GetCompilationAsync(DisposalToken);
+        Assert.Empty(await document.Project.GetSourceGeneratedDocumentsAsync(DisposalToken));
+
+        var snapshotManager = OOPExportProvider.GetExportedValue<RemoteSnapshotManager>();
+
+        // Now turn the source generator on, to simulate Razor starting up and initializing OOP
+        RazorCohostingOptions.UseRazorCohostServer = true;
+
+        var projectSnapshot = snapshotManager.GetSnapshot(document.Project);
+        var documentSnapshot = projectSnapshot.GetDocument(document);
+        await projectSnapshot.GetRequiredCodeDocumentAsync(documentSnapshot, DisposalToken);
+
+        Assert.True(projectSnapshot.Project.IsRetryProject());
+
+        var changedDocument = document.Project.Solution.WithAdditionalDocumentText(document.Id, SourceText.From("Different")).GetAdditionalDocument(document.Id);
+        Assert.NotNull(changedDocument);
+
+        projectSnapshot = snapshotManager.GetSnapshot(changedDocument.Project);
+        documentSnapshot = projectSnapshot.GetDocument(changedDocument);
+        await projectSnapshot.GetRequiredCodeDocumentAsync(documentSnapshot, DisposalToken);
+
+        Assert.False(projectSnapshot.Project.IsRetryProject());
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/RetryProjectTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/RetryProjectTest.cs
@@ -69,7 +69,7 @@ public class RetryProjectTest(ITestOutputHelper testOutputHelper) : CohostEndpoi
             """;
         var document = CreateProjectAndRazorDocument(input.Text, RazorFileKind.Component);
 
-        // Make sure the source generator has been run while cohosting is off, to simular Roslyn winning the initialization race
+        // Make sure the source generator has been run while cohosting is off, to simulate Roslyn winning the initialization race
         //var compilation = await document.Project.GetCompilationAsync(DisposalToken);
         Assert.Empty(await document.Project.GetSourceGeneratedDocumentsAsync(DisposalToken));
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/RetryProjectTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/RetryProjectTest.cs
@@ -35,14 +35,6 @@ public class RetryProjectTest(ITestOutputHelper testOutputHelper) : CohostEndpoi
         // Now turn the source generator on, to simulate Razor starting up and initializing OOP
         RazorCohostingOptions.UseRazorCohostServer = true;
 
-        var snapshotManager = OOPExportProvider.GetExportedValue<RemoteSnapshotManager>();
-        var projectSnapshot = snapshotManager.GetSnapshot(document.Project);
-        var documentSnapshot = projectSnapshot.GetDocument(document);
-
-        await projectSnapshot.GetRequiredCodeDocumentAsync(documentSnapshot, DisposalToken);
-
-        Assert.True(projectSnapshot.Project.IsRetryProject());
-
         var inputText = await document.GetTextAsync(DisposalToken);
         var linePosition = inputText.GetLinePosition(input.Position);
 
@@ -82,6 +74,7 @@ public class RetryProjectTest(ITestOutputHelper testOutputHelper) : CohostEndpoi
 
         await projectSnapshot.GetRequiredCodeDocumentAsync(documentSnapshot, DisposalToken);
 
+        projectSnapshot = snapshotManager.GetSnapshot(document.Project);
         Assert.True(projectSnapshot.Project.IsRetryProject());
     }
 
@@ -162,6 +155,7 @@ public class RetryProjectTest(ITestOutputHelper testOutputHelper) : CohostEndpoi
         var documentSnapshot = projectSnapshot.GetDocument(document);
         await projectSnapshot.GetRequiredCodeDocumentAsync(documentSnapshot, DisposalToken);
 
+        projectSnapshot = snapshotManager.GetSnapshot(document.Project);
         Assert.True(projectSnapshot.Project.IsRetryProject());
 
         var changedDocument = document.Project.Solution.WithAdditionalDocumentText(document.Id, SourceText.From("Different")).GetAdditionalDocument(document.Id);


### PR DESCRIPTION
Fixes the startup issue we have if Razor loses the race condition, and Roslyn caches the generator run result while it's in "cohosting off" mode.

Essentially our snapshot manager, which is our first port of call for "I would like to run this OOP service for this solution snapshot" will not sometimes redirect calls to a forked snapshot, that ensures the generator will have had a chance to re-run after it has seen the cohosting flag turn on. Some minor changes to solution and project snapshots because this could happen while code is in-flight, but after the first requests are done, subsequent requests flow through the system as normal (albeit being silently redirected to the fork) and once almost any change to the project or additional files has happened, the whole "retry project" notion becomes unnecessary.

Val build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2793362&view=results
Test insertion: https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/670224