### PR TITLE
Take 2 to fix the image load regression

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/LSPRequestInvokerWrapper.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/LSPRequestInvokerWrapper.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
+
+namespace Microsoft.VisualStudio.Razor.ProjectSystem;
+
+/// <summary>
+/// Wraps LSPRequestInvoker so that MEF doesn't need to load the ContainedLanguage.dll to satisfy imports
+/// </summary>
+/// <param name="requestInvoker"></param>
+[Export(typeof(LSPRequestInvokerWrapper))]
+[method: ImportingConstructor]
+internal sealed class LSPRequestInvokerWrapper(Lazy<LSPRequestInvoker> requestInvoker)
+{
+    private readonly Lazy<LSPRequestInvoker> _requestInvoker = requestInvoker;
+
+    public Task<ReinvokeResponse<TOut>> ReinvokeRequestOnServerAsync<TIn, TOut>(
+        string method,
+        string languageServerName,
+        TIn parameters,
+        CancellationToken cancellationToken)
+        where TIn : notnull
+    {
+        return _requestInvoker.Value.ReinvokeRequestOnServerAsync<TIn, TOut>(method, languageServerName, parameters, cancellationToken);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/RenameProjectTreeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/RenameProjectTreeHandler.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Razor.Utilities;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
-using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.Razor.LanguageClient;
 using Microsoft.VisualStudio.Shell;
@@ -26,13 +25,13 @@ namespace Microsoft.VisualStudio.Razor.ProjectSystem;
 internal sealed partial class RenameProjectTreeHandler(
     [Import(ExportContractNames.Scopes.UnconfiguredProject)] IProjectAsynchronousTasksService projectAsynchronousTasksService,
     SVsServiceProvider serviceProvider,
-    Lazy<LSPRequestInvoker> requestInvoker,
+    Lazy<LSPRequestInvokerWrapper> requestInvoker,
     LanguageServerFeatureOptions featureOptions,
     ILoggerFactory loggerFactory) : ProjectTreeActionHandlerBase
 {
     private readonly IProjectAsynchronousTasksService _projectAsynchronousTasksService = projectAsynchronousTasksService;
     private readonly SVsServiceProvider _serviceProvider = serviceProvider;
-    private readonly Lazy<LSPRequestInvoker> _requestInvoker = requestInvoker;
+    private readonly Lazy<LSPRequestInvokerWrapper> _requestInvoker = requestInvoker;
     private readonly LanguageServerFeatureOptions _featureOptions = featureOptions;
     private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<RenameProjectTreeHandler>();
 


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2677553

PIT run shows this prevents the image load. It's not flagged as a highlight though :(
https://dev.azure.com/devdiv/DevDiv/_apps/hub/ms-vseng.pit-vsengPerf.pit-hub?targetBuild=11413.276.dn-bot.260115.000316.700145&targetBranch=main&targetPerfBuildId=13099347&runGroup=PerfDDRITs64&baselineBuild=11413.276&baselineBranch=main

Can't deep link apparently, but looking at WebTools Debugging test, Stop Debugging scenario, adjusted images in memory counter.

<img width="1052" height="82" alt="image" src="https://github.com/user-attachments/assets/fc4dfa77-452d-4ed2-b2f6-1b4c79d84206" />

<img width="989" height="111" alt="image" src="https://github.com/user-attachments/assets/fe85422d-3b50-4d3a-ae1c-50b1006505d7" />
