### PR TITLE
Avoid broken NetCore1ES-Svc-Internal in more places

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -3,10 +3,9 @@
 #
 
 variables:
-# Hard-coding DncEngInternalBuildPool to avoid broken NetCore1ESPool-Svc-Internal temporarily
-# - template: /eng/common/templates-official/variables/pool-providers.yml@self
-- name: DncEngInternalBuildPool
-  value: NetCore1ESPool-Internal
+# Defines $(DncEngInternalBuildPool)
+- template: /eng/common/templates-official/variables/pool-providers.yml@self
+
 - name: Build.Repository.Clean
   value: true
 - name: _TeamName


### PR DESCRIPTION
Follow up on https://github.com/dotnet/razor/pull/12441 (which didn't work in all cases for servicing branches).