### PR TITLE
Move NetVSCode to net10.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -40,8 +40,11 @@
     <!-- Embed source files that are not tracked by the source control manager in the PDB. -->
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
 
-    <!-- Working around https://github.com/dotnet/sdk/issues/24747 -->
-    <NoWarn>$(NoWarn);NU1505</NoWarn>
+    <!--
+      NU1505: Working around https://github.com/dotnet/sdk/issues/24747
+      NETSDK1233: Working around https://github.com/dotnet/sdk/issues/51678 until we move our Windows CI to VS2026 images.
+    -->
+    <NoWarn>$(NoWarn);NU1505;NETSDK1233</NoWarn>
 
     <!-- Working around https://github.com/microsoft/msbuild/pull/4764 -->
     <EmbeddedResourceUseDependentUponConvention>false</EmbeddedResourceUseDependentUponConvention>


### PR DESCRIPTION
The C# extension has moved to net10.0.

See C# ext: https://github.com/dotnet/vscode-csharp/pull/8839 and Roslyn: https://github.com/dotnet/roslyn/pull/81508