### PR TITLE
Remove timeout causing folding behavior instability on document open

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/HtmlDocumentServices/HtmlDocumentSynchronizer.SynchronizationRequest.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/HtmlDocumentServices/HtmlDocumentSynchronizer.SynchronizationRequest.cs
@@ -32,7 +32,6 @@ internal sealed partial class HtmlDocumentSynchronizer
         {
             _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             var token = _cts.Token;
-            _cts.CancelAfter(TimeSpan.FromMilliseconds(500));
             _cts.Token.Register(Dispose);
             _ = syncFunction.Invoke(document, _requestedVersion, token).ContinueWith((t, state) =>
             {


### PR DESCRIPTION
This timeout is hitting for folding requests on solution/document open, resulting in folding ranges commonly being empty when opening the first razor document in a solution. The syncFunction callback wraps an OOP call to IRemoteHtmlDocumentService.GetHtmlDocumentTextAsync which can be quite slow in the open document/solution scenario.

Instead, we just remove the timeout and depend on SynchronizationRequest.Dispose usage to cancel any stuck task when the document moves forward.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2641895