### PR TITLE
Pull publishdata from branch being published

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -1,4 +1,4 @@
-#
+﻿#
 # See https://docs.microsoft.com/azure/devops/pipelines/yaml-schema for reference.
 #
 
@@ -435,6 +435,6 @@ extends:
               componentPassword: $(dn-bot-dnceng-build-e-code-full-release-e-packaging-r)
               componentBuildProjectName: internal
               sourceBranch: "$(ComponentBranchName)"
-              publishDataURI: "https://dev.azure.com/dnceng/internal/_apis/git/repositories/dotnet-razor/items?path=/eng/config/PublishData.json&api-version=6.0"
+              publishDataURI: "https://dev.azure.com/dnceng/internal/_apis/git/repositories/dotnet-razor/items?path=eng/config/PublishData.json&version=$(ComponentBranchName)&api-version=6.0"
               publishDataAccessToken: "$(System.AccessToken)"
               dropPath: '$(Pipeline.Workspace)\VSSetup'


### PR DESCRIPTION
﻿### Summary of the changes
Pull publish data from the branch being published.  Same change made in Roslyn to make it easier to allow us to cleanup publishdata and make it easier to configure branch publishing.

Validation in progress