### PR TITLE
Bring our in-memory logger to OOP

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Logging/AbstractMemoryLoggerProvider.Buffer.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Logging/AbstractMemoryLoggerProvider.Buffer.cs
@@ -4,9 +4,9 @@
 using System;
 using System.Threading;
 
-namespace Microsoft.VisualStudio.Razor.Logging;
+namespace Microsoft.CodeAnalysis.Razor.Logging;
 
-internal partial class MemoryLoggerProvider
+internal partial class AbstractMemoryLoggerProvider
 {
     /// <summary>
     /// A circular in memory buffer to store logs in memory.

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Logging/AbstractMemoryLoggerProvider.Logger.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Logging/AbstractMemoryLoggerProvider.Logger.cs
@@ -2,11 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using Microsoft.CodeAnalysis.Razor.Logging;
 
-namespace Microsoft.VisualStudio.Razor.Logging;
+namespace Microsoft.CodeAnalysis.Razor.Logging;
 
-internal partial class MemoryLoggerProvider
+internal partial class AbstractMemoryLoggerProvider
 {
     private class Logger(Buffer buffer, string categoryName) : ILogger
     {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Logging/AbstractMemoryLoggerProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Logging/AbstractMemoryLoggerProvider.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.CodeAnalysis.Razor.Logging;
+
+internal abstract partial class AbstractMemoryLoggerProvider : ILoggerProvider
+{
+    // How many messages will the buffer contain
+    private const int BufferSize = 5000;
+    private readonly Buffer _buffer = new(BufferSize);
+
+    public ILogger CreateLogger(string categoryName)
+        => new Logger(_buffer, categoryName);
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Logging/MemoryLoggerProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Logging/MemoryLoggerProvider.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis.Razor.Logging;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor.Logging;
+
+internal sealed class MemoryLoggerProvider : AbstractMemoryLoggerProvider
+{
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Logging/TraceSourceLoggerFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Logging/TraceSourceLoggerFactory.cs
@@ -6,7 +6,10 @@ using Microsoft.CodeAnalysis.Razor.Logging;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor.Logging;
 
-internal sealed partial class TraceSourceLoggerFactory(TraceSource traceSource) : AbstractLoggerFactory([new LoggerProvider(traceSource)])
+internal sealed partial class TraceSourceLoggerFactory(TraceSource traceSource)
+    : AbstractLoggerFactory([
+        new LoggerProvider(traceSource),
+        new MemoryLoggerProvider()])
 {
     public TraceSource TraceSource { get; } = traceSource;
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/MemoryLoggerProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/MemoryLoggerProvider.cs
@@ -6,12 +6,6 @@ using Microsoft.CodeAnalysis.Razor.Logging;
 namespace Microsoft.VisualStudio.Razor.Logging;
 
 [ExportLoggerProvider]
-internal partial class MemoryLoggerProvider : ILoggerProvider
+internal sealed class MemoryLoggerProvider : AbstractMemoryLoggerProvider
 {
-    // How many messages will the buffer contain
-    private const int BufferSize = 5000;
-    private readonly Buffer _buffer = new(BufferSize);
-
-    public ILogger CreateLogger(string categoryName)
-        => new Logger(_buffer, categoryName);
 }


### PR DESCRIPTION
The in-memory logger we have has been very useful in diagnosing what is actually going on when looking at a memory dump. Now that a lot of our work happens in the Roslyn OOP, we're missing out on a lot of those log messages.