### PR TITLE
Be OS agnostic when generating semantic token baseline files

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
@@ -1042,7 +1042,7 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             testName += "_VSCode";
         }
 
-        var fileName = $"Semantic\\TestFiles\\{testName}";
+        var fileName = Path.Combine("Semantic", "TestFiles", testName);
 
         var baselineFileName = Path.ChangeExtension(fileName, ".semantic.txt");
 

--- a/src/Razor/test/Microsoft.VisualStudioCode.RazorExtension.Test/Endpoints/Shared/CohostSemanticTokensRangeEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudioCode.RazorExtension.Test/Endpoints/Shared/CohostSemanticTokensRangeEndpointTest.cs
@@ -177,7 +177,7 @@ public class CohostSemanticTokensRangeEndpointTest(ITestOutputHelper testOutputH
             testName += "_misc_file";
         }
 
-        var baselineFileName = $@"TestFiles\SemanticTokens\{testName}.txt";
+        var baselineFileName = Path.Combine("TestFiles", "SemanticTokens", $"{testName}.txt");
         if (GenerateBaselines.ShouldGenerate)
         {
             WriteBaselineFile(actualFileContents, baselineFileName);


### PR DESCRIPTION
Seems our windows-centric lifestyle has caused some issues for Copilot when it tries to generate baselines (for unrelated tests) in https://github.com/dotnet/razor/pull/12575