### PR TITLE
Avoid broken NetCore1ESPool-Svc-Internal pool

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -75,7 +75,7 @@ extends:
       autoBaseline: true
     sdl:
       sourceAnalysisPool:
-        name: NetCore1ESPool-Svc-Internal
+        name: NetCore1ESPool-Internal
         image: 1es-windows-2022
         os: windows
       policheck:
@@ -84,7 +84,7 @@ extends:
         enabled: true
         configFile: '$(Build.SourcesDirectory)/eng/TSAConfig.gdntsa'
     pool:
-      name: NetCore1ESPool-Svc-Internal
+      name: NetCore1ESPool-Internal
       image: windows.vs2022preview.amd64
       os: windows
     customBuildTags:
@@ -420,7 +420,7 @@ extends:
         - job: insert
           displayName: Insert to VS
           pool:
-            name: NetCore1ESPool-Svc-Internal
+            name: NetCore1ESPool-Internal
             demands: ImageOverride -equals windows.vs2022.amd64
           steps:
           - download: current


### PR DESCRIPTION
Fixes (or works around?) broken official builds. Validation: https://dev.azure.com/dnceng/internal/_build/results?buildId=2831149&view=results