### PR TITLE
Manual codeflow of VMR's 2xx branch after subscription change 

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -6,7 +6,7 @@
          that is treated as an analyzer, there can be file locking issues if Razor.Diagnostics.Analyzers isn't
          built before Razor.slnx. Setting "BuildInParallel" to "false" ensures that this solution will be fully
          built first. -->
-    <ProjectToBuild Include="$(RepoRoot)\eng\BuildAnalyzers.sln" BuildInParallel="false" />
+    <ProjectToBuild Condition="'$(DotNetBuildSourceOnly)' != 'true'" Include="$(RepoRoot)\eng\BuildAnalyzers.sln" BuildInParallel="false" />
 
     <ProjectToBuild Condition="'$(OS)'=='WINDOWS_NT' and '$(SdkTaskProjects)'==''" Include="$(MSBuildThisFileDirectory)..\Razor.slnx" />
 

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -5,31 +5,30 @@ This file should be imported by eng/Versions.props
 -->
 <Project>
   <PropertyGroup>
-    <!-- dotnet/roslyn dependencies -->
-    <MicrosoftCodeAnalysisAnalyzersPackageVersion>5.3.0-2.25630.5</MicrosoftCodeAnalysisAnalyzersPackageVersion>
-    <MicrosoftCodeAnalysisCommonPackageVersion>5.3.0-2.25630.5</MicrosoftCodeAnalysisCommonPackageVersion>
-    <MicrosoftCodeAnalysisCSharpPackageVersion>5.3.0-2.25630.5</MicrosoftCodeAnalysisCSharpPackageVersion>
-    <MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>5.3.0-2.25630.5</MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>5.3.0-2.25630.5</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>5.3.0-2.25630.5</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesPackageVersion>5.3.0-2.25630.5</MicrosoftCodeAnalysisEditorFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>5.3.0-2.25630.5</MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>5.3.0-2.25630.5</MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>
-    <MicrosoftCodeAnalysisExternalAccessFSharpPackageVersion>5.3.0-2.25630.5</MicrosoftCodeAnalysisExternalAccessFSharpPackageVersion>
-    <MicrosoftCodeAnalysisExternalAccessRazorEditorFeaturesPackageVersion>5.3.0-2.25630.5</MicrosoftCodeAnalysisExternalAccessRazorEditorFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisExternalAccessRazorFeaturesPackageVersion>5.3.0-2.25630.5</MicrosoftCodeAnalysisExternalAccessRazorFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisLanguageServerProtocolPackageVersion>5.3.0-2.25630.5</MicrosoftCodeAnalysisLanguageServerProtocolPackageVersion>
-    <MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>5.3.0-2.25630.5</MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>
-    <MicrosoftCodeAnalysisTestUtilitiesPackageVersion>5.3.0-2.25630.5</MicrosoftCodeAnalysisTestUtilitiesPackageVersion>
-    <MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>5.3.0-2.25630.5</MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>5.3.0-2.25630.5</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>5.3.0-2.25630.5</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
-    <MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>5.3.0-2.25630.5</MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>
-    <MicrosoftNetCompilersToolsetPackageVersion>5.3.0-2.25630.5</MicrosoftNetCompilersToolsetPackageVersion>
-    <MicrosoftVisualStudioLanguageServicesPackageVersion>5.3.0-2.25630.5</MicrosoftVisualStudioLanguageServicesPackageVersion>
-    <RoslynDiagnosticsAnalyzersPackageVersion>5.3.0-2.25630.5</RoslynDiagnosticsAnalyzersPackageVersion>
-    <!-- dotnet/arcade dependencies -->
-    <MicrosoftDotNetArcadeSdkPackageVersion>10.0.0-beta.25626.5</MicrosoftDotNetArcadeSdkPackageVersion>
+    <!-- dotnet/dotnet dependencies -->
+    <MicrosoftCodeAnalysisAnalyzersPackageVersion>5.3.0-2.26064.108</MicrosoftCodeAnalysisAnalyzersPackageVersion>
+    <MicrosoftCodeAnalysisCommonPackageVersion>5.3.0-2.26064.108</MicrosoftCodeAnalysisCommonPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>5.3.0-2.26064.108</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>5.3.0-2.26064.108</MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>5.3.0-2.26064.108</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>5.3.0-2.26064.108</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesPackageVersion>5.3.0-2.26064.108</MicrosoftCodeAnalysisEditorFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>5.3.0-2.26064.108</MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>5.3.0-2.26064.108</MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>
+    <MicrosoftCodeAnalysisExternalAccessFSharpPackageVersion>5.3.0-2.26064.108</MicrosoftCodeAnalysisExternalAccessFSharpPackageVersion>
+    <MicrosoftCodeAnalysisExternalAccessRazorEditorFeaturesPackageVersion>5.3.0-2.26064.108</MicrosoftCodeAnalysisExternalAccessRazorEditorFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisExternalAccessRazorFeaturesPackageVersion>5.3.0-2.26064.108</MicrosoftCodeAnalysisExternalAccessRazorFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisLanguageServerProtocolPackageVersion>5.3.0-2.26064.108</MicrosoftCodeAnalysisLanguageServerProtocolPackageVersion>
+    <MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>5.3.0-2.26064.108</MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>
+    <MicrosoftCodeAnalysisTestUtilitiesPackageVersion>5.3.0-2.26064.108</MicrosoftCodeAnalysisTestUtilitiesPackageVersion>
+    <MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>5.3.0-2.26064.108</MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>5.3.0-2.26064.108</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>5.3.0-2.26064.108</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
+    <MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>5.3.0-2.26064.108</MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>
+    <MicrosoftDotNetArcadeSdkPackageVersion>10.0.0-beta.26064.108</MicrosoftDotNetArcadeSdkPackageVersion>
+    <MicrosoftNetCompilersToolsetPackageVersion>5.3.0-2.26064.108</MicrosoftNetCompilersToolsetPackageVersion>
+    <MicrosoftVisualStudioLanguageServicesPackageVersion>5.3.0-2.26064.108</MicrosoftVisualStudioLanguageServicesPackageVersion>
+    <RoslynDiagnosticsAnalyzersPackageVersion>5.3.0-2.26064.108</RoslynDiagnosticsAnalyzersPackageVersion>
     <!-- dotnet/aspnetcore dependencies -->
     <MicrosoftExtensionsObjectPoolPackageVersion>8.0.0</MicrosoftExtensionsObjectPoolPackageVersion>
     <!-- dotnet/runtime dependencies -->
