### PR TITLE
Fix integration tests

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/GoToImplementationTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/GoToImplementationTests.cs
@@ -31,14 +31,16 @@ public class GoToImplementationTests(ITestOutputHelper testOutputHelper) : Abstr
         await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.IndexRazorFile, ControlledHangMitigatingCancellationToken);
 
         // Change text to refer back to Program class
-        await TestServices.Editor.SetTextAsync(@"<SurveyPrompt Title=""@nameof(Program)", ControlledHangMitigatingCancellationToken);
-        await TestServices.Editor.PlaceCaretAsync("Program", charsOffset: -1, ControlledHangMitigatingCancellationToken);
+        var position = await TestServices.Editor.SetTextAsync("""
+            <SurveyPrompt Title="@nameof(BlazorProject.Data.Weather$$Forecast)" />
+            """, ControlledHangMitigatingCancellationToken);
+        await TestServices.Editor.PlaceCaretAsync(position, ControlledHangMitigatingCancellationToken);
 
         // Act
         await TestServices.Editor.InvokeGoToImplementationAsync(ControlledHangMitigatingCancellationToken);
 
         // Assert
-        await TestServices.Editor.WaitForActiveWindowAsync("Program.cs", ControlledHangMitigatingCancellationToken);
+        await TestServices.Editor.WaitForActiveWindowAsync("WeatherForecast.cs", ControlledHangMitigatingCancellationToken);
     }
 
     [IdeFact]


### PR DESCRIPTION
Roslyn changed and now reports source generated files in GTI, so our test failed because we were expecting one result, and got two. The fix is just to change to use a class that doesn't have a source generated partial to it.