### PR TITLE
Don't run tests in official builds

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -320,6 +320,8 @@ extends:
             - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
               - _BuildArgs: /p:DotNetPublishUsingPipelines=true
                   /p:OfficialBuildId=$(Build.BuildNumber)
+            - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
+              - _BuildArgs: -test
 
             steps:
             - task: Bash@3
@@ -347,7 +349,7 @@ extends:
                 targetPath: artifacts/TestResults/$(_BuildConfig)
                 artifact: $(Agent.Os)_$(Agent.JobName) Attempt $(System.JobAttempt) TestResults
               displayName: Publish Test Results
-              condition: always()
+              condition: in(variables['Build.Reason'], 'PullRequest')
 
           - job: Linux
             pool:
@@ -365,6 +367,8 @@ extends:
             - LANG: 'en_US.UTF-8'
             - LANGUAGE: 'en_US.UTF-8'
             - _BuildArgs: ''
+            - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
+              - _BuildArgs: -test
 
             # Variables for internal Official builds
             - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
@@ -389,7 +393,7 @@ extends:
                 targetPath: artifacts/TestResults/$(_BuildConfig)/
                 artifact: $(Agent.Os)_$(Agent.JobName) Attempt $(System.JobAttempt) TestResults
               displayName: Publish Test Results
-              condition: always()
+              condition: in(variables['Build.Reason'], 'PullRequest')
 
     - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
       - template: /eng/common/templates-official/post-build/post-build.yml@self


### PR DESCRIPTION
We stopped running tests in official builds on Windows in https://github.com/dotnet/razor/pull/8617 but never did it for linux and mac. An oversight on my behalf, but worth fixing since the linux legs seem to be flaky at the moment.

Val build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2860995&view=results