### PR TITLE
Fix formatting of multiline `@if` statements

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPass.CSharpDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPass.CSharpDocumentGenerator.cs
@@ -946,6 +946,10 @@ internal partial class CSharpFormattingPass
             public override LineInfo VisitCSharpCodeBlock(CSharpCodeBlockSyntax node)
             {
                 // Matches things like @if, so skip the first character, but output as C# otherwise
+                // Make sure to output leading whitespace, if any, as Roslyn can move multi-line constructs relative to the first
+                // line, and if we don't maintain input whitespace, we're effectively de-denting, which means when it re-indents,
+                // Roslyn will indent other lines, causing them to migrate right over time.
+                _builder.Append(_sourceText.ToString(TextSpan.FromBounds(_currentLine.Start, _currentFirstNonWhitespacePosition)));
                 _builder.AppendLine(_sourceText.ToString(TextSpan.FromBounds(_currentToken.Position + 1, _currentLine.End)));
 
                 return CreateLineInfo(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/DocumentFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/DocumentFormattingTest.cs
@@ -19,6 +19,46 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentFormattingTestBase(testOutput)
 {
     [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/9658#issuecomment-3943605712")]
+    public async Task MultilineIfStatement()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                <div>
+                    @if (true ||
+                        true ||
+                        true ||
+                        true)
+                        {
+                            // Hi
+                        }
+                    </div>
+                """,
+            htmlFormatted: """
+                <div>
+                    @if (true ||
+                    true ||
+                    true ||
+                    true)
+                    {
+                    // Hi
+                    }
+                </div>
+                """,
+            expected: """
+                <div>
+                    @if (true ||
+                        true ||
+                        true ||
+                        true)
+                    {
+                        // Hi
+                    }
+                </div>
+                """);
+    }
+
+    [Fact]
     [WorkItem("https://developercommunity.visualstudio.com/t/Format-Document-in-a-blazor-documents-ad/11046727")]
     public async Task MultilineRawStringLiteral()
     {


### PR DESCRIPTION
Fixes this specific comment: https://github.com/dotnet/razor/issues/9658#issuecomment-3943605712