### PR TITLE
Fix indentation after complete tags

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/language-configuration.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/language-configuration.json
@@ -25,7 +25,7 @@
     { "open": "<", "close": ">" }
   ],
   "indentationRules": {
-    "increaseIndentPattern": "<(?!\\?|(?:area|base|br|col|frame|hr|html|img|input|keygen|link|menuitem|meta|param|source|track|wbr)\\b|(\"[^\"]*\"|'[^']*'|[^>])*\\/>)([-_\\.A-Za-z0-9]+)(?=\\s|>)\\b(\"[^\"]*\"|'[^']*'|[^>])*>(?!.*<\\/\\1>)|<!--(?!.*-->)|\\{[^}\"']*$",
+    "increaseIndentPattern": "<(?!\\?|(?:area|base|br|col|frame|hr|html|img|input|keygen|link|menuitem|meta|param|source|track|wbr)\\b|(?:\"[^\"]*\"|'[^']*'|[^>])*\\/>)([-_\\.A-Za-z0-9]+)(?=\\s|>)\\b(?:\"[^\"]*\"|'[^']*'|[^>])*>(?!.*<\\/\\1>)|<!--(?!.*-->)|\\{[^}\"']*$",
     "decreaseIndentPattern": "^\\s*(<\\/(?!html)[-_\\.A-Za-z0-9]+\\b[^>]*>|-->|\\})"
   },
   "onEnterRules": [

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageConfigurationTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageConfigurationTest.cs
@@ -26,6 +26,16 @@ public class LanguageConfigurationTest(ITestOutputHelper output)
     [InlineData("""<table title="@(1 > 2 ? "re\"d" : "blue")">""", true)]
     [InlineData("""<div dir="@(1 > 2 ? "ltr" : "rtl")"/>""", false)]
     [InlineData("""<table title="@(1 > 2 ? "re\"d" : "blue")"/>""", false)]
+    // Lines with closing tag on same line should NOT increase indent
+    [InlineData("""<button stuff></button>""", false)]
+    [InlineData("""<div></div>""", false)]
+    [InlineData("""<div class="hello"></div>""", false)]
+    [InlineData("""<ValidationMessage For="() => Input.Username" class="text-danger"></ValidationMessage>""", false)]
+    // Void elements should NOT increase indent
+    [InlineData("""<br>""", false)]
+    [InlineData("""<hr>""", false)]
+    [InlineData("""<input>""", false)]
+    [InlineData("""<img src="foo.png">""", false)]
     public void ShouldIncreaseIndentation(string input, bool expected)
     {
         var langConfig = GetLanguageConfigurationJson();


### PR DESCRIPTION
Regressed in https://github.com/dotnet/razor/pull/12727 because I used a group, not a non-capturing group, which broke end tag detection. Fixed and added tests. This should fix the integration tests too.