### PR TITLE
Skip test on mac

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudioCode.RazorExtension.Test/RazorWorkspaceListenerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudioCode.RazorExtension.Test/RazorWorkspaceListenerTest.cs
@@ -80,7 +80,7 @@ public class RazorWorkspaceListenerTest(ITestOutputHelper testOutputHelper) : To
         Assert.Equal(1, listener.SerializeCalls[project2.Id]);
     }
 
-    [Fact]
+    [ConditionalFact(Is.Windows)]
     public async Task ProjectAddedAndRemoved_NoTasks()
     {
         using var workspace = new AdhocWorkspace(CodeAnalysis.Host.Mef.MefHostServices.DefaultHost);


### PR DESCRIPTION
This test is flaky on Mac, and has broken a few of my PR runs, and even our official `main` CI run a few times.

Justification:
* This test wasn't running on Mac at all until 4 days ago anyway
* The code under test doesn't run in cohosting, so will be deleted soon enough anyway.