### PR TITLE
Format type parameter values as types

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentFormattingTest.cs
@@ -7303,4 +7303,21 @@ public class DocumentFormattingTest(FormattingTestContext context, HtmlFormattin
                     </span>
                 }
                 """);
+
+    [FormattingTestFact]
+    [WorkItem("https://github.com/dotnet/razor/issues/12445")]
+    public Task TypeParameterAttribute()
+     => RunFormattingTestAsync(
+         input: """
+                <div>
+                <InputSelect TValue="Guid?">
+                </InputSelect>
+                </div>
+                """,
+         expected: """
+                <div>
+                    <InputSelect TValue="Guid?">
+                    </InputSelect>
+                </div>
+                """);
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/12445

With our generic "code-gen as though everything is an expression", Roslyn was formatting `Guid?` as `Guid ?`