@@ -38,7 +37,7 @@ This file should be imported by eng/Versions.props
   </PropertyGroup>
   <!--Property group for alternate package version names-->
   <PropertyGroup>
-    <!-- dotnet/roslyn dependencies -->
+    <!-- dotnet/dotnet dependencies -->
     <MicrosoftCodeAnalysisAnalyzersVersion>$(MicrosoftCodeAnalysisAnalyzersPackageVersion)</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisCommonVersion>$(MicrosoftCodeAnalysisCommonPackageVersion)</MicrosoftCodeAnalysisCommonVersion>
     <MicrosoftCodeAnalysisCSharpVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftCodeAnalysisCSharpVersion>
@@ -58,11 +57,10 @@ This file should be imported by eng/Versions.props
     <MicrosoftCodeAnalysisWorkspacesCommonVersion>$(MicrosoftCodeAnalysisWorkspacesCommonPackageVersion)</MicrosoftCodeAnalysisWorkspacesCommonVersion>
     <MicrosoftCodeAnalysisWorkspacesMSBuildVersion>$(MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion)</MicrosoftCodeAnalysisWorkspacesMSBuildVersion>
     <MicrosoftCommonLanguageServerProtocolFrameworkVersion>$(MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion)</MicrosoftCommonLanguageServerProtocolFrameworkVersion>
+    <MicrosoftDotNetArcadeSdkVersion>$(MicrosoftDotNetArcadeSdkPackageVersion)</MicrosoftDotNetArcadeSdkVersion>
     <MicrosoftNetCompilersToolsetVersion>$(MicrosoftNetCompilersToolsetPackageVersion)</MicrosoftNetCompilersToolsetVersion>
     <MicrosoftVisualStudioLanguageServicesVersion>$(MicrosoftVisualStudioLanguageServicesPackageVersion)</MicrosoftVisualStudioLanguageServicesVersion>
     <RoslynDiagnosticsAnalyzersVersion>$(RoslynDiagnosticsAnalyzersPackageVersion)</RoslynDiagnosticsAnalyzersVersion>
-    <!-- dotnet/arcade dependencies -->
-    <MicrosoftDotNetArcadeSdkVersion>$(MicrosoftDotNetArcadeSdkPackageVersion)</MicrosoftDotNetArcadeSdkVersion>
     <!-- dotnet/aspnetcore dependencies -->
     <MicrosoftExtensionsObjectPoolVersion>$(MicrosoftExtensionsObjectPoolPackageVersion)</MicrosoftExtensionsObjectPoolVersion>
     <!-- dotnet/runtime dependencies -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,100 +1,100 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
