### PR TITLE
Encode double slash as underscore slash in hint names

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.Helpers.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.Helpers.cs
@@ -21,6 +21,10 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             {
                 switch (filePath[i])
                 {
+                    case '\\' or '/' when i + 1 < filePath.Length && filePath[i + 1] is '\\' or '/':
+                        // Roslyn will throw on '//', but some weird Uri's have them, so sanitize to '_/'
+                        builder.Append('_');
+                        break;
                     case '\\' or '/' when i > 0:
                         builder.Append('/');
                         break;


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/12595

Not sure if this is an accidental regression from https://github.com/dotnet/razor/pull/12477, or if VS Code just changed their Uri scheme, but either way. There is more we could filter out here, but I think we should wait and see if anyone hits it, otherwise we're just increasing the chance of non-unique hint names:
https://github.com/dotnet/roslyn/blob/main/src/Compilers/Core/Portable/SourceGeneration/AdditionalSourcesCollection.cs#L27