### PR TITLE
Reduce redundant import tree parsing

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultRazorParsingPhase.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultRazorParsingPhase.cs
@@ -13,7 +13,7 @@ internal class DefaultRazorParsingPhase : RazorEnginePhaseBase, IRazorParsingPha
     private static readonly ConditionalWeakTable<RazorSourceDocument, RazorSyntaxTree> s_importTrees = new();
 
 #if !NET
-    private static readonly object s_importTreeslock = new();
+    private static readonly object s_importTreesLock = new();
 #endif
 
     protected override void ExecuteCore(RazorCodeDocument codeDocument, CancellationToken cancellationToken)
@@ -37,7 +37,7 @@ internal class DefaultRazorParsingPhase : RazorEnginePhaseBase, IRazorParsingPha
 #else
                 // NetStandard2.0 doesn't have a nice AddOrUpdate method, so we'll use our own locking to
                 // ensure the CWT is updated correctly.
-                lock (s_importTreeslock)
+                lock (s_importTreesLock)
                 {
                     if (TryGetCachedImportTree(import, options, out var cachedTree))
                     {

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultRazorParsingPhase.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultRazorParsingPhase.cs
@@ -1,6 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if !NET
+using System;
+#endif
+
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 
@@ -8,6 +13,8 @@ namespace Microsoft.AspNetCore.Razor.Language;
 
 internal class DefaultRazorParsingPhase : RazorEnginePhaseBase, IRazorParsingPhase
 {
+    private static readonly ConditionalWeakTable<RazorSourceDocument, RazorSyntaxTree> s_importTrees = new();
+
     protected override void ExecuteCore(RazorCodeDocument codeDocument, CancellationToken cancellationToken)
     {
         var options = codeDocument.ParserOptions;
@@ -18,7 +25,27 @@ internal class DefaultRazorParsingPhase : RazorEnginePhaseBase, IRazorParsingPha
 
         foreach (var import in codeDocument.Imports)
         {
-            importSyntaxTrees.Add(RazorSyntaxTree.Parse(import, options));
+            if (!s_importTrees.TryGetValue(import, out var tree)
+                || !tree.Options.Equals(options))
+            {
+                tree = RazorSyntaxTree.Parse(import, options);
+
+#if NET
+                s_importTrees.AddOrUpdate(import, tree);
+#else
+                try
+                {
+                    // good effort update of CWT value
+                    s_importTrees.Remove(import);
+                    s_importTrees.Add(import, tree);
+                }
+                catch (ArgumentException)
+                {
+                }
+#endif
+            }
+
+            importSyntaxTrees.Add(tree);
         }
 
         codeDocument.SetImportSyntaxTrees(importSyntaxTrees.ToImmutableAndClear());

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorParserOptions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorParserOptions.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.CSharp;
 namespace Microsoft.AspNetCore.Razor.Language;
 
 public sealed partial class RazorParserOptions
+    : IEquatable<RazorParserOptions>
 {
     private static RazorLanguageVersion DefaultLanguageVersion => RazorLanguageVersion.Latest;
     private static RazorFileKind DefaultFileKind => RazorFileKind.Legacy;
@@ -190,5 +191,16 @@ public sealed partial class RazorParserOptions
         return flags == _flags
             ? this
             : new(LanguageVersion, FileKind, Directives, CSharpParseOptions, flags);
+    }
+
+    public bool Equals(RazorParserOptions? other)
+    {
+        return
+            other is not null
+            && LanguageVersion == other.LanguageVersion
+            && FileKind == other.FileKind
+            && CSharpParseOptions == other.CSharpParseOptions
+            && _flags == other._flags
+            && Directives.SequenceEqual(other.Directives);
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorParserOptions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorParserOptions.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using Microsoft.AspNetCore.Razor.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language;
 
@@ -197,10 +199,28 @@ public sealed partial class RazorParserOptions
     {
         return
             other is not null
-            && LanguageVersion == other.LanguageVersion
-            && FileKind == other.FileKind
-            && CSharpParseOptions == other.CSharpParseOptions
             && _flags == other._flags
-            && Directives.SequenceEqual(other.Directives);
+            && FileKind == other.FileKind
+            && LanguageVersion == other.LanguageVersion
+            && CSharpParseOptions == other.CSharpParseOptions
+            && Directives.SequenceEqual(other.Directives, ReferenceEqualityComparer<DirectiveDescriptor>.Instance);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return Equals(obj as RazorParserOptions);
+    }
+
+    public override int GetHashCode()
+    {
+        var combiner = HashCodeCombiner.Start();
+        combiner.Add(base.GetHashCode());
+        combiner.Add(_flags);
+        combiner.Add(FileKind);
+        combiner.Add(LanguageVersion);
+        combiner.Add(CSharpParseOptions);
+        combiner.Add(Directives);
+
+        return combiner.CombinedHash;
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorParserOptions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorParserOptions.cs
@@ -214,12 +214,11 @@ public sealed partial class RazorParserOptions
     public override int GetHashCode()
     {
         var combiner = HashCodeCombiner.Start();
-        combiner.Add(base.GetHashCode());
         combiner.Add(_flags);
         combiner.Add(FileKind);
         combiner.Add(LanguageVersion);
         combiner.Add(CSharpParseOptions);
-        combiner.Add(Directives);
+        combiner.Add(Directives, ReferenceEqualityComparer<DirectiveDescriptor>.Instance);
 
         return combiner.CombinedHash;
     }


### PR DESCRIPTION
The same RazorSourceDocument for imports gets parsed many times during solution load. This simply holds onto those results so we don't need to reparse the same import document multiple times.

This is just the simplest way I could see to do this, but I don't know this area very well, so if anyone has a better suggestion to reduce these parses, I'm very willing to look into those approaches too. The other approaches I started to dig into other than a CWT ended up changing public apis, so I went this approach with the acknowledgement that I would call out my uncertainty in the PR and ask for other approaches.

This shows a pretty large reduction in both CPU and allocations under DefaultRazorParsingPhase.ExecurtCore. From the test insertion, I see CPU go from 2876 ms (3.9%) to 1412 ms (2.1%). Allocations went from 199.4 MB (7.9%) to 95.5 MB (4.1%).

Test insertion: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/670198