### PR TITLE
Remove SyntaxTokenCache.Entry

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/InternalSyntax/SyntaxTokenCache.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Syntax/InternalSyntax/SyntaxTokenCache.cs
@@ -11,21 +11,9 @@ internal sealed class SyntaxTokenCache
     private const int CacheMask = CacheSize - 1;
     public static readonly SyntaxTokenCache Instance = new();
 
-    private readonly Entry[] _cache = new Entry[CacheSize];
+    private readonly SyntaxToken[] _cache = new SyntaxToken[CacheSize];
 
     internal SyntaxTokenCache() { }
-
-    private readonly struct Entry
-    {
-        public int Hash { get; }
-        public SyntaxToken? Token { get; }
-
-        internal Entry(int hash, SyntaxToken token)
-        {
-            Hash = hash;
-            Token = token;
-        }
-    }
 
     public bool CanBeCached(SyntaxKind kind, params RazorDiagnostic[] diagnostics)
         => diagnostics.Length == 0;
@@ -38,15 +26,15 @@ internal sealed class SyntaxTokenCache
         var indexableHash = hash ^ (hash >> 16);
 
         var idx = indexableHash & CacheMask;
-        var e = _cache[idx];
+        var token = _cache[idx];
 
-        if (e.Hash == hash && e.Token != null && e.Token.Kind == kind && e.Token.Content == content)
+        if (token != null && token.Kind == kind && token.Content == content)
         {
-            return e.Token;
+            return token;
         }
 
-        var token = new SyntaxToken(kind, content, []);
-        _cache[idx] = new Entry(hash, token);
+        token = new SyntaxToken(kind, content, []);
+        _cache[idx] = token;
 
         return token;
     }


### PR DESCRIPTION
While debugging some related code, I noticed this class didn't use a lock when getting the Entry, which smelled to me like a possible torn read/write issue (and those suck). 

I mentioned this to Dustin to make sure I wasn't being goofy, and he thought that might be a concern here too, but then raised the valid point that the reason for it being a struct (to have a hash in addition to the SyntaxToken) wasn't even necessary.