### PR TITLE
Prevent assert on disconnect of a LiveShare session

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LiveShare/Guest/ProjectSnapshotSynchronizationServiceFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LiveShare/Guest/ProjectSnapshotSynchronizationServiceFactory.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.LiveShare;
 using Microsoft.VisualStudio.Razor.LiveShare.Serialization;
 using Microsoft.VisualStudio.Threading;
@@ -18,10 +19,18 @@ namespace Microsoft.VisualStudio.Razor.LiveShare.Guest;
 internal class ProjectSnapshotSynchronizationServiceFactory(
     ProjectSnapshotManager projectManager,
     ILoggerFactory loggerFactory,
+    LanguageServerFeatureOptions featureOptions,
     JoinableTaskContext joinableTaskContext) : ICollaborationServiceFactory
 {
     public async Task<ICollaborationService> CreateServiceAsync(CollaborationSession sessionContext, CancellationToken cancellationToken)
     {
+        if (featureOptions.UseRazorCohostServer)
+        {
+            // We can't return null, so just return a service that does nothing. Once cohosting is the only option
+            // we can remove this class entirely.
+            return new NoOpProjectSnapshotSynchronizationService();
+        }
+
         // This collaboration service depends on these serializers being immediately available so we need to register these now so the
         // guest project snapshot manager can retrieve the hosts project state.
         var serializer = (JsonSerializer)sessionContext.GetService(typeof(JsonSerializer));
@@ -38,5 +47,9 @@ internal class ProjectSnapshotSynchronizationServiceFactory(
         await synchronizationService.InitializeAsync(cancellationToken);
 
         return synchronizationService;
+    }
+
+    private sealed class NoOpProjectSnapshotSynchronizationService : ICollaborationService
+    {
     }
 }


### PR DESCRIPTION
Just a small thing I noticed while investigating https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2598812

When a liveshare session is disconnected, the dispose method ended up initializing the (old) ProjectSnapshotManager, which then complains cohosting is on.