### PR TITLE
Add theme info for leading whitespace to a comment

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
@@ -217,6 +217,16 @@
         </dict>
       </dict>
 
+      <dict>
+        <key>scope</key>
+        <string>punctuation.whitespace.comment.leading.cs</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>whitespace</string>
+        </dict>
+      </dict>
+
       <!-- Classification removed temporarily due to https://github.com/dotnet/razor-tooling/issues/5614 -->
       <!-- <dict>
         <key>scope</key>


### PR DESCRIPTION
Previously whitespace on the line before comments was getting classified as a comment per the grammar here (https://github.com/dotnet/razor/blob/d1f80a13ab01f10a1d7bdb62ad20278425d8cfd2/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/csharp.tmLanguage.json#L5559)

*** Before ***
<img width="173" height="98" alt="image" src="https://github.com/user-attachments/assets/f0ffc3e4-90b2-4b36-9f06-c82ba300bb80" />

*** After ***
<img width="178" height="99" alt="image" src="https://github.com/user-attachments/assets/7c0f46b0-d4da-4978-93b1-7ccf7e39f01b" />

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2718214
