### PR TITLE
Make ContainedLanguage import lazy

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/RenameProjectTreeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/RenameProjectTreeHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.Razor.ProjectSystem;
 
 [Order(RazorConstants.AboveManagedProjectSystemOrder)]
 [Export(typeof(IProjectTreeActionHandler))]
-[AppliesTo(WellKnownProjectCapabilities.DotNetCoreCSharp)]
+[AppliesTo(WellKnownProjectCapabilities.DotNetCoreRazor)]
 [method: ImportingConstructor]
 internal sealed partial class RenameProjectTreeHandler(
     [Import(ExportContractNames.Scopes.UnconfiguredProject)] IProjectAsynchronousTasksService projectAsynchronousTasksService,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/WellKnownProjectCapabilities.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/WellKnownProjectCapabilities.cs
@@ -5,6 +5,7 @@ namespace Microsoft.VisualStudio.Razor;
 
 internal static class WellKnownProjectCapabilities
 {
+    public const string DotNetCoreRazor = "DotNetCoreRazor";
     public const string DotNetCoreCSharp = "CSharp&CPS";
     public const string LegacyRazorEditor = "LegacyRazorEditor";
 }


### PR DESCRIPTION
Should fix https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2677553

My head was all in rename lang, but CPS imports `IProjectTreeActionHandler`s for lots of reasons we don't care about, and don't want anyone to care about us. Also took the time to tweak the capabilities for light up, which won't affect the test that regressed, but seems like it probably a little broad before :)