### PR TITLE
Better handle attribute snippet completion in components

### DIFF
--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
@@ -220,6 +220,19 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
     }
 
     [Fact]
+    public void GetAttributeCompletions_NonIndexer_ReturnsCompletionWithEqualsCommitInsertFalse()
+    {
+        // Arrange
+        var owner = GetOwner("<input @$$></input>");
+
+        // Act
+        var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions(owner, "@", "input", [], _defaultTagHelperContext, _defaultRazorCompletionOptions);
+
+        // Assert
+        AssertContains(completions, "bind=\"$0\"", "@bind", [new RazorCommitCharacter("=", Insert: false), new RazorCommitCharacter(":")]);
+    }
+
+    [Fact]
     public void GetAttributeCompletions_WithNoAutoQuotesOption_ReturnsNonQuotedSnippet()
     {
         // Arrange
@@ -271,7 +284,7 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
         var completions = DirectiveAttributeCompletionItemProvider.GetAttributeCompletions(owner, "@", "input", [], _defaultTagHelperContext, _defaultRazorCompletionOptions);
 
         // Assert
-        AssertContains(completions, "bind-", "@bind-...", []);
+        AssertContains(completions, "bind-", "@bind-...", ImmutableArray<string>.Empty);
     }
 
     [Fact]
@@ -318,6 +331,17 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
             insertText == completion.InsertText &&
             displayText == completion.DisplayText &&
             commitCharacters.SequenceEqual(completion.CommitCharacters.Select(c => c.Character)) &&
+            RazorCompletionItemKind.DirectiveAttribute == completion.Kind);
+    }
+
+    private static void AssertContains(ImmutableArray<RazorCompletionItem> completions, string insertText, string displayText, ImmutableArray<RazorCommitCharacter> commitCharacters)
+    {
+        displayText ??= insertText;
+
+        Assert.Contains(completions, completion =>
+            insertText == completion.InsertText &&
+            displayText == completion.DisplayText &&
+            commitCharacters.SequenceEqual(completion.CommitCharacters) &&
             RazorCompletionItemKind.DirectiveAttribute == completion.Kind);
     }
 


### PR DESCRIPTION
Better handle attribute snippet completion in components

This addresses a scenario where completion commit would insert an extra '=' inside the attribute value. For example, committing "@&#8203;ref" via typing '=' in this code 

```HTML+Razor
<p @re />
```

below would end up with the following document contents:

```HTML+Razor
<p @ref="=" />
```

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2581843