-  <Source Uri="https://github.com/dotnet/dotnet" Mapping="razor" Sha="7ec0eaa34a5eb9e1f915209c96c56fb53ea61c61" BarId="293565" />
+  <Source Uri="https://github.com/dotnet/dotnet" Mapping="razor" Sha="cbfb8ee940d9d2458c24214a976305d5f1c5fe32" BarId="297285" />
   <ProductDependencies>
-    <Dependency Name="Roslyn.Diagnostics.Analyzers" Version="5.3.0-2.25630.5">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>635d2b812121ef9fafe0de223b09be64e5a4a291</Sha>
+    <Dependency Name="Roslyn.Diagnostics.Analyzers" Version="5.3.0-2.26064.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>cbfb8ee940d9d2458c24214a976305d5f1c5fe32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="5.3.0-2.25630.5">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>635d2b812121ef9fafe0de223b09be64e5a4a291</Sha>
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="5.3.0-2.26064.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>cbfb8ee940d9d2458c24214a976305d5f1c5fe32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CommonLanguageServerProtocol.Framework" Version="5.3.0-2.25630.5">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>635d2b812121ef9fafe0de223b09be64e5a4a291</Sha>
+    <Dependency Name="Microsoft.CommonLanguageServerProtocol.Framework" Version="5.3.0-2.26064.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>cbfb8ee940d9d2458c24214a976305d5f1c5fe32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Common" Version="5.3.0-2.25630.5">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>635d2b812121ef9fafe0de223b09be64e5a4a291</Sha>
+    <Dependency Name="Microsoft.CodeAnalysis.Common" Version="5.3.0-2.26064.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>cbfb8ee940d9d2458c24214a976305d5f1c5fe32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="5.3.0-2.25630.5">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>635d2b812121ef9fafe0de223b09be64e5a4a291</Sha>
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="5.3.0-2.26064.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>cbfb8ee940d9d2458c24214a976305d5f1c5fe32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.EditorFeatures" Version="5.3.0-2.25630.5">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>635d2b812121ef9fafe0de223b09be64e5a4a291</Sha>
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.EditorFeatures" Version="5.3.0-2.26064.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>cbfb8ee940d9d2458c24214a976305d5f1c5fe32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="5.3.0-2.25630.5">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>635d2b812121ef9fafe0de223b09be64e5a4a291</Sha>
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="5.3.0-2.26064.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>cbfb8ee940d9d2458c24214a976305d5f1c5fe32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0-2.25630.5">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>635d2b812121ef9fafe0de223b09be64e5a4a291</Sha>
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0-2.26064.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>cbfb8ee940d9d2458c24214a976305d5f1c5fe32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures" Version="5.3.0-2.25630.5">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>635d2b812121ef9fafe0de223b09be64e5a4a291</Sha>
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures" Version="5.3.0-2.26064.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>cbfb8ee940d9d2458c24214a976305d5f1c5fe32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Common" Version="5.3.0-2.25630.5">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>635d2b812121ef9fafe0de223b09be64e5a4a291</Sha>
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Common" Version="5.3.0-2.26064.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>cbfb8ee940d9d2458c24214a976305d5f1c5fe32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Text" Version="5.3.0-2.25630.5">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>635d2b812121ef9fafe0de223b09be64e5a4a291</Sha>
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Text" Version="5.3.0-2.26064.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>cbfb8ee940d9d2458c24214a976305d5f1c5fe32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Remote.ServiceHub" Version="5.3.0-2.25630.5">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>635d2b812121ef9fafe0de223b09be64e5a4a291</Sha>
+    <Dependency Name="Microsoft.CodeAnalysis.Remote.ServiceHub" Version="5.3.0-2.26064.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>cbfb8ee940d9d2458c24214a976305d5f1c5fe32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="5.3.0-2.25630.5">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>635d2b812121ef9fafe0de223b09be64e5a4a291</Sha>
+    <Dependency Name="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="5.3.0-2.26064.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>cbfb8ee940d9d2458c24214a976305d5f1c5fe32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.3.0-2.25630.5">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>635d2b812121ef9fafe0de223b09be64e5a4a291</Sha>
+    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.3.0-2.26064.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>cbfb8ee940d9d2458c24214a976305d5f1c5fe32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.3.0-2.25630.5">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>635d2b812121ef9fafe0de223b09be64e5a4a291</Sha>
+    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.3.0-2.26064.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>cbfb8ee940d9d2458c24214a976305d5f1c5fe32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.VisualStudio.LanguageServices" Version="5.3.0-2.25630.5">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>635d2b812121ef9fafe0de223b09be64e5a4a291</Sha>
+    <Dependency Name="Microsoft.VisualStudio.LanguageServices" Version="5.3.0-2.26064.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>cbfb8ee940d9d2458c24214a976305d5f1c5fe32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Test.Utilities" Version="5.3.0-2.25630.5">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>635d2b812121ef9fafe0de223b09be64e5a4a291</Sha>
+    <Dependency Name="Microsoft.CodeAnalysis.Test.Utilities" Version="5.3.0-2.26064.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>cbfb8ee940d9d2458c24214a976305d5f1c5fe32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.Razor.Features" Version="5.3.0-2.25630.5">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>635d2b812121ef9fafe0de223b09be64e5a4a291</Sha>
+    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.Razor.Features" Version="5.3.0-2.26064.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>cbfb8ee940d9d2458c24214a976305d5f1c5fe32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.Razor.EditorFeatures" Version="5.3.0-2.25630.5">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>635d2b812121ef9fafe0de223b09be64e5a4a291</Sha>
+    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.Razor.EditorFeatures" Version="5.3.0-2.26064.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>cbfb8ee940d9d2458c24214a976305d5f1c5fe32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.LanguageServer.Protocol" Version="5.3.0-2.25630.5">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>635d2b812121ef9fafe0de223b09be64e5a4a291</Sha>
+    <Dependency Name="Microsoft.CodeAnalysis.LanguageServer.Protocol" Version="5.3.0-2.26064.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>cbfb8ee940d9d2458c24214a976305d5f1c5fe32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.FSharp" Version="5.3.0-2.25630.5">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>635d2b812121ef9fafe0de223b09be64e5a4a291</Sha>
+    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.FSharp" Version="5.3.0-2.26064.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>cbfb8ee940d9d2458c24214a976305d5f1c5fe32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0-2.25630.5">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>635d2b812121ef9fafe0de223b09be64e5a4a291</Sha>
+    <Dependency Name="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0-2.26064.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>cbfb8ee940d9d2458c24214a976305d5f1c5fe32</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25626.5">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>d8dca0b41b903e7182e64543773390b969dab96b</Sha>
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.26064.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>cbfb8ee940d9d2458c24214a976305d5f1c5fe32</Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows Microsoft.Extensions.ObjectPool and System.Collections.Immutable packages
          to be retrieved from live source-build and their content consumed by packages produced by razor.

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -560,26 +560,19 @@ function LocateVisualStudio([object]$vsRequirements = $null){
     })
   }
 
