### PR TITLE
Close GC hole in EnumExtensions

### DIFF
--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/EnumExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/EnumExtensions.cs
@@ -16,22 +16,22 @@ internal static class EnumExtensions
     {
         if (sizeof(T) == sizeof(byte))
         {
-            Unsafe.As<T, byte>(ref value) |= Unsafe.As<T, byte>(ref flag);
+            Unsafe.As<T, byte>(ref value) |= *(byte*)&flag;
             return;
         }
         else if (sizeof(T) == sizeof(ushort))
         {
-            Unsafe.As<T, ushort>(ref value) |= Unsafe.As<T, ushort>(ref flag);
+            Unsafe.As<T, ushort>(ref value) |= *(ushort*)&flag;
             return;
         }
         else if (sizeof(T) == sizeof(uint))
         {
-            Unsafe.As<T, uint>(ref value) |= Unsafe.As<T, uint>(ref flag);
+            Unsafe.As<T, uint>(ref value) |= *(uint*)&flag;
             return;
         }
         else if (sizeof(T) == sizeof(ulong))
         {
-            Unsafe.As<T, ulong>(ref value) |= Unsafe.As<T, ulong>(ref flag);
+            Unsafe.As<T, ulong>(ref value) |= *(ulong*)&flag;
             return;
         }
 
@@ -45,22 +45,22 @@ internal static class EnumExtensions
     {
         if (sizeof(T) == sizeof(byte))
         {
-            Unsafe.As<T, byte>(ref value) &= (byte)~Unsafe.As<T, byte>(ref flag);
+            Unsafe.As<T, byte>(ref value) &= (byte)~*(byte*)&flag;
             return;
         }
         else if (sizeof(T) == sizeof(ushort))
         {
-            Unsafe.As<T, ushort>(ref value) &= (ushort)~Unsafe.As<T, ushort>(ref flag);
+            Unsafe.As<T, ushort>(ref value) &= (ushort)~*(ushort*)&flag;
             return;
         }
         else if (sizeof(T) == sizeof(uint))
         {
-            Unsafe.As<T, uint>(ref value) &= ~Unsafe.As<T, uint>(ref flag);
+            Unsafe.As<T, uint>(ref value) &= ~*(uint*)&flag;
             return;
         }
         else if (sizeof(T) == sizeof(ulong))
         {
-            Unsafe.As<T, ulong>(ref value) &= ~Unsafe.As<T, ulong>(ref flag);
+            Unsafe.As<T, ulong>(ref value) &= ~*(ulong*)&flag;
             return;
         }
 


### PR DESCRIPTION
A GC hole exists in `EnumExtensions.SetFlag` and `EnumExtensions.ClearFlag`. If the incoming _value_ argument points to a field in a heap-allocated object, a GC could occur between the initial call to `AsPointer` and the later `*(T*)v |= ...;` or `*(T*)v &= ...;` construct, causing a write to the wrong memory address.

Here's one example of where the _value_ argument will point to a field within a heap-allocated object, potentially causing the GC hole:
https://github.com/dotnet/razor/blob/acc88b9b8223cc8ec70189670feec1e1300734ed/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorParserOptions.Builder.cs#L31-L35

The fix is to remove the call to `Unsafe.AsPointer` and to use managed pointers. This PR doesn't reduce the unsafe-equivalent code within the target methods, but it does close the GC hole. Other improvements (like turning the `Debug.Assert` at the end of the method into a proper exception, or throwing if the Enum is backed by a floating point data type, etc.) are out of scope of this PR.