### PR TITLE
Update ngen priorities for Razor assemblies

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -190,7 +190,7 @@
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.VisualStudio.LanguageServer.ContainedLanguage\Microsoft.VisualStudio.LanguageServer.ContainedLanguage.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.LanguageServices.Razor\Microsoft.VisualStudio.LanguageServices.Razor.csproj" >
-      <NgenPriority>1</NgenPriority>
+      <NgenPriority>2</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.VisualStudio.LegacyEditor.Razor\Microsoft.VisualStudio.LegacyEditor.Razor.csproj" />
     <ProjectReference Include="..\..\..\Compiler\Microsoft.CodeAnalysis.Razor.Compiler\src\Microsoft.CodeAnalysis.Razor.Compiler.csproj">
@@ -219,7 +219,7 @@
   <ItemGroup>
     <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.Razor.Compiler.dll">
       <Ngen>true</Ngen>
-      <NgenPriority>1</NgenPriority>
+      <NgenPriority>2</NgenPriority>
     </VSIXSourceItem>
   </ItemGroup>
 


### PR DESCRIPTION
﻿### Summary of the changes
VS 2026 is focused on improving startup time. To do this, we are changing ngen priorities so only assemblies with large JIT time during startup are priority 2. 

This change updates the priorities of Microsoft.CodeAnlysis.Razor.Complier.dll and Microsoft.VisualStudio.LanguageServices.Razor.dll to be priority 2 since they were not a part of the startup trace of VS 2026.