-  if (!$vsRequirements) {
-    if (Get-Member -InputObject $GlobalJson.tools -Name 'vs' -ErrorAction SilentlyContinue) {
-      $vsRequirements = $GlobalJson.tools.vs
-    } else {
-      $vsRequirements = $null
-    }
-  }
-
+  if (!$vsRequirements) { $vsRequirements = $GlobalJson.tools.vs }
   $args = @('-latest', '-format', 'json', '-requires', 'Microsoft.Component.MSBuild', '-products', '*')
 
   if (!$excludePrereleaseVS) {
     $args += '-prerelease'
   }
 
-  if ($vsRequirements -and (Get-Member -InputObject $vsRequirements -Name 'version' -ErrorAction SilentlyContinue)) {
+  if (Get-Member -InputObject $vsRequirements -Name 'version') {
     $args += '-version'
     $args += $vsRequirements.version
   }
 
-  if ($vsRequirements -and (Get-Member -InputObject $vsRequirements -Name 'components' -ErrorAction SilentlyContinue)) {
+  if (Get-Member -InputObject $vsRequirements -Name 'components') {
     foreach ($component in $vsRequirements.components) {
       $args += '-requires'
       $args += $component

--- a/global.json
+++ b/global.json
@@ -21,7 +21,7 @@
     "rollForward": "latestPatch"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25626.5",
+    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.26064.108",
     "Microsoft.Build.NoTargets": "3.7.0"
   }
 }

--- a/src/Analyzers/Razor.Diagnostics.Analyzers/Razor.Diagnostics.Analyzers.csproj
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers/Razor.Diagnostics.Analyzers.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
-    <ExcludeFromSourceOnlyBuild>false</ExcludeFromSourceOnlyBuild>
     <IsShippingPackage>false</IsShippingPackage>
   </PropertyGroup>
 

--- a/src/Compiler/Directory.Build.props
+++ b/src/Compiler/Directory.Build.props
@@ -37,7 +37,7 @@
     <WarningsNotAsErrors>$(WarningsNotAsErrors);xUnit1004</WarningsNotAsErrors>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(DotNetBuildFromVMR)' != 'true'">
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" NoWarn="NU1608" PrivateAssets="All" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" PrivateAssets="All" />
 

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/test/IsViewComponentTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/test/IsViewComponentTest.cs
@@ -24,15 +24,15 @@ public class IsViewComponentTest
     {
         var assembly = typeof(IsViewComponentTest).GetTypeInfo().Assembly;
         Compilation = TestCompilation.Create(assembly);
-        TestViewComponentAttributeSymbol = Compilation.GetTypeByMetadataName(typeof(TestViewComponentAttribute).FullName).AssumeNotNull();
-        TestNonViewComponentAttributeSymbol = Compilation.GetTypeByMetadataName(typeof(TestNonViewComponentAttribute).FullName).AssumeNotNull();
+        TestViewComponentAttributeSymbol = Compilation.GetTypeByMetadataName(typeof(TestViewComponentAttribute).FullName.AssumeNotNull()).AssumeNotNull();
+        TestNonViewComponentAttributeSymbol = Compilation.GetTypeByMetadataName(typeof(TestNonViewComponentAttribute).FullName.AssumeNotNull()).AssumeNotNull();
     }
 
     [Fact]
     public void IsViewComponent_PlainViewComponent_ReturnsTrue()
     {
         // Arrange
-        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Valid_PlainViewComponent).FullName);
+        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Valid_PlainViewComponent).FullName.AssumeNotNull());
         Assert.NotNull(tagHelperSymbol);
 
         // Act
