### PR TITLE
[18.3] Use the VS2022 release image in CI

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -87,7 +87,7 @@ extends:
         configFile: '$(Build.SourcesDirectory)/eng/TSAConfig.gdntsa'
     pool:
       name: $(DncEngInternalBuildPool)
-      image: windows.vs2022preview.amd64
+      image: windows.vs2022.amd64
       os: windows
     customBuildTags:
     - ES365AIMigrationTooling
@@ -115,7 +115,7 @@ extends:
               displayName: Code check
               pool:
                 name: $(DncEngInternalBuildPool)
-                demands: ImageOverride -equals windows.vs2022preview.amd64
+                demands: ImageOverride -equals windows.vs2022.amd64
               steps:
               - task: NuGetCommand@2
                 displayName: 'Clear NuGet caches'
@@ -148,7 +148,7 @@ extends:
             timeoutInMinutes: 120
             pool:
               name: $(DncEngInternalBuildPool)
-              demands: ImageOverride -equals windows.vs2022preview.amd64
+              demands: ImageOverride -equals windows.vs2022.amd64
             strategy:
               matrix:
                 release:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ stages:
         displayName: Code check
         pool:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals windows.vs2022preview.amd64.open
+          demands: ImageOverride -equals windows.vs2022.amd64.open
         steps:
         - task: NuGetCommand@2
           displayName: 'Clear NuGet caches'
@@ -81,7 +81,7 @@ stages:
         timeoutInMinutes: 120
         pool:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals windows.vs2022preview.amd64.open
+          demands: ImageOverride -equals windows.vs2022.amd64.open
         strategy:
           matrix:
             debug:


### PR DESCRIPTION
Cherry-pick of https://github.com/dotnet/razor/pull/12764