### PR TITLE
Revert "[release/dev18.0] Revert "Revert "Default the cohosting option in the generator to on."""

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorCohostingOptions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorCohostingOptions.cs
@@ -5,5 +5,5 @@ internal static class RazorCohostingOptions
     /// <summary>
     /// True if razor is running in the cohosting mode
     /// </summary>
-    internal static bool UseRazorCohostServer { get; set; } = true;
+    internal static bool UseRazorCohostServer { get; set; } = false;
 }

--- a/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorTests.cs
+++ b/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorTests.cs
@@ -10,7 +10,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -2616,9 +2615,6 @@ namespace AspNetCoreGeneratedDocument
             // start with the generator suppressed (this is the default state in VS)
             driver = SetSuppressionState(true);
 
-            // Disable co-hosting, this test only applies to non-cohosting scenarios
-            RazorCohostingOptions.UseRazorCohostServer = false;
-
             // results should be empty, and no recorded steps should have run
             using var eventListener = new RazorEventListener();
             var result = RunGenerator(compilation!, ref driver).VerifyPageOutput();
@@ -3461,7 +3457,6 @@ namespace MyApp
                 ["Component.Razor"] = "<h1>Hello world</h1>",
             });
             var compilation = await project.GetCompilationAsync();
-            RazorCohostingOptions.UseRazorCohostServer = false;
 
             // Start with the generator suppressed
             var (driver, additionalTexts, optionsProvider) = await GetDriverWithAdditionalTextAndProviderAsync(project, configureGlobalOptions: (o) =>


### PR DESCRIPTION
Reverts dotnet/razor#12270