### PR TITLE
Don't create a new FormattingContext if there weren't any cleanup changes

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
@@ -132,11 +132,13 @@ internal sealed class CSharpOnTypeFormattingPass(
 
         // We make an optimistic attempt at fixing corner cases.
         var cleanupChanges = CleanupDocument(changedContext, linePositionSpanAfterFormatting);
-        var cleanedText = formattedText.WithChanges(cleanupChanges);
-        context.Logger?.LogSourceText("AfterCleanupDocument", cleanedText);
+        var cleanedText = formattedText;
 
         if (!cleanupChanges.IsEmpty)
         {
+            cleanedText = formattedText.WithChanges(cleanupChanges);
+            context.Logger?.LogSourceText("AfterCleanupDocument", cleanedText);
+
             changedContext = await changedContext.WithTextAsync(cleanedText, cancellationToken).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
FormattingContext.WithTextAsync shows up as the major CPU time user during onTypeFormatting, mostly due to it's eventual call to GeneratorRunResult.CreateAsync. This change just avoids one of those calls when not necessary.