### PR TITLE
[Test only change] Only track steps when needed

### DIFF
--- a/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorTests.cs
+++ b/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorTests.cs
@@ -2617,7 +2617,7 @@ namespace AspNetCoreGeneratedDocument
             });
 
             var compilation = await project.GetCompilationAsync();
-            var (driver, additionalTexts, optionsProvider) = await GetDriverWithAdditionalTextAndProviderAsync(project);
+            var (driver, additionalTexts, optionsProvider) = await GetDriverWithAdditionalTextAndProviderAsync(project, trackSteps: true);
 
             // start with the generator suppressed (this is the default state in VS)
             driver = SetSuppressionState(true);

--- a/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorTestsBase.cs
+++ b/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorTestsBase.cs
@@ -57,11 +57,11 @@ public abstract class RazorSourceGeneratorTestsBase
         return (result.Item1, result.Item2);
     }
 
-    protected static async ValueTask<(GeneratorDriver, ImmutableArray<AdditionalText>, TestAnalyzerConfigOptionsProvider)> GetDriverWithAdditionalTextAndProviderAsync(Project project, Action<TestAnalyzerConfigOptionsProvider>? configureGlobalOptions = null, bool hostOutputs = false)
+    protected static async ValueTask<(GeneratorDriver, ImmutableArray<AdditionalText>, TestAnalyzerConfigOptionsProvider)> GetDriverWithAdditionalTextAndProviderAsync(Project project, Action<TestAnalyzerConfigOptionsProvider>? configureGlobalOptions = null, bool hostOutputs = false, bool trackSteps = false)
     {
         var razorSourceGenerator = new RazorSourceGenerator(testUniqueIds: "test").AsSourceGenerator();
         var disabledOutputs = hostOutputs ? IncrementalGeneratorOutputKind.None : (IncrementalGeneratorOutputKind)0b100000;
-        var driver = (GeneratorDriver)CSharpGeneratorDriver.Create(new[] { razorSourceGenerator }, parseOptions: (CSharpParseOptions)project.ParseOptions!, driverOptions: new GeneratorDriverOptions(disabledOutputs, true));
+        var driver = (GeneratorDriver)CSharpGeneratorDriver.Create(new[] { razorSourceGenerator }, parseOptions: (CSharpParseOptions)project.ParseOptions!, driverOptions: new GeneratorDriverOptions(disabledOutputs, trackSteps));
 
         var optionsProvider = new TestAnalyzerConfigOptionsProvider();
         optionsProvider.TestGlobalOptions["build_property.RazorConfiguration"] = "Default";
@@ -479,6 +479,9 @@ internal static class Extensions
     [Conditional("GENERATE_BASELINES")]
     private static void GenerateOutputBaseline(string baselinePath, string text)
     {
+        var directory = Path.GetDirectoryName(baselinePath)!;
+        Directory.CreateDirectory(directory);
+
         text = text.Replace("\r", "").Replace("\n", "\r\n");
         File.WriteAllText(baselinePath, text, _baselineEncoding);
     }


### PR DESCRIPTION
While working on https://github.com/dotnet/razor/pull/12477 I noticed that `RazorSourceGeneratorTagHelperTests.ViewImports` tests were taking over 30 seconds per run (and thanks to the theory we run it 11 times) seriously slowing down the tests.

After some investigation I discovered it's actually the generator tracking infrastructure that was causing the slowness. Disabling tracking makes them take around 500ms. I'll open an issue on roslyn to address that, but we only actually use tracking for a single test, so I've just disabled it for all the other tests in the assembly. 

I also included a fix to the baseline generation that occurs due to #12477 