@@ -46,7 +46,7 @@ public class IsViewComponentTest
     public void IsViewComponent_DecoratedViewComponent_ReturnsTrue()
     {
         // Arrange
-        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Valid_DecoratedVC).FullName);
+        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Valid_DecoratedVC).FullName.AssumeNotNull());
         Assert.NotNull(tagHelperSymbol);
 
         // Act
@@ -60,7 +60,7 @@ public class IsViewComponentTest
     public void IsViewComponent_InheritedViewComponent_ReturnsTrue()
     {
         // Arrange
-        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Valid_InheritedVC).FullName);
+        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Valid_InheritedVC).FullName.AssumeNotNull());
         Assert.NotNull(tagHelperSymbol);
 
         // Act
@@ -74,7 +74,7 @@ public class IsViewComponentTest
     public void IsViewComponent_AbstractViewComponent_ReturnsFalse()
     {
         // Arrange
-        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_AbstractViewComponent).FullName);
+        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_AbstractViewComponent).FullName.AssumeNotNull());
         Assert.NotNull(tagHelperSymbol);
 
         // Act
@@ -88,7 +88,7 @@ public class IsViewComponentTest
     public void IsViewComponent_GenericViewComponent_ReturnsFalse()
     {
         // Arrange
-        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_GenericViewComponent<>).FullName);
+        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_GenericViewComponent<>).FullName.AssumeNotNull());
         Assert.NotNull(tagHelperSymbol);
 
         // Act
@@ -102,7 +102,7 @@ public class IsViewComponentTest
     public void IsViewComponent_InternalViewComponent_ReturnsFalse()
     {
         // Arrange
-        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_InternalViewComponent).FullName);
+        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_InternalViewComponent).FullName.AssumeNotNull());
         Assert.NotNull(tagHelperSymbol);
 
         // Act
@@ -116,7 +116,7 @@ public class IsViewComponentTest
     public void IsViewComponent_DecoratedNonViewComponent_ReturnsFalse()
     {
         // Arrange
-        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_DecoratedViewComponent).FullName);
+        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_DecoratedViewComponent).FullName.AssumeNotNull());
         Assert.NotNull(tagHelperSymbol);
 
         // Act
