### PR TITLE
Don't run tests in official builds

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -337,7 +337,6 @@ extends:
                 --pack
                 --configuration $(_BuildConfig)
                 --prepareMachine
-                --test
                 $(_BuildArgs)
               name: Build
               displayName: Restore, Build and Test
@@ -380,7 +379,6 @@ extends:
                 --pack
                 --configuration $(_BuildConfig)
                 --prepareMachine
-                --test
                 $(_BuildArgs)
               name: Build
               displayName: Restore, Build and Test


### PR DESCRIPTION
We stopped running tests in official builds on Windows in https://github.com/dotnet/razor/pull/8617 but never did it for linux and mac. An oversight on my behalf, but worth fixing since the linux legs seem to be flaky at the moment.