### PR TITLE
TagHelperCollection Part 5: Add weak cache for TagHelperDocumentContext

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/RazorCodeDocumentExtensionsTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/RazorCodeDocumentExtensionsTest.cs
@@ -52,7 +52,7 @@ public class RazorCodeDocumentExtensionsTest
         // Arrange
         var codeDocument = TestRazorCodeDocument.CreateEmpty();
 
-        var expected = TagHelperDocumentContext.Create(tagHelpers: []);
+        var expected = TagHelperDocumentContext.GetOrCreate(tagHelpers: []);
         codeDocument.SetTagHelperContext(expected);
 
         // Act

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultRazorTagHelperContextDiscoveryPhase.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultRazorTagHelperContextDiscoveryPhase.cs
@@ -51,7 +51,7 @@ internal sealed partial class DefaultRazorTagHelperContextDiscoveryPhase : Razor
         // This will always be null for a component document.
         var tagHelperPrefix = visitor.TagHelperPrefix;
 
-        var context = TagHelperDocumentContext.Create(tagHelperPrefix, visitor.GetResults());
+        var context = TagHelperDocumentContext.GetOrCreate(tagHelperPrefix, visitor.GetResults());
         codeDocument.SetTagHelperContext(context);
         codeDocument.SetPreTagHelperSyntaxTree(syntaxTree);
     }

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/TagHelperCompletionBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/TagHelperCompletionBenchmark.cs
@@ -31,7 +31,7 @@ public class TagHelperCompletionBenchmark
     {
         var tagHelperCompletionService = new TagHelperCompletionService();
         var context = new AttributeCompletionContext(
-            TagHelperDocumentContext.Create([.. CommonResources.TelerikTagHelpers]),
+            TagHelperDocumentContext.GetOrCreate([.. CommonResources.TelerikTagHelpers]),
             existingCompletions: [],
             currentTagName: "PageTitle",
             currentAttributeName: null,
@@ -48,7 +48,7 @@ public class TagHelperCompletionBenchmark
     {
         var tagHelperCompletionService = new TagHelperCompletionService();
         var context = new ElementCompletionContext(
-            TagHelperDocumentContext.Create([.. CommonResources.TelerikTagHelpers]),
+            TagHelperDocumentContext.GetOrCreate([.. CommonResources.TelerikTagHelpers]),
             existingCompletions: s_existingElementCompletions,
             containingTagName: null,
             attributes: [],

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Serialization/CompletionListSerializationBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Serialization/CompletionListSerializationBenchmark.cs
@@ -66,7 +66,7 @@ public class CompletionListSerializationBenchmark
         var sourceDocument = RazorSourceDocument.Create(documentContent, RazorSourceDocumentProperties.Default);
         var codeDocument = RazorCodeDocument.Create(sourceDocument);
         var syntaxTree = RazorSyntaxTree.Parse(sourceDocument);
-        var tagHelperDocumentContext = TagHelperDocumentContext.Create([.. CommonResources.LegacyTagHelpers]);
+        var tagHelperDocumentContext = TagHelperDocumentContext.GetOrCreate([.. CommonResources.LegacyTagHelpers]);
 
         var owner = syntaxTree.Root.FindInnermostNode(queryIndex, includeWhitespace: true, walkMarkersBack: true);
         var context = new RazorCompletionContext(codeDocument, queryIndex, owner, syntaxTree, tagHelperDocumentContext);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionProvider.cs
@@ -116,7 +116,7 @@ internal class TagHelperCompletionProvider(ITagHelperCompletionService tagHelper
         var ancestors = containingAttribute.Parent.Ancestors();
         var nonDirectiveAttributeTagHelpers = tagHelperDocumentContext.TagHelpers.Where(
             static tagHelper => !tagHelper.BoundAttributes.Any(static attribute => attribute.IsDirectiveAttribute));
-        var filteredContext = TagHelperDocumentContext.Create(tagHelperDocumentContext.Prefix, nonDirectiveAttributeTagHelpers);
+        var filteredContext = TagHelperDocumentContext.GetOrCreate(tagHelperDocumentContext.Prefix, nonDirectiveAttributeTagHelpers);
         var (ancestorTagName, ancestorIsTagHelper) = TagHelperFacts.GetNearestAncestorTagInfo(ancestors);
         var attributeCompletionContext = new AttributeCompletionContext(
             filteredContext,

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DefaultRazorCompletionFactsServiceTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DefaultRazorCompletionFactsServiceTest.cs
@@ -18,7 +18,7 @@ public class DefaultRazorCompletionFactsServiceTest(ITestOutputHelper testOutput
         var sourceDocument = RazorSourceDocument.Create("", RazorSourceDocumentProperties.Default);
         var codeDocument = RazorCodeDocument.Create(sourceDocument);
         var syntaxTree = RazorSyntaxTree.Parse(TestRazorSourceDocument.Create());
-        var tagHelperDocumentContext = TagHelperDocumentContext.Create(tagHelpers: []);
+        var tagHelperDocumentContext = TagHelperDocumentContext.GetOrCreate(tagHelpers: []);
 
         var completionItem1 = RazorCompletionItem.CreateDirective(
             displayText: "displayText1",

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.AttributeNames.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.AttributeNames.cs
@@ -180,7 +180,7 @@ public partial class DirectiveAttributeCompletionItemProviderTest : RazorTooling
     public void GetAttributeCompletions_NoDescriptorsForTag_ReturnsEmptyCollection()
     {
         // Arrange
-        var documentContext = TagHelperDocumentContext.Create(tagHelpers: []);
+        var documentContext = TagHelperDocumentContext.GetOrCreate(tagHelpers: []);
         var context = GetDefaultDirectivateAttributeCompletionContext("@bin");
 
         // Act
@@ -197,7 +197,7 @@ public partial class DirectiveAttributeCompletionItemProviderTest : RazorTooling
         var descriptor = TagHelperDescriptorBuilder.CreateTagHelper("CatchAll", "TestAssembly");
         descriptor.BoundAttributeDescriptor(boundAttribute => boundAttribute.Name = "Test");
         descriptor.TagMatchingRule(rule => rule.RequireTagName("*"));
-        var documentContext = TagHelperDocumentContext.Create([descriptor.Build()]);
+        var documentContext = TagHelperDocumentContext.GetOrCreate([descriptor.Build()]);
 
         var context = GetDefaultDirectivateAttributeCompletionContext("@bin");
 

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.ParameterNames.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.ParameterNames.cs
@@ -35,7 +35,7 @@ public partial class DirectiveAttributeCompletionItemProviderTest
     public void GetAttributeParameterCompletions_NoDescriptorsForTag_ReturnsEmptyCollection()
     {
         // Arrange
-        var documentContext = TagHelperDocumentContext.Create(tagHelpers: []);
+        var documentContext = TagHelperDocumentContext.GetOrCreate(tagHelpers: []);
         var context = GetDefaultDirectiveAttributeCompletionContext("@bin");
 
         // Act
@@ -52,7 +52,7 @@ public partial class DirectiveAttributeCompletionItemProviderTest
         var descriptor = TagHelperDescriptorBuilder.CreateTagHelper("CatchAll", "TestAssembly");
         descriptor.BoundAttributeDescriptor(boundAttribute => boundAttribute.Name = "Test");
         descriptor.TagMatchingRule(rule => rule.RequireTagName("*"));
-        var documentContext = TagHelperDocumentContext.Create([descriptor.Build()]);
+        var documentContext = TagHelperDocumentContext.GetOrCreate([descriptor.Build()]);
 
         var context = GetDefaultDirectiveAttributeCompletionContext("@bin");
 

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeTransitionCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeTransitionCompletionItemProviderTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion;
 
 public class DirectiveAttributeTransitionCompletionItemProviderTest(ITestOutputHelper testOutput) : ToolingTestBase(testOutput)
 {
-    private readonly TagHelperDocumentContext _tagHelperDocumentContext = TagHelperDocumentContext.Create(tagHelpers: []);
+    private readonly TagHelperDocumentContext _tagHelperDocumentContext = TagHelperDocumentContext.GetOrCreate(tagHelpers: []);
     private readonly DirectiveAttributeTransitionCompletionItemProvider _provider = new(TestLanguageServerFeatureOptions.Instance);
 
     [Fact]

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
@@ -425,7 +425,7 @@ public class DirectiveCompletionItemProviderTest(ITestOutputHelper testOutput) :
         var sourceDocument = RazorSourceDocument.Create("", RazorSourceDocumentProperties.Default);
         var codeDocument = RazorCodeDocument.Create(sourceDocument);
 
-        var tagHelperDocumentContext = TagHelperDocumentContext.Create(tagHelpers: []);
+        var tagHelperDocumentContext = TagHelperDocumentContext.GetOrCreate(tagHelpers: []);
         var owner = syntaxTree.Root.FindInnermostNode(absoluteIndex);
         owner = AbstractRazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, absoluteIndex);
         return new RazorCompletionContext(codeDocument, absoluteIndex, owner, syntaxTree, tagHelperDocumentContext, reason);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/LanguageServerTagHelperCompletionServiceTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/LanguageServerTagHelperCompletionServiceTest.cs
@@ -1314,7 +1314,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     {
         attributes = attributes.NullToEmpty();
 
-        var documentContext = TagHelperDocumentContext.Create(tagHelperPrefix, tagHelpers);
+        var documentContext = TagHelperDocumentContext.GetOrCreate(tagHelperPrefix, tagHelpers);
         var completionContext = new ElementCompletionContext(
             documentContext,
             existingCompletions,
@@ -1337,7 +1337,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     {
         attributes = attributes.NullToEmpty();
 
-        var documentContext = TagHelperDocumentContext.Create(tagHelperPrefix, tagHelpers);
+        var documentContext = TagHelperDocumentContext.GetOrCreate(tagHelperPrefix, tagHelpers);
         var completionContext = new AttributeCompletionContext(
             documentContext,
             existingCompletions,

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/MarkupTransitionCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/MarkupTransitionCompletionItemProviderTest.cs
@@ -299,7 +299,7 @@ public class MarkupTransitionCompletionItemProviderTest(ITestOutputHelper testOu
         var sourceDocument = RazorSourceDocument.Create("", RazorSourceDocumentProperties.Default);
         var codeDocument = RazorCodeDocument.Create(sourceDocument);
 
-        var tagHelperDocumentContext = TagHelperDocumentContext.Create(tagHelpers: []);
+        var tagHelperDocumentContext = TagHelperDocumentContext.GetOrCreate(tagHelpers: []);
 
         var owner = syntaxTree.Root.FindInnermostNode(absoluteIndex, includeWhitespace: true, walkMarkersBack: true);
         owner = AbstractRazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, absoluteIndex);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/RazorCompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/RazorCompletionListProviderTest.cs
@@ -536,7 +536,7 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
         var sourceDocument = TestRazorSourceDocument.Create(text, filePath: documentFilePath);
         var syntaxTree = RazorSyntaxTree.Parse(sourceDocument);
         codeDocument.SetSyntaxTree(syntaxTree);
-        var tagHelperDocumentContext = TagHelperDocumentContext.Create(tagHelpers ?? []);
+        var tagHelperDocumentContext = TagHelperDocumentContext.GetOrCreate(tagHelpers ?? []);
         codeDocument.SetTagHelperContext(tagHelperDocumentContext);
         return codeDocument;
     }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/TagHelperFactsTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/TagHelperFactsTest.cs
@@ -23,7 +23,7 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
                 .Build()
         ];
 
-        var documentContext = TagHelperDocumentContext.Create(tagHelpers);
+        var documentContext = TagHelperDocumentContext.GetOrCreate(tagHelpers);
 
         var binding = TagHelperFacts.GetTagHelperBinding(
             documentContext,
@@ -56,7 +56,7 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
                 .Build(),
         ];
 
-        var documentContext = TagHelperDocumentContext.Create(tagHelpers);
+        var documentContext = TagHelperDocumentContext.GetOrCreate(tagHelpers);
 
         var binding = TagHelperFacts.GetTagHelperBinding(
             documentContext,
@@ -85,7 +85,7 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
                 .Build()
         ];
 
-        var documentContext = TagHelperDocumentContext.Create(tagHelpers);
+        var documentContext = TagHelperDocumentContext.GetOrCreate(tagHelpers);
         var binding = TagHelperFacts.GetTagHelperBinding(
             documentContext,
             tagName: "a",
@@ -120,7 +120,7 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
             tagHelpers[0].BoundAttributes.First()
         };
 
-        var documentContext = TagHelperDocumentContext.Create(tagHelpers);
+        var documentContext = TagHelperDocumentContext.GetOrCreate(tagHelpers);
 
         var binding = TagHelperFacts.GetTagHelperBinding(
             documentContext,
@@ -149,7 +149,7 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
                 .Build()
         ];
 
-        var documentContext = TagHelperDocumentContext.Create(tagHelpers);
+        var documentContext = TagHelperDocumentContext.GetOrCreate(tagHelpers);
 
         var result = TagHelperFacts.GetTagHelpersGivenTag(
             documentContext,
@@ -169,7 +169,7 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
                 .Build()
         ];
 
-        var documentContext = TagHelperDocumentContext.Create(tagHelpers);
+        var documentContext = TagHelperDocumentContext.GetOrCreate(tagHelpers);
 
         var result = TagHelperFacts.GetTagHelpersGivenTag(
             documentContext,
@@ -192,7 +192,7 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
                 .Build()
         ];
 
-        var documentContext = TagHelperDocumentContext.Create(tagHelpers);
+        var documentContext = TagHelperDocumentContext.GetOrCreate(tagHelpers);
 
         var result = TagHelperFacts.GetTagHelpersGivenTag(
             documentContext,
@@ -215,7 +215,7 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
                 .Build()
         ];
 
-        var documentContext = TagHelperDocumentContext.Create(prefix: "th", tagHelpers);
+        var documentContext = TagHelperDocumentContext.GetOrCreate(prefix: "th", tagHelpers);
 
         var result = TagHelperFacts.GetTagHelpersGivenTag(
             documentContext,
@@ -238,7 +238,7 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
                 .Build()
         ];
 
-        var documentContext = TagHelperDocumentContext.Create(tagHelpers);
+        var documentContext = TagHelperDocumentContext.GetOrCreate(tagHelpers);
 
         var result = TagHelperFacts.GetTagHelpersGivenTag(
             documentContext,
@@ -258,7 +258,7 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
                 .Build()
         ];
 
-        var documentContext = TagHelperDocumentContext.Create(tagHelpers);
+        var documentContext = TagHelperDocumentContext.GetOrCreate(tagHelpers);
 
         var result = TagHelperFacts.GetTagHelpersGivenParent(
             documentContext,
@@ -280,7 +280,7 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
                 .Build()
         ];
 
-        var documentContext = TagHelperDocumentContext.Create(tagHelpers);
+        var documentContext = TagHelperDocumentContext.GetOrCreate(tagHelpers);
 
         var result = TagHelperFacts.GetTagHelpersGivenParent(
             documentContext,
@@ -299,7 +299,7 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
                 .Build()
         ];
 
-        var documentContext = TagHelperDocumentContext.Create(tagHelpers);
+        var documentContext = TagHelperDocumentContext.GetOrCreate(tagHelpers);
 
         var result = TagHelperFacts.GetTagHelpersGivenParent(
             documentContext,
@@ -321,7 +321,7 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
                 .Build()
         ];
 
-        var documentContext = TagHelperDocumentContext.Create(tagHelpers);
+        var documentContext = TagHelperDocumentContext.GetOrCreate(tagHelpers);
 
         var result = TagHelperFacts.GetTagHelpersGivenParent(
             documentContext,

--- a/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Completion/LegacyTagHelperCompletionServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Completion/LegacyTagHelperCompletionServiceTest.cs
@@ -1282,7 +1282,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
         bool containingParentIsTagHelper = false,
         string? tagHelperPrefix = null)
     {
-        var documentContext = TagHelperDocumentContext.Create(tagHelperPrefix, tagHelpers);
+        var documentContext = TagHelperDocumentContext.GetOrCreate(tagHelperPrefix, tagHelpers);
         var completionContext = new ElementCompletionContext(
             documentContext,
             existingCompletions,
@@ -1305,7 +1305,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     {
         attributes = attributes.NullToEmpty();
 
-        var documentContext = TagHelperDocumentContext.Create(tagHelperPrefix, tagHelpers);
+        var documentContext = TagHelperDocumentContext.GetOrCreate(tagHelperPrefix, tagHelpers);
         var completionContext = new AttributeCompletionContext(
             documentContext,
             existingCompletions,

--- a/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
@@ -211,7 +211,7 @@ public class RazorDirectiveCompletionSourceTest(ITestOutputHelper testOutput) : 
         var syntaxTree = RazorSyntaxTree.Parse(source, codeDocument.ParserOptions);
         codeDocument.SetSyntaxTree(syntaxTree);
 
-        codeDocument.SetTagHelperContext(TagHelperDocumentContext.Create(tagHelpers: []));
+        codeDocument.SetTagHelperContext(TagHelperDocumentContext.GetOrCreate(tagHelpers: []));
 
         var parserMock = new StrictMock<IVisualStudioRazorParser>();
         parserMock

--- a/src/Razor/test/Microsoft.VisualStudioCode.RazorExtension.Test/Endpoints/Shared/CohostRenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudioCode.RazorExtension.Test/Endpoints/Shared/CohostRenameEndpointTest.cs
@@ -17,6 +17,8 @@ using Xunit.Abstractions;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 
+[CollectionDefinition(nameof(CohostRenameEndpointTest), DisableParallelization = true)]
+[Collection(nameof(CohostRenameEndpointTest))]
 public class CohostRenameEndpointTest(ITestOutputHelper testOutputHelper) : CohostEndpointTestBase(testOutputHelper)
 {
     [Fact]


### PR DESCRIPTION
| [Prelude](https://github.com/dotnet/razor/pull/12503) | [Part 1](https://github.com/dotnet/razor/pull/12504) | [Part 2](https://github.com/dotnet/razor/pull/12505) | [Part 3](https://github.com/dotnet/razor/pull/12506) | [Part 4](https://github.com/dotnet/razor/pull/12507) | Part 5 |

This change introduces a weak cache for `TagHelperDocumentContext` keyed by the tag helper prefix string and `TagHelperCollection` checksum. This helps avoid creating new `TagHelperBinders` for the same set of tag helpers, since `TagHelperBinder` is expensive to create.

----
CI Build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2842228&view=results
Toolset Run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2842250&view=results