@@ -130,7 +130,7 @@ public class IsViewComponentTest
     public void IsViewComponent_InheritedNonViewComponent_ReturnsFalse()
     {
         // Arrange
-        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_InheritedViewComponent).FullName);
+        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_InheritedViewComponent).FullName.AssumeNotNull());
         Assert.NotNull(tagHelperSymbol);
 
         // Act

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/IsViewComponentTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/IsViewComponentTest.cs
@@ -24,15 +24,15 @@ public class IsViewComponentTest
     {
         var assembly = typeof(IsViewComponentTest).GetTypeInfo().Assembly;
         Compilation = TestCompilation.Create(assembly);
-        TestViewComponentAttributeSymbol = Compilation.GetTypeByMetadataName(typeof(TestViewComponentAttribute).FullName).AssumeNotNull();
-        TestNonViewComponentAttributeSymbol = Compilation.GetTypeByMetadataName(typeof(TestNonViewComponentAttribute).FullName).AssumeNotNull();
+        TestViewComponentAttributeSymbol = Compilation.GetTypeByMetadataName(typeof(TestViewComponentAttribute).FullName.AssumeNotNull()).AssumeNotNull();
+        TestNonViewComponentAttributeSymbol = Compilation.GetTypeByMetadataName(typeof(TestNonViewComponentAttribute).FullName.AssumeNotNull()).AssumeNotNull();
     }
 
     [Fact]
     public void IsViewComponent_PlainViewComponent_ReturnsTrue()
     {
         // Arrange
-        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Valid_PlainViewComponent).FullName);
+        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Valid_PlainViewComponent).FullName.AssumeNotNull());
         Assert.NotNull(tagHelperSymbol);
 
         // Act
@@ -46,7 +46,7 @@ public class IsViewComponentTest
     public void IsViewComponent_DecoratedViewComponent_ReturnsTrue()
     {
         // Arrange
-        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Valid_DecoratedVC).FullName);
+        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Valid_DecoratedVC).FullName.AssumeNotNull());
         Assert.NotNull(tagHelperSymbol);
 
         // Act
@@ -60,7 +60,7 @@ public class IsViewComponentTest
     public void IsViewComponent_InheritedViewComponent_ReturnsTrue()
     {
         // Arrange
-        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Valid_InheritedVC).FullName);
+        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Valid_InheritedVC).FullName.AssumeNotNull());
         Assert.NotNull(tagHelperSymbol);
 
         // Act
@@ -74,7 +74,7 @@ public class IsViewComponentTest
     public void IsViewComponent_AbstractViewComponent_ReturnsFalse()
     {
         // Arrange
-        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_AbstractViewComponent).FullName);
+        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_AbstractViewComponent).FullName.AssumeNotNull());
         Assert.NotNull(tagHelperSymbol);
 
         // Act
@@ -88,7 +88,7 @@ public class IsViewComponentTest
     public void IsViewComponent_GenericViewComponent_ReturnsFalse()
     {
         // Arrange
-        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_GenericViewComponent<>).FullName);
+        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_GenericViewComponent<>).FullName.AssumeNotNull());
         Assert.NotNull(tagHelperSymbol);
 
         // Act
@@ -102,7 +102,7 @@ public class IsViewComponentTest
     public void IsViewComponent_InternalViewComponent_ReturnsFalse()
     {
         // Arrange
-        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_InternalViewComponent).FullName);
+        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_InternalViewComponent).FullName.AssumeNotNull());
         Assert.NotNull(tagHelperSymbol);
 
         // Act
@@ -116,7 +116,7 @@ public class IsViewComponentTest
     public void IsViewComponent_DecoratedNonViewComponent_ReturnsFalse()
     {
         // Arrange
-        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_DecoratedViewComponent).FullName);
+        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_DecoratedViewComponent).FullName.AssumeNotNull());
         Assert.NotNull(tagHelperSymbol);
 
         // Act
@@ -130,7 +130,7 @@ public class IsViewComponentTest
     public void IsViewComponent_InheritedNonViewComponent_ReturnsFalse()
     {
         // Arrange
-        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_InheritedViewComponent).FullName);
+        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_InheritedViewComponent).FullName.AssumeNotNull());
         Assert.NotNull(tagHelperSymbol);
 
         // Act

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/IsViewComponentTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/IsViewComponentTest.cs
@@ -24,15 +24,15 @@ public class IsViewComponentTest
     {
         var assembly = typeof(IsViewComponentTest).GetTypeInfo().Assembly;
         Compilation = TestCompilation.Create(assembly);
-        TestViewComponentAttributeSymbol = Compilation.GetTypeByMetadataName(typeof(TestViewComponentAttribute).FullName).AssumeNotNull();
-        TestNonViewComponentAttributeSymbol = Compilation.GetTypeByMetadataName(typeof(TestNonViewComponentAttribute).FullName).AssumeNotNull();
+        TestViewComponentAttributeSymbol = Compilation.GetTypeByMetadataName(typeof(TestViewComponentAttribute).FullName.AssumeNotNull()).AssumeNotNull();
+        TestNonViewComponentAttributeSymbol = Compilation.GetTypeByMetadataName(typeof(TestNonViewComponentAttribute).FullName.AssumeNotNull()).AssumeNotNull();
     }
 
     [Fact]
     public void IsViewComponent_PlainViewComponent_ReturnsTrue()
     {
         // Arrange
-        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Valid_PlainViewComponent).FullName);
+        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Valid_PlainViewComponent).FullName.AssumeNotNull());
         Assert.NotNull(tagHelperSymbol);
 
         // Act
