### PR TITLE
Upgrade dotnet version to 10.0.102

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "10.0.101",
+    "dotnet": "10.0.102",
     "runtimes": {
       "dotnet": [
         "2.1.30",
@@ -16,7 +16,7 @@
     }
   },
   "sdk": {
-    "version": "10.0.101",
+    "version": "10.0.102",
     "allowPrerelease": false,
     "rollForward": "latestPatch"
   },


### PR DESCRIPTION
Just following https://github.com/dotnet/roslyn/pull/82217 so we don't need two different SDKs installed. Though our roll forward means we wouldn't anyway 🤷‍♂️