### PR TITLE
Revert "Revert "Fix some issues with our options in the new experience""

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/SemanticTokensRefreshNotifier.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/SemanticTokensRefreshNotifier.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Settings;
+using Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer;
+
+[Export(typeof(IRazorCohostStartupService))]
+[method: ImportingConstructor]
+internal sealed class SemanticTokensRefreshNotifier(IClientSettingsManager clientSettingsManager) : IRazorCohostStartupService, IDisposable
+{
+    private readonly IClientSettingsManager _clientSettingsManager = clientSettingsManager;
+
+    private IRazorClientLanguageServerManager? _razorClientLanguageServerManager;
+    private bool _lastColorBackground;
+
+    public int Order => WellKnownStartupOrder.Default;
+
+    public Task StartupAsync(VSInternalClientCapabilities clientCapabilities, RazorCohostRequestContext requestContext, CancellationToken cancellationToken)
+    {
+        _razorClientLanguageServerManager = requestContext.GetRequiredService<IRazorClientLanguageServerManager>();
+
+        if (clientCapabilities.Workspace?.SemanticTokens?.RefreshSupport ?? false)
+        {
+            _lastColorBackground = _clientSettingsManager.GetClientSettings().AdvancedSettings.ColorBackground;
+            _clientSettingsManager.ClientSettingsChanged += ClientSettingsManager_ClientSettingsChanged;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void ClientSettingsManager_ClientSettingsChanged(object sender, EventArgs e)
+    {
+        var colorBackground = _clientSettingsManager.GetClientSettings().AdvancedSettings.ColorBackground;
+        if (colorBackground == _lastColorBackground)
+        {
+            return;
+        }
+
+        _lastColorBackground = colorBackground;
+        _razorClientLanguageServerManager.AssumeNotNull().SendNotificationAsync(Methods.WorkspaceSemanticTokensRefreshName, CancellationToken.None).Forget();
+    }
+
+    public void Dispose()
+    {
+        _clientSettingsManager.ClientSettingsChanged -= ClientSettingsManager_ClientSettingsChanged;
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Options/SettingsNames.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Options/SettingsNames.cs
@@ -5,22 +5,19 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Options;
 
 internal static class SettingsNames
 {
-    public record Setting(string LegacyName, string UnifiedName);
+    public const string UnifiedCollection = "languages.razor.advanced";
 
-    public const string LegacyCollection = "Razor";
-    public const string UnifiedCollection = "textEditor.razor.advanced";
+    public static readonly string FormatOnType = UnifiedCollection + ".formatOnType";
+    public static readonly string AutoClosingTags = UnifiedCollection + ".autoClosingTags";
+    public static readonly string AutoInsertAttributeQuotes = UnifiedCollection + ".autoInsertAttributeQuotes";
+    public static readonly string ColorBackground = UnifiedCollection + ".colorBackground";
+    public static readonly string CodeBlockBraceOnNextLine = UnifiedCollection + ".codeBlockBraceOnNextLine";
+    public static readonly string CommitElementsWithSpace = UnifiedCollection + ".commitCharactersWithSpace";
+    public static readonly string Snippets = UnifiedCollection + ".snippets";
+    public static readonly string LogLevel = UnifiedCollection + ".logLevel";
+    public static readonly string FormatOnPaste = UnifiedCollection + ".formatOnPaste";
 
-    public static readonly Setting FormatOnType = new("FormatOnType", UnifiedCollection + ".formatOnType");
-    public static readonly Setting AutoClosingTags = new("AutoClosingTags", UnifiedCollection + ".autoClosingTags");
-    public static readonly Setting AutoInsertAttributeQuotes = new("AutoInsertAttributeQuotes", UnifiedCollection + ".autoInsertAttributeQuotes");
-    public static readonly Setting ColorBackground = new("ColorBackground", UnifiedCollection + ".colorBackground");
-    public static readonly Setting CodeBlockBraceOnNextLine = new("CodeBlockBraceOnNextLine", UnifiedCollection + ".codeBlockBraceOnNextLine");
-    public static readonly Setting CommitElementsWithSpace = new("CommitElementsWithSpace", UnifiedCollection + ".commitCharactersWithSpace");
-    public static readonly Setting Snippets = new("Snippets", UnifiedCollection + ".snippets");
-    public static readonly Setting LogLevel = new("LogLevel", UnifiedCollection + ".logLevel");
-    public static readonly Setting FormatOnPaste = new("FormatOnPaste", UnifiedCollection + ".formatOnPaste");
-
-    public static readonly Setting[] AllSettings =
+    public static readonly string[] AllSettings =
     [
         FormatOnType,
         AutoClosingTags,


### PR DESCRIPTION
Reverts dotnet/razor#12288

Second commit fixes the mistake in our setting names that caused the fault. Looks like the mismatch in names has always been there, so this setting was never working properly between new and old options screens.