### PR TITLE
Ensure RazorVSInternalCompletionParams is used for serialization of completion requests

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlRequestInvoker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlRequestInvoker.cs
@@ -68,7 +68,7 @@ internal sealed class HtmlRequestInvoker(
             _logger.LogDebug($"Making LSP request for {method} from {htmlDocument.Uri}{(request is ITextDocumentPositionParams positionParams ? $" at {positionParams.Position}" : "")}, checksum {syncResult.Checksum}.");
 
             // Passing Guid.Empty to this method will mean no tracking
-            using var _ = _telemetryReporter.TrackLspRequest(Methods.TextDocumentCodeActionName, RazorLSPConstants.HtmlLanguageServerName, threshold, correlationId);
+            using var _ = _telemetryReporter.TrackLspRequest(method, RazorLSPConstants.HtmlLanguageServerName, threshold, correlationId);
 
             var result = await _requestInvoker.ReinvokeRequestOnServerAsync<TRequest, TResponse?>(
                 htmlDocument.Snapshot.TextBuffer,


### PR DESCRIPTION
Without this type being used, serialization loses the VSInternalCompletionContext.InvokeKind, which is critical for webtools to determine the correct range to replace.

Without this, webtools indicates a range to be replaced based on the assumption that this is a forced completion session, which in turns affects how vseditor determines filtering of items in the completion list.

Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2581568