@@ -46,7 +46,7 @@ public class IsViewComponentTest
     public void IsViewComponent_DecoratedViewComponent_ReturnsTrue()
     {
         // Arrange
-        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Valid_DecoratedVC).FullName);
+        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Valid_DecoratedVC).FullName.AssumeNotNull());
         Assert.NotNull(tagHelperSymbol);
 
         // Act
@@ -60,7 +60,7 @@ public class IsViewComponentTest
     public void IsViewComponent_InheritedViewComponent_ReturnsTrue()
     {
         // Arrange
-        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Valid_InheritedVC).FullName);
+        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Valid_InheritedVC).FullName.AssumeNotNull());
         Assert.NotNull(tagHelperSymbol);
 
         // Act
@@ -74,7 +74,7 @@ public class IsViewComponentTest
     public void IsViewComponent_AbstractViewComponent_ReturnsFalse()
     {
         // Arrange
-        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_AbstractViewComponent).FullName);
+        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_AbstractViewComponent).FullName.AssumeNotNull());
         Assert.NotNull(tagHelperSymbol);
 
         // Act
@@ -88,7 +88,7 @@ public class IsViewComponentTest
     public void IsViewComponent_GenericViewComponent_ReturnsFalse()
     {
         // Arrange
-        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_GenericViewComponent<>).FullName);
+        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_GenericViewComponent<>).FullName.AssumeNotNull());
         Assert.NotNull(tagHelperSymbol);
 
         // Act
@@ -102,7 +102,7 @@ public class IsViewComponentTest
     public void IsViewComponent_InternalViewComponent_ReturnsFalse()
     {
         // Arrange
-        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_InternalViewComponent).FullName);
+        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_InternalViewComponent).FullName.AssumeNotNull());
         Assert.NotNull(tagHelperSymbol);
 
         // Act
@@ -116,7 +116,7 @@ public class IsViewComponentTest
     public void IsViewComponent_DecoratedNonViewComponent_ReturnsFalse()
     {
         // Arrange
-        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_DecoratedViewComponent).FullName);
+        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_DecoratedViewComponent).FullName.AssumeNotNull());
         Assert.NotNull(tagHelperSymbol);
 
         // Act
@@ -130,7 +130,7 @@ public class IsViewComponentTest
     public void IsViewComponent_InheritedNonViewComponent_ReturnsFalse()
     {
         // Arrange
-        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_InheritedViewComponent).FullName);
+        var tagHelperSymbol = Compilation.GetTypeByMetadataName(typeof(Invalid_InheritedViewComponent).FullName.AssumeNotNull());
         Assert.NotNull(tagHelperSymbol);
 
         // Act

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/test/DefaultTagHelperDescriptorFactoryTest.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/test/DefaultTagHelperDescriptorFactoryTest.cs
@@ -1141,7 +1141,7 @@ public class DefaultTagHelperDescriptorFactoryTest : TagHelperDescriptorProvider
     {
         // Arrange
         var factory = new DefaultTagHelperDescriptorFactory(includeDocumentation: false, excludeHidden: false);
-        var typeSymbol = Compilation.GetTypeByMetadataName(typeof(Enumerable).FullName);
+        var typeSymbol = Compilation.GetTypeByMetadataName(typeof(Enumerable).FullName!);
 
         Assert.NotNull(typeSymbol);
 
@@ -1187,7 +1187,7 @@ public class DefaultTagHelperDescriptorFactoryTest : TagHelperDescriptorProvider
                             .AsDictionaryAttribute<object>("valid-prefix4-"))
                         .BoundAttribute(name: "valid-name5", propertyName: "SortedDictionaryProperty", typeName: GetDictionaryTypeName<SortedDictionary<string, int>>(), static b => b
                             .AsDictionaryAttribute<int>("valid-prefix5-"))
