### PR TITLE
Fix race condition in MemoryCache.Compact()

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Utilities/MemoryCache`2.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Utilities/MemoryCache`2.cs
@@ -64,7 +64,7 @@ internal class MemoryCache<TKey, TValue>
 
     protected virtual void Compact()
     {
-        var kvps = _dict.OrderBy(x => x.Value.LastAccess).ToArray();
+        var kvps = _dict.ToArray().OrderBy(x => x.Value.LastAccess).ToArray();
 
         for (var i = 0; i < _sizeLimit / 2; i++)
         {


### PR DESCRIPTION
## Summary

Fixes #12430

This PR resolves a race condition in `MemoryCache<TKey, TValue>.Compact()` that was causing intermittent test failures.

## The Problem

The `Compact()` method was enumerating a `ConcurrentDictionary` directly while other threads could simultaneously modify it:

```csharp
var kvps = _dict.OrderBy(x => x.Value.LastAccess).ToArray();
```

This violated thread-safety expectations and caused `ArgumentException` during concurrent operations.

## The Solution

Add an initial `.ToArray()` call to create a snapshot before sorting:

```csharp
var kvps = _dict.ToArray().OrderBy(x => x.Value.LastAccess).ToArray();
```

This ensures we operate on a stable snapshot rather than the live dictionary, preventing concurrent modifications from disrupting the LINQ enumeration.

## Impact

- Eliminates race condition without requiring additional locking
- Minimal performance overhead (one extra array allocation)
- Resolves intermittent test failures in `Microsoft.CodeAnalysis.Razor.Utilities.MemoryCacheTest.ConcurrentSets_DoesNotThrow`