### PR TITLE
Fix fault event names

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Snippets/SnippetService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Snippets/SnippetService.cs
@@ -15,6 +15,7 @@ using Microsoft.VisualStudio.ProjectSystem.VS;
 using Microsoft.VisualStudio.Razor.Extensions;
 using Microsoft.VisualStudio.Razor.Settings;
 using Microsoft.VisualStudio.Razor.Snippets;
+using Microsoft.VisualStudio.Razor.Telemetry;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Threading;
@@ -60,14 +61,14 @@ internal class SnippetService
         _serviceProvider = serviceProvider;
         _snippetCache = snippetCache;
         _advancedSettingsStorage = advancedSettingsStorage;
-        _joinableTaskFactory.RunAsync(InitializeAsync).FileAndForget(faultEventName: "dotnet/razor/SnippetService_Initialize");
+        _joinableTaskFactory.RunAsync(InitializeAsync).FileAndForget(TelemetryReporter.GetEventName("SnippetService_Initialize"));
     }
 
     private async Task InitializeAsync()
     {
         await _advancedSettingsStorage.OnChangedAsync(_ =>
         {
-            PopulateAsync().FileAndForget(faultEventName: "dotnet/razor/SnippetService_Populate");
+            PopulateAsync().FileAndForget(TelemetryReporter.GetEventName("SnippetService_Populate"));
         }).ConfigureAwait(false);
 
         await _joinableTaskFactory.SwitchToMainThreadAsync();


### PR DESCRIPTION
Drew brought this to my attention. These strings are supposed to be fault names, and we were hitting a first chance exception, if loading snippets failed, because the fault event name wasn't valid.

<img width="1634" height="626" alt="image" src="https://github.com/user-attachments/assets/54e74e25-2224-4c64-9123-40b2a4f7508b" />

```
Microsoft.VisualStudio.Telemetry.dll!Microsoft.VisualStudio.Telemetry.Common.Utilities.Validation.EventValidationEnforcer.ThrowIfEventIsInvalid(string eventName, Microsoft.VisualStudio.Telemetry.Common.Utilities.Validation.EventValidationResult validationResult)  Unknown
  Microsoft.VisualStudio.Telemetry.dll!Microsoft.VisualStudio.Telemetry.Common.Utilities.Validation.EventValidationEnforcer.ValidateEvent(string eventName)  Unknown
  Microsoft.VisualStudio.Telemetry.dll!Microsoft.VisualStudio.Telemetry.DataModelEventNameHelper.SetProductFeatureEntityName(string eventName, Microsoft.VisualStudio.Telemetry.TelemetryPropertyBags.PrefixedConcurrent<object> reservedProperties)  Unknown
  Microsoft.VisualStudio.Telemetry.dll!Microsoft.VisualStudio.Telemetry.FaultEvent.FaultEvent(string eventName, string description, Microsoft.VisualStudio.Telemetry.FaultSeverity faultSeverity, System.Exception exceptionObject, System.Func<Microsoft.VisualStudio.Telemetry.IFaultUtility, int> gatherEventDetails)  Unknown
  Microsoft.VisualStudio.Shell.15.0.dll!Microsoft.VisualStudio.Shell.VsTaskLibraryHelper.FileAndForget.AnonymousMethod__36_0(System.Threading.Tasks.Task t, object state)  Unknown
  mscorlib.dll!System.Threading.Tasks.ContinuationResultTaskFromTask<System.Threading.Tasks.Task<object>>.InnerInvoke()  Unknown
  mscorlib.dll!System.Threading.Tasks.Task.Execute()  Unknown
  mscorlib.dll!System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, object state, bool preserveSyncCtx)  Unknown
  mscorlib.dll!System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, object state, bool preserveSyncCtx)  Unknown
  mscorlib.dll!System.Threading.Tasks.Task.ExecuteWithThreadLocal(ref System.Threading.Tasks.Task currentTaskSlot)  Unknown
  mscorlib.dll!System.Threading.Tasks.Task.ExecuteEntry(bool bPreventDoubleExecution)  Unknown
  mscorlib.dll!System.Threading.Tasks.ThreadPoolTaskScheduler.TryExecuteTaskInline(System.Threading.Tasks.Task task, bool taskWasPreviouslyQueued)  Unknown
  mscorlib.dll!System.Threading.Tasks.TaskScheduler.TryRunInline(System.Threading.Tasks.Task task, bool taskWasPreviouslyQueued)  Unknown
  mscorlib.dll!System.Threading.Tasks.TaskContinuation.InlineIfPossibleOrElseQueue(System.Threading.Tasks.Task task, bool needsProtection)  Unknown
  mscorlib.dll!System.Threading.Tasks.Task.ContinueWithCore(System.Threading.Tasks.Task continuationTask, System.Threading.Tasks.TaskScheduler scheduler, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions options)  Unknown
  mscorlib.dll!System.Threading.Tasks.Task.ContinueWith<System.Threading.Tasks.Task<object>>(System.Func<System.Threading.Tasks.Task, object, System.Threading.Tasks.Task<object>> continuationFunction, object state, System.Threading.Tasks.TaskScheduler scheduler, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, ref System.Threading.StackCrawlMark stackMark)  Unknown
  mscorlib.dll!System.Threading.Tasks.Task.ContinueWith<System.Threading.Tasks.Task<object>>(System.Func<System.Threading.Tasks.Task, object, System.Threading.Tasks.Task<object>> continuationFunction, object state, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler)  Unknown
  Microsoft.VisualStudio.Shell.15.0.dll!Microsoft.VisualStudio.Shell.VsTaskLibraryHelper.FileAndForget(System.Threading.Tasks.Task task, string faultEventName, string faultDescription, System.Func<System.Exception, bool> fileOnlyIf, System.Collections.Generic.IReadOnlyDictionary<string, object> properties)  Unknown
>  Microsoft.VisualStudio.RazorExtension.dll!Microsoft.VisualStudio.RazorExtension.Snippets.SnippetService.InitializeAsync.AnonymousMethod__9_0(Microsoft.CodeAnalysis.Razor.Settings.ClientAdvancedSettings _) Line 70
```