### PR TITLE
Fix breakpoint placement in cohosting

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/CohostStartupService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/CohostStartupService.cs
@@ -14,9 +14,7 @@ using Microsoft.CodeAnalysis.Razor.Protocol;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 
-#pragma warning disable CS0618 // Type or member is obsolete. Will be addressed in https://github.com/dotnet/razor/pull/12079 but Roslyn changes are batched
 [Export(typeof(ICohostStartupService))]
-#pragma warning restore CS0618 // Type or member is obsolete
 [method: ImportingConstructor]
 internal sealed class CohostStartupService(
     [ImportMany] IEnumerable<Lazy<IRazorCohostStartupService>> lazyStartupServices,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostActivator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostActivator.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+[Export(typeof(IRazorCohostStartupService))]
+[method: ImportingConstructor]
+internal sealed class CohostActivator(ILspServerActivationTracker activationTracker) : IRazorCohostStartupService
+{
+    private readonly ILspServerActivationTracker _activationTracker = activationTracker;
+
+    public int Order => WellKnownStartupOrder.Default;
+
+    public Task StartupAsync(VSInternalClientCapabilities clientCapabilities, RazorCohostRequestContext requestContext, CancellationToken cancellationToken)
+    {
+        _activationTracker.Activated();
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/RazorProjectSystemInProcess.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/RazorProjectSystemInProcess.cs
@@ -157,6 +157,8 @@ internal partial class RazorProjectSystemInProcess
     {
         if (await IsCohostingActiveAsync(cancellationToken))
         {
+            // In cohosting we don't wait for anything, we just update the Razor doc and assume that Roslyn will do the right things
+            await updater();
             return;
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/12243

Breakpoint placement was working fine, but our IVsLanguageDebugInfo implementation waits for the "LSP server" to activate, so figured we'd better let it know we have :)