### PR TITLE
Update alc generator type check to use FullName

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/GeneratorRunResult.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/GeneratorRunResult.cs
@@ -63,7 +63,7 @@ internal readonly record struct GeneratorRunResult(RazorGeneratorResult Generato
         {
             if (throwIfNotFound)
             {
-                if (result.Results.SingleOrDefault(r => r.Generator.GetGeneratorType().Name == "Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator").Generator is { } wrongGenerator)
+                if (result.Results.SingleOrDefault(r => r.Generator.GetGeneratorType().FullName == "Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator").Generator is { } wrongGenerator)
                 {
                     // Wrong ALC?
                     throw new InvalidOperationException(SR.FormatRazor_source_generator_reference_incorrect(wrongGenerator.GetGeneratorType().Assembly.Location, typeof(RazorSourceGenerator).Assembly.Location, project.Name));


### PR DESCRIPTION
We have a check to detect when ALC redirection is not working correctly, unfortunately that check was checking the wrong name so we never hit it.