### PR TITLE
Fix syntax errors in test inputs

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/Shared/CohostDocumentHighlightEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/Shared/CohostDocumentHighlightEndpointTest.cs
@@ -134,7 +134,7 @@ public class CohostDocumentHighlightEndpointTest(ITestOutputHelper testOutputHel
 
                 @code
                 {
-                    [|IDisposable|].Dispose()
+                    void Dispose([|IDisposable|] thingToDispose)
                     {
                     }
                 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/Shared/CohostFoldingRangeEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/Shared/CohostFoldingRangeEndpointTest.cs
@@ -86,13 +86,13 @@ public class CohostFoldingRangeEndpointTest(ITestOutputHelper testOutputHelper) 
                 <div>
                   Hello World
                 </div>
-                else {[|
+                } else {[|
                 <div>
                     Goodbye World
                 </div>
                 }|]
-              }
-            |]</div>
+            |]  }
+            </div>
             """);
 
     [Fact]
@@ -160,7 +160,7 @@ public class CohostFoldingRangeEndpointTest(ITestOutputHelper testOutputHelper) 
             <p>hello!</p>
 
             @code {[|
-                var helloWorld = "";
+                private string helloWorld = "";
             }|]
 
             <p>hello!</p>
@@ -172,7 +172,7 @@ public class CohostFoldingRangeEndpointTest(ITestOutputHelper testOutputHelper) 
             <p>hello!</p>
 
             @functions {[|
-                var helloWorld = "";
+                private string helloWorld = "";
             }|]
 
             <p>hello!</p>

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/Shared/CohostGoToDefinitionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/Shared/CohostGoToDefinitionEndpointTest.cs
@@ -28,8 +28,9 @@ public class CohostGoToDefinitionEndpointTest(ITestOutputHelper testOutputHelper
             }
             @functions
             {
-                void [|GetX|]()
+                int [|GetX|]()
                 {
+                    return 4;
                 }
             }
             """;
@@ -248,7 +249,7 @@ public class CohostGoToDefinitionEndpointTest(ITestOutputHelper testOutputHelper
                         {
                             public string Invoke(int authorId)
                             {
-                                return firstName;
+                                return "Steve";
                             }
                         }
                         """).Text));

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/Shared/CohostGoToImplementationEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/Shared/CohostGoToImplementationEndpointTest.cs
@@ -30,8 +30,9 @@ public class CohostGoToImplementationEndpointTest(ITestOutputHelper testOutputHe
 
             @code
             {
-                void [|GetX|]()
+                int [|GetX|]()
                 {
+                    return 4;
                 }
             }
             """;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/Shared/CohostInlayHintEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/Shared/CohostInlayHintEndpointTest.cs
@@ -116,6 +116,7 @@ public class CohostInlayHintEndpointTest(ITestOutputHelper testOutputHelper) : C
                     <InputText Value="@(_value)" />
                 </div>
 
+                @code { private string _value = ""; }
                 """,
             toolTipMap: [],
             output: """
@@ -125,7 +126,8 @@ public class CohostInlayHintEndpointTest(ITestOutputHelper testOutputHelper) : C
                     <InputText Value="@_value" />
                     <InputText Value="@(_value)" />
                 </div>
-
+                
+                @code { private string _value = ""; }
                 """);
 
     [Theory]


### PR DESCRIPTION
Noticed the folding range test was invalid and wrong, and wondered how many other tests might be invalid due to mistakes so decided to fix them all. Turns out they were mostly fine. Of course a whole bunch need to not compile, so didn't put in permanent validation or anything.
