### PR TITLE
Reduce closure allocations in TokenizerBackedParser.ConfigureSpanContext

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/TokenizerBackedParser.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/TokenizerBackedParser.cs
@@ -705,11 +705,15 @@ internal abstract class TokenizerBackedParser<TTokenizer> : ParserBase, IDisposa
 
     protected void ConfigureSpanContext(SpanContextConfigActionWithPreviousConfig? config)
     {
-        var prev = SpanContextConfig;
         SpanContextConfig = config == null
             ? null
-            : ((SpanEditHandlerBuilder? span, ref ISpanChunkGenerator? chunkGenerator) => config(span, ref chunkGenerator, prev));
+            : GetNewSpanContextConfigAction(config, SpanContextConfig);
         InitializeContext();
+
+        static SpanContextConfigAction GetNewSpanContextConfigAction(SpanContextConfigActionWithPreviousConfig config, SpanContextConfigAction? prev)
+        {
+            return (span, ref chunkGenerator) => config(span, ref chunkGenerator, prev);
+        }
     }
 
     protected void InitializeContext()


### PR DESCRIPTION
Reduce closure allocations in TokenizerBackedParser.ConfigureSpanContext

Move the closure allocation to it's own method which should slightly reduce allocations when there isn't an existing SpanContextConfig.

Speeedometer run failed for some reason and I don't want to wait another 8 hours to get verify what I'm pretty confident in already.

Test insertion pipeline run (failed): https://dev.azure.com/dnceng/internal/_build/results?buildId=2795099&view=results