### PR TITLE
Reduce the range walked for formatting content validation

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/FormattingContentValidationPass.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/FormattingContentValidationPass.cs
@@ -23,9 +23,8 @@ internal sealed class FormattingContentValidationPass(ILoggerFactory loggerFacto
     public Task<bool> IsValidAsync(FormattingContext context, ImmutableArray<TextChange> changes, CancellationToken cancellationToken)
     {
         var text = context.SourceText;
-        var changedText = text.WithChanges(changes);
 
-        if (!text.NonWhitespaceContentEquals(changedText))
+        if (!text.NonWhitespaceContentEquals(changes))
         {
             // Looks like we removed some non-whitespace content as part of formatting. Oops.
             // Discard this formatting result.


### PR DESCRIPTION
Previously, this validation pass would walk over the whole content of the original and changed texts. This change modifies it instead to walk over the affected ranges in the original and changed texts based on the given set of changes.