-                        .BoundAttribute(name: "valid-name6", propertyName: "StringProperty", typeName: typeof(string).FullName)
+                        .BoundAttribute(name: "valid-name6", propertyName: "StringProperty", typeName: typeof(string).FullName!)
                         .BoundAttribute(name: string.Empty, propertyName: "GetOnlyDictionaryProperty", typeName: GetDictionaryTypeName<IDictionary<string, int>>(), static b => b
                             .AsDictionaryAttribute<int>("get-only-dictionary-property-"))
                         .BoundAttribute(name: string.Empty, propertyName: "GetOnlyDictionaryPropertyWithAttributePrefix", typeName: GetDictionaryTypeName<IDictionary<string, string>>(), static b => b
@@ -1195,7 +1195,7 @@ public class DefaultTagHelperDescriptorFactoryTest : TagHelperDescriptorProvider
                     diagnostics: []),
                 Combine(
                     NameAndBoundAttributes("SingleInvalidHtmlAttributePrefix", static b => b
-                        .BoundAttribute(name: "valid-name", propertyName: "StringProperty", typeName: typeof(string).FullName, static b => b
+                        .BoundAttribute(name: "valid-name", propertyName: "StringProperty", typeName: typeof(string).FullName!, static b => b
                             .AddDiagnostic(RazorDiagnosticFactory.CreateTagHelper_InvalidAttributePrefixNotNull(
                                 "TestNamespace.SingleInvalidHtmlAttributePrefix",
                                 "StringProperty")))),

--- a/src/Razor/Directory.Build.props
+++ b/src/Razor/Directory.Build.props
@@ -3,7 +3,7 @@
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(DotNetBuildFromVMR)' != 'true'">
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" NoWarn="NU1608" PrivateAssets="all" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" PrivateAssets="all" />
 

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/ProjectLoadBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/ProjectLoadBenchmark.cs
@@ -10,6 +10,8 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.AspNetCore.Razor.Microbenchmarks;
 
+#pragma warning disable VSTHRD200
+
 public class ProjectLoadBenchmark : ProjectSnapshotManagerBenchmarkBase
 {
     [IterationSetup]

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Tooltip/TypeNameStringResolver.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Tooltip/TypeNameStringResolver.cs
@@ -11,21 +11,22 @@ internal static class TypeNameStringResolver
 {
     private static readonly Dictionary<string, string> s_primitiveDisplayTypeNameLookups = new(StringComparer.Ordinal)
     {
-        [typeof(byte).FullName] = "byte",
-        [typeof(sbyte).FullName] = "sbyte",
-        [typeof(int).FullName] = "int",
-        [typeof(uint).FullName] = "uint",
-        [typeof(short).FullName] = "short",
-        [typeof(ushort).FullName] = "ushort",
-        [typeof(long).FullName] = "long",
-        [typeof(ulong).FullName] = "ulong",
-        [typeof(float).FullName] = "float",
-        [typeof(double).FullName] = "double",
-        [typeof(char).FullName] = "char",
-        [typeof(bool).FullName] = "bool",
-        [typeof(object).FullName] = "object",
-        [typeof(string).FullName] = "string",
-        [typeof(decimal).FullName] = "decimal",
+        // These null suppressions are required for the VMR, which builds using v5.0 of Roslyn
+        [typeof(byte).FullName!] = "byte",
+        [typeof(sbyte).FullName!] = "sbyte",
+        [typeof(int).FullName!] = "int",
+        [typeof(uint).FullName!] = "uint",
+        [typeof(short).FullName!] = "short",
+        [typeof(ushort).FullName!] = "ushort",
+        [typeof(long).FullName!] = "long",
+        [typeof(ulong).FullName!] = "ulong",
+        [typeof(float).FullName!] = "float",
+        [typeof(double).FullName!] = "double",
+        [typeof(char).FullName!] = "char",
+        [typeof(bool).FullName!] = "bool",
+        [typeof(object).FullName!] = "object",
+        [typeof(string).FullName!] = "string",
+        [typeof(decimal).FullName!] = "decimal",
     };
 
     public static bool TryGetSimpleName(string typeName, [NotNullWhen(returnValue: true)] out string? resolvedName)

--- a/src/Razor/test/.editorconfig
+++ b/src/Razor/test/.editorconfig
@@ -1,0 +1,4 @@
+[*.cs]
+
+# VSTHRD200: Use "Async" suffix for async methods
+dotnet_diagnostic.VSTHRD200.severity = none

--- a/src/Shared/Directory.Build.props
+++ b/src/Shared/Directory.Build.props
@@ -11,7 +11,7 @@
     <RollForward Condition="'$(IsTestProject)' == 'true'">LatestMajor</RollForward>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(DotNetBuildFromVMR)' != 'true'">
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" NoWarn="NU1608" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" />
 


### PR DESCRIPTION
After razor switched to backflow from `2xx` instead of `main`, the backflow is blocked because it jumped between branches:

```
     repo                   VMR
       │                     │ 1.
       │                     O────┐
       │                  2. │    │
     3.O◄──────────────────────O    │
       │                     │    │
       │  ??? ◄────────────────┼────O 4.
       │                     │
```