### PR TITLE
Don't run in VS Code integration tests in CI

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudioCode.Razor.IntegrationTests/Microsoft.VisualStudioCode.Razor.IntegrationTests.csproj
+++ b/src/Razor/test/Microsoft.VisualStudioCode.Razor.IntegrationTests/Microsoft.VisualStudioCode.Razor.IntegrationTests.csproj
@@ -7,8 +7,9 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
 
-    <!-- Don't run in CI when running the rest of the unit tests -->
+    <!-- Don't run in CI when running the rest of the unit tests or integration tests -->
     <IsUnitTestProject>false</IsUnitTestProject>
+    <IsIntegrationTestProject>false</IsIntegrationTestProject>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I didn't intend these to run in CI as they're not reliable enough, but I forgot to test with our separate integration test pipeline.