### PR TITLE
Fix some issues with our options in the new experience

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/SemanticTokensRefreshNotifier.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/SemanticTokensRefreshNotifier.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Settings;
+using Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer;
+
+[Export(typeof(IRazorCohostStartupService))]
+[method: ImportingConstructor]
+internal sealed class SemanticTokensRefreshNotifier(IClientSettingsManager clientSettingsManager) : IRazorCohostStartupService, IDisposable
+{
+    private readonly IClientSettingsManager _clientSettingsManager = clientSettingsManager;
+
+    private IRazorClientLanguageServerManager? _razorClientLanguageServerManager;
+    private bool _lastColorBackground;
+
+    public int Order => WellKnownStartupOrder.Default;
+
+    public Task StartupAsync(VSInternalClientCapabilities clientCapabilities, RazorCohostRequestContext requestContext, CancellationToken cancellationToken)
+    {
+        _razorClientLanguageServerManager = requestContext.GetRequiredService<IRazorClientLanguageServerManager>();
+
+        if (clientCapabilities.Workspace?.SemanticTokens?.RefreshSupport ?? false)
+        {
+            _lastColorBackground = _clientSettingsManager.GetClientSettings().AdvancedSettings.ColorBackground;
+            _clientSettingsManager.ClientSettingsChanged += ClientSettingsManager_ClientSettingsChanged;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void ClientSettingsManager_ClientSettingsChanged(object sender, EventArgs e)
+    {
+        var colorBackground = _clientSettingsManager.GetClientSettings().AdvancedSettings.ColorBackground;
+        if (colorBackground == _lastColorBackground)
+        {
+            return;
+        }
+
+        _lastColorBackground = colorBackground;
+        _razorClientLanguageServerManager.AssumeNotNull().SendNotificationAsync(Methods.WorkspaceSemanticTokensRefreshName, CancellationToken.None).Forget();
+    }
+
+    public void Dispose()
+    {
+        _clientSettingsManager.ClientSettingsChanged -= ClientSettingsManager_ClientSettingsChanged;
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Options/OptionsStorage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Options/OptionsStorage.cs
@@ -29,56 +29,6 @@ internal class OptionsStorage : IAdvancedSettingsStorage, IDisposable
     private IDisposable? _unifiedSettingsSubscription;
     private bool _changedBeforeSubscription;
 
-    public bool FormatOnType
-    {
-        get => GetBool(SettingsNames.FormatOnType, defaultValue: true);
-    }
-
-    public bool AutoClosingTags
-    {
-        get => GetBool(SettingsNames.AutoClosingTags, defaultValue: true);
-    }
-
-    public bool AutoInsertAttributeQuotes
-    {
-        get => GetBool(SettingsNames.AutoInsertAttributeQuotes, defaultValue: true);
-    }
-
-    public bool ColorBackground
-    {
-        get => GetBool(SettingsNames.ColorBackground, defaultValue: false);
-    }
-
-    public bool CodeBlockBraceOnNextLine
-    {
-        get => GetBool(SettingsNames.CodeBlockBraceOnNextLine, defaultValue: false);
-    }
-
-    public bool CommitElementsWithSpace
-    {
-        get => GetBool(SettingsNames.CommitElementsWithSpace, defaultValue: true);
-    }
-
-    public SnippetSetting Snippets
-    {
-        get => GetEnum(SettingsNames.Snippets, SnippetSetting.All);
-    }
-
-    public LogLevel LogLevel
-    {
-        get => GetEnum(SettingsNames.LogLevel, LogLevel.Warning);
-    }
-
-    public bool FormatOnPaste
-    {
-        get => GetBool(SettingsNames.FormatOnPaste, defaultValue: true);
-    }
-
-    public ImmutableArray<string> TaskListDescriptors
-    {
-        get { return _taskListDescriptors; }
-    }
-
     [ImportingConstructor]
     public OptionsStorage(
         SVsServiceProvider synchronousServiceProvider,
@@ -148,7 +98,17 @@ internal class OptionsStorage : IAdvancedSettingsStorage, IDisposable
     private EventHandler<ClientAdvancedSettingsChangedEventArgs>? _changed;
 
     public ClientAdvancedSettings GetAdvancedSettings()
-        => new(FormatOnType, AutoClosingTags, AutoInsertAttributeQuotes, ColorBackground, CodeBlockBraceOnNextLine, CommitElementsWithSpace, Snippets, LogLevel, FormatOnPaste, TaskListDescriptors);
+        => new(
+            GetBool(SettingsNames.FormatOnType, defaultValue: true),
+            GetBool(SettingsNames.AutoClosingTags, defaultValue: true),
+            GetBool(SettingsNames.AutoInsertAttributeQuotes, defaultValue: true),
+            GetBool(SettingsNames.ColorBackground, defaultValue: false),
+            GetBool(SettingsNames.CodeBlockBraceOnNextLine, defaultValue: false),
+            GetBool(SettingsNames.CommitElementsWithSpace, defaultValue: true),
+            GetEnum(SettingsNames.Snippets, SnippetSetting.All),
+            GetEnum(SettingsNames.LogLevel, LogLevel.Warning),
+            GetBool(SettingsNames.FormatOnPaste, defaultValue: true),
+            _taskListDescriptors);
 
     public bool GetBool(string name, bool defaultValue)
     {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Options/OptionsStorage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Options/OptionsStorage.cs
@@ -31,55 +31,46 @@ internal class OptionsStorage : IAdvancedSettingsStorage, IDisposable
 
     public bool FormatOnType
     {
-        set => SetBool(SettingsNames.FormatOnType.LegacyName, value);
         get => GetBool(SettingsNames.FormatOnType, defaultValue: true);
     }
 
     public bool AutoClosingTags
     {
-        set => SetBool(SettingsNames.AutoClosingTags.LegacyName, value);
         get => GetBool(SettingsNames.AutoClosingTags, defaultValue: true);
     }
 
     public bool AutoInsertAttributeQuotes
     {
-        set => SetBool(SettingsNames.AutoInsertAttributeQuotes.LegacyName, value);
         get => GetBool(SettingsNames.AutoInsertAttributeQuotes, defaultValue: true);
     }
 
     public bool ColorBackground
     {
-        set => SetBool(SettingsNames.ColorBackground.LegacyName, value);
         get => GetBool(SettingsNames.ColorBackground, defaultValue: false);
     }
 
     public bool CodeBlockBraceOnNextLine
     {
-        set => SetBool(SettingsNames.CodeBlockBraceOnNextLine.LegacyName, value);
         get => GetBool(SettingsNames.CodeBlockBraceOnNextLine, defaultValue: false);
     }
 
     public bool CommitElementsWithSpace
     {
-        set => SetBool(SettingsNames.CommitElementsWithSpace.LegacyName, value);
         get => GetBool(SettingsNames.CommitElementsWithSpace, defaultValue: true);
     }
 
     public SnippetSetting Snippets
     {
-        set => SetInt(SettingsNames.Snippets.LegacyName, (int)value);
         get => GetEnum(SettingsNames.Snippets, SnippetSetting.All);
     }
 
     public LogLevel LogLevel
     {
-        set => SetInt(SettingsNames.LogLevel.LegacyName, (int)value);
         get => GetEnum(SettingsNames.LogLevel, LogLevel.Warning);
     }
 
     public bool FormatOnPaste
     {
-        set => SetBool(SettingsNames.FormatOnPaste.LegacyName, value);
         get => GetBool(SettingsNames.FormatOnPaste, defaultValue: true);
     }
 
@@ -169,14 +160,6 @@ internal class OptionsStorage : IAdvancedSettingsStorage, IDisposable
         return defaultValue;
     }
 
-    public void SetBool(string name, bool value)
-    {
-        _writableSettingsStore.SetBoolean(SettingsNames.LegacyCollection, name, value);
-        _telemetryReporter.Value.ReportEvent("OptionChanged", Severity.Normal, new Property(name, value));
-
-        NotifyChange();
-    }
-
     public T GetEnum<T>(string name, T defaultValue) where T : struct, Enum
     {
         if (_unifiedSettingsReader.AssumeNotNull().GetValue<string>(name) is { Outcome: SettingRetrievalOutcome.Success, Value: { } unifiedValue })
@@ -188,14 +171,6 @@ internal class OptionsStorage : IAdvancedSettingsStorage, IDisposable
         }
 
         return defaultValue;
-    }
-
-    public void SetInt(string name, int value)
-    {
-        _writableSettingsStore.SetInt32(SettingsNames.LegacyCollection, name, value);
-        _telemetryReporter.Value.ReportEvent("OptionChanged", Severity.Normal, new Property(name, value));
-
-        NotifyChange();
     }
 
     private void NotifyChange()

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Options/SettingsNames.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Options/SettingsNames.cs
@@ -6,9 +6,9 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Options;
 internal static class SettingsNames
 {
     public record Setting(string LegacyName, string UnifiedName);
+    public const string UnifiedCollection = "languages.razor.advanced";
 
     public const string LegacyCollection = "Razor";
-    public const string UnifiedCollection = "textEditor.razor.advanced";
 
     public static readonly Setting FormatOnType = new("FormatOnType", UnifiedCollection + ".formatOnType");
     public static readonly Setting AutoClosingTags = new("AutoClosingTags", UnifiedCollection + ".autoClosingTags");

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Options/SettingsNames.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Options/SettingsNames.cs
@@ -5,22 +5,19 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Options;
 
 internal static class SettingsNames
 {
-    public record Setting(string LegacyName, string UnifiedName);
     public const string UnifiedCollection = "languages.razor.advanced";
 
-    public const string LegacyCollection = "Razor";
+    public static readonly string FormatOnType = UnifiedCollection + ".formatOnType";
+    public static readonly string AutoClosingTags = UnifiedCollection + ".autoClosingTags";
+    public static readonly string AutoInsertAttributeQuotes = UnifiedCollection + ".autoInsertAttributeQuotes";
+    public static readonly string ColorBackground = UnifiedCollection + ".colorBackground";
+    public static readonly string CodeBlockBraceOnNextLine = UnifiedCollection + ".codeBlockBraceOnNextLine";
+    public static readonly string CommitElementsWithSpace = UnifiedCollection + ".commitCharactersWithSpace";
+    public static readonly string Snippets = UnifiedCollection + ".snippets";
+    public static readonly string LogLevel = UnifiedCollection + ".logLevel";
+    public static readonly string FormatOnPaste = UnifiedCollection + ".formatOnPaste";
 
-    public static readonly Setting FormatOnType = new("FormatOnType", UnifiedCollection + ".formatOnType");
-    public static readonly Setting AutoClosingTags = new("AutoClosingTags", UnifiedCollection + ".autoClosingTags");
-    public static readonly Setting AutoInsertAttributeQuotes = new("AutoInsertAttributeQuotes", UnifiedCollection + ".autoInsertAttributeQuotes");
-    public static readonly Setting ColorBackground = new("ColorBackground", UnifiedCollection + ".colorBackground");
-    public static readonly Setting CodeBlockBraceOnNextLine = new("CodeBlockBraceOnNextLine", UnifiedCollection + ".codeBlockBraceOnNextLine");
-    public static readonly Setting CommitElementsWithSpace = new("CommitElementsWithSpace", UnifiedCollection + ".commitCharactersWithSpace");
-    public static readonly Setting Snippets = new("Snippets", UnifiedCollection + ".snippets");
-    public static readonly Setting LogLevel = new("LogLevel", UnifiedCollection + ".logLevel");
-    public static readonly Setting FormatOnPaste = new("FormatOnPaste", UnifiedCollection + ".formatOnPaste");
-
-    public static readonly Setting[] AllSettings =
+    public static readonly string[] AllSettings =
     [
         FormatOnType,
         AutoClosingTags,


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/12260
Fixes https://github.com/dotnet/razor/issues/10200

First commit fixes a stupid bug I introduced which caused our settings to just not work. Sometimes it seems they would migrate from the legacy settings, but it was pretty hit and miss.

In manual testing, I then ran into #10200 which I'd forgotten that I'd logged a while ago, but with the benefit of time now that the old options screen is gone completely, the fix is really easy. Seems the legacy settings were just delayed as compared to UI events in the unified settings experience, but we can now just read directly from unified settings. Then I cleaned up a bit.