### PR TITLE
Fix indentation following self closing tag with lambda attribute

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/language-configuration.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/language-configuration.json
@@ -25,7 +25,7 @@
     { "open": "<", "close": ">" }
   ],
   "indentationRules": {
-    "increaseIndentPattern": "<(?!\\?|(?:area|base|br|col|frame|hr|html|img|input|keygen|link|menuitem|meta|param|source|track|wbr)\\b|[^>]*\\/>)([-_\\.A-Za-z0-9]+)(?=\\s|>)\\b[^>]*>(?!.*<\\/\\1>)|<!--(?!.*-->)|\\{[^}\"']*$",
+    "increaseIndentPattern": "<(?!\\?|(?:area|base|br|col|frame|hr|html|img|input|keygen|link|menuitem|meta|param|source|track|wbr)\\b|(\"[^\"]*\"|'[^']*'|[^>])*\\/>)([-_\\.A-Za-z0-9]+)(?=\\s|>)\\b(\"[^\"]*\"|'[^']*'|[^>])*>(?!.*<\\/\\1>)|<!--(?!.*-->)|\\{[^}\"']*$",
     "decreaseIndentPattern": "^\\s*(<\\/(?!html)[-_\\.A-Za-z0-9]+\\b[^>]*>|-->|\\})"
   },
   "onEnterRules": [

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageConfigurationTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageConfigurationTest.cs
@@ -11,13 +11,29 @@ using Xunit.Abstractions;
 
 namespace Microsoft.VisualStudio.Razor;
 
-public class LanguageConfigurationTest
+public class LanguageConfigurationTest(ITestOutputHelper output)
 {
-    private readonly ITestOutputHelper _output;
+    private readonly ITestOutputHelper _output = output;
 
-    public LanguageConfigurationTest(ITestOutputHelper output)
+    [Theory]
+    [InlineData("""<ValidationMessage>""", true)]
+    [InlineData("""<ValidationMessage Attr="Value">""", true)]
+    [InlineData("""<ValidationMessage For="() => Input.Username" class="text-danger">""", true)]
+    [InlineData("""<ValidationMessage />""", false)]
+    [InlineData("""<ValidationMessage Attr="Value" />""", false)]
+    [InlineData("""<ValidationMessage For="() => Input.Username" class="text-danger" />""", false)]
+    public void ShouldIncreaseIndentation(string input, bool expected)
     {
-        _output = output;
+        var langConfig = GetLanguageConfigurationJson();
+
+        var rules = langConfig["indentationRules"];
+        Assert.NotNull(rules);
+        var pattern = rules.Value<string>("increaseIndentPattern");
+        Assert.NotNull(pattern);
+
+        var isMatch = IsMatch(input, pattern);
+
+        Assert.Equal(expected, isMatch);
     }
 
     [Theory]
@@ -50,10 +66,7 @@ public class LanguageConfigurationTest
 
     public bool WillIndent(string input, int position)
     {
-        var dir = Environment.CurrentDirectory;
-        dir = dir.Substring(0, dir.IndexOf("artifacts"));
-        var langConfigFile = Path.Combine(dir, @"src\Razor\src\Microsoft.VisualStudio.RazorExtension", "language-configuration.json");
-        var langConfig = JObject.Parse(File.ReadAllText(langConfigFile));
+        var langConfig = GetLanguageConfigurationJson();
 
         var onEnterRules = langConfig["onEnterRules"]!;
         foreach (var rule in onEnterRules)
@@ -64,7 +77,9 @@ public class LanguageConfigurationTest
             var before = input.Substring(0, position);
             var after = input.Substring(position);
 
-            if (Regex.IsMatch(before, beforePattern))
+            Assert.NotNull(beforePattern);
+
+            if (IsMatch(before, beforePattern))
             {
                 _output.WriteLine("Matched beforeText pattern: " + beforePattern);
                 if (afterPattern is null)
@@ -72,7 +87,7 @@ public class LanguageConfigurationTest
                     _output.WriteLine("No afterText pattern found. Match!");
                     return true;
                 }
-                else if (Regex.IsMatch(after, afterPattern))
+                else if (IsMatch(after, afterPattern))
                 {
                     _output.WriteLine("Matched afterText pattern: " + afterPattern);
                     _output.WriteLine("Match!");
@@ -85,5 +100,21 @@ public class LanguageConfigurationTest
 
         _output.WriteLine("No match on any pattern.");
         return false;
+    }
+
+    private static bool IsMatch(string input, string pattern)
+    {
+        // Matches VS behaviour when reading our language-configuration.json
+        // https://devdiv.visualstudio.com/DevDiv/_git/VSEditor?path=/src/Productivity/TextMate/Core/LanguageConfiguration/Impl/FastRegexConverter.cs&version=GBmain&line=27&lineEnd=28&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents
+        return Regex.IsMatch(input, pattern, RegexOptions.Compiled | RegexOptions.ECMAScript, TimeSpan.FromMilliseconds(1000));
+    }
+
+    private static JObject GetLanguageConfigurationJson()
+    {
+        var dir = Environment.CurrentDirectory;
+        dir = dir.Substring(0, dir.IndexOf("artifacts"));
+        var langConfigFile = Path.Combine(dir, @"src\Razor\src\Microsoft.VisualStudio.RazorExtension", "language-configuration.json");
+        var langConfig = JObject.Parse(File.ReadAllText(langConfigFile));
+        return langConfig;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/12705

Copilot did the regex change, I did the 2 days of debugging through the editor to work out where to put it 😛