### PR TITLE
Add SuppressMvcRazorImports configuration option

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/MvcImportProjectFeatureTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/MvcImportProjectFeatureTest.cs
@@ -16,11 +16,49 @@ public class MvcImportProjectFeatureTest
         using var imports = new PooledArrayBuilder<RazorProjectItem>();
 
         // Act
-        MvcImportProjectFeature.AddDefaultDirectivesImport(ref imports.AsRef());
+        MvcImportProjectFeature.AddDefaultDirectivesImport(suppressMvcRazorImports: false, ref imports.AsRef());
 
         // Assert
         var import = Assert.Single(imports.ToImmutable());
         Assert.Null(import.FilePath);
+    }
+
+    [Fact]
+    public void AddDefaultDirectivesImport_DefaultImportContainsMvcDirectives()
+    {
+        // Arrange
+        using var imports = new PooledArrayBuilder<RazorProjectItem>();
+
+        // Act
+        MvcImportProjectFeature.AddDefaultDirectivesImport(suppressMvcRazorImports: false, ref imports.AsRef());
+
+        // Assert
+        var import = Assert.Single(imports.ToImmutable());
+        var content = ReadContent(import);
+        Assert.Contains("@inject", content);
+        Assert.Contains("@addTagHelper", content);
+        Assert.Contains("@using global::Microsoft.AspNetCore.Mvc", content);
+    }
+
+    [Fact]
+    public void AddDefaultDirectivesImport_SuppressMvcRazorImports_OmitsMvcDirectives()
+    {
+        // Arrange
+        using var imports = new PooledArrayBuilder<RazorProjectItem>();
+
+        // Act
+        MvcImportProjectFeature.AddDefaultDirectivesImport(suppressMvcRazorImports: true, ref imports.AsRef());
+
+        // Assert
+        var import = Assert.Single(imports.ToImmutable());
+        var content = ReadContent(import);
+        Assert.DoesNotContain("@inject", content);
+        Assert.DoesNotContain("@addTagHelper", content);
+        Assert.DoesNotContain("Microsoft.AspNetCore.Mvc", content);
+        Assert.Contains("@using global::System", content);
+        Assert.Contains("@using global::System.Collections.Generic", content);
+        Assert.Contains("@using global::System.Linq", content);
+        Assert.Contains("@using global::System.Threading.Tasks", content);
     }
 
     [Fact]
@@ -70,5 +108,12 @@ public class MvcImportProjectFeatureTest
             import => Assert.Equal("/_ViewImports.cshtml", import.FilePath),
             import => Assert.Equal("/Pages/_ViewImports.cshtml", import.FilePath),
             import => Assert.Equal("/Pages/Contact/_ViewImports.cshtml", import.FilePath));
+    }
+
+    private static string ReadContent(RazorProjectItem item)
+    {
+        using var stream = item.Read();
+        using var reader = new System.IO.StreamReader(stream);
+        return reader.ReadToEnd();
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorConfiguration.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorConfiguration.cs
@@ -16,6 +16,7 @@ public sealed record class RazorConfiguration(
     bool UseConsolidatedMvcViews = true,
     bool SuppressAddComponentParameter = false,
     bool UseRoslynTokenizer = false,
+    bool SuppressMvcRazorImports = false,
     ImmutableArray<string> PreprocessorSymbols = default)
 {
     public ImmutableArray<string> PreprocessorSymbols
@@ -32,6 +33,7 @@ public sealed record class RazorConfiguration(
         UseConsolidatedMvcViews: true,
         SuppressAddComponentParameter: false,
         UseRoslynTokenizer: false,
+        SuppressMvcRazorImports: false,
         PreprocessorSymbols: []);
 
     public bool Equals(RazorConfiguration? other)
@@ -42,6 +44,7 @@ public sealed record class RazorConfiguration(
            SuppressAddComponentParameter == other.SuppressAddComponentParameter &&
            UseConsolidatedMvcViews == other.UseConsolidatedMvcViews &&
            UseRoslynTokenizer == other.UseRoslynTokenizer &&
+           SuppressMvcRazorImports == other.SuppressMvcRazorImports &&
            PreprocessorSymbols.SequenceEqual(other.PreprocessorSymbols) &&
            Extensions.SequenceEqual(other.Extensions);
 
@@ -55,6 +58,7 @@ public sealed record class RazorConfiguration(
         hash.Add(SuppressAddComponentParameter);
         hash.Add(UseConsolidatedMvcViews);
         hash.Add(UseRoslynTokenizer);
+        hash.Add(SuppressMvcRazorImports);
         hash.Add(PreprocessorSymbols);
         return hash;
     }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Mvc/MvcImportProjectFeature.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Mvc/MvcImportProjectFeature.cs
@@ -29,6 +29,13 @@ internal sealed class MvcImportProjectFeature : RazorProjectEngineFeatureBase, I
 @addTagHelper global::Microsoft.AspNetCore.Mvc.Razor.TagHelpers.BodyTagHelper, Microsoft.AspNetCore.Mvc.Razor
 ");
 
+    private static readonly DefaultImportProjectItem s_defaultImportNoMvc = new($"Default non-MVC imports ({ImportsFileName})", @"
+@using global::System
+@using global::System.Collections.Generic
+@using global::System.Linq
+@using global::System.Threading.Tasks
+");
+
     public void CollectImports(RazorProjectItem projectItem, ref PooledArrayBuilder<RazorProjectItem> imports)
     {
         ArgHelper.ThrowIfNull(projectItem);
@@ -39,16 +46,16 @@ internal sealed class MvcImportProjectFeature : RazorProjectEngineFeatureBase, I
             return;
         }
 
-        AddDefaultDirectivesImport(ref imports);
+        AddDefaultDirectivesImport(ProjectEngine.Configuration.SuppressMvcRazorImports, ref imports);
 
         // We add hierarchical imports second so any default directive imports can be overridden.
         AddHierarchicalImports(projectItem, ref imports);
     }
 
     // Internal for testing
-    internal static void AddDefaultDirectivesImport(ref PooledArrayBuilder<RazorProjectItem> imports)
+    internal static void AddDefaultDirectivesImport(bool suppressMvcRazorImports, ref PooledArrayBuilder<RazorProjectItem> imports)
     {
-        imports.Add(s_defaultImport);
+        imports.Add(suppressMvcRazorImports ? s_defaultImportNoMvc : s_defaultImport);
     }
 
     // Internal for testing

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.RazorProviders.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.RazorProviders.cs
@@ -33,6 +33,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             globalOptions.TryGetValue("build_property.RootNamespace", out var rootNamespace);
             globalOptions.TryGetValue("build_property.SupportLocalizedComponentNames", out var supportLocalizedComponentNames);
             globalOptions.TryGetValue("build_property.GenerateRazorMetadataSourceChecksumAttributes", out var generateMetadataSourceChecksumAttributes);
+            globalOptions.TryGetValue("build_property.SuppressMvcRazorImports", out var suppressMvcRazorImports);
 
             Diagnostic? diagnostic = null;
             if (!globalOptions.TryGetValue("build_property.RazorLangVersion", out var razorLanguageVersionString) ||
@@ -54,7 +55,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                 ? false
                 : CSharpCompilation.Create("components", references: minimalReferences).HasAddComponentParameter();
 
-            var razorConfiguration = new RazorConfiguration(razorLanguageVersion, configurationName ?? "default", Extensions: [], UseConsolidatedMvcViews: true, SuppressAddComponentParameter: !isComponentParameterSupported);
+            var razorConfiguration = new RazorConfiguration(razorLanguageVersion, configurationName ?? "default", Extensions: [], UseConsolidatedMvcViews: true, SuppressAddComponentParameter: !isComponentParameterSupported, SuppressMvcRazorImports: suppressMvcRazorImports == "true");
 
             // We use the new tokenizer only when requested for now.
             var useRoslynTokenizer = parseOptions.UseRoslynTokenizer();

--- a/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorTests.cs
+++ b/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorTests.cs
@@ -1345,6 +1345,51 @@ namespace AspNetCoreGeneratedDocument
 
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/razor/issues/8259")]
+        public async Task SourceGenerator_CshtmlFiles_SuppressMvcRazorImports()
+        {
+            // Arrange
+            var project = CreateTestProject(new()
+            {
+                ["Pages/Index.cshtml"] = "<h1>Hello world</h1>",
+            });
+            var compilation = await project.GetCompilationAsync();
+            var (driver, _, _) = await GetDriverWithAdditionalTextAndProviderAsync(project, options =>
+            {
+                options.TestGlobalOptions["build_property.SuppressMvcRazorImports"] = "true";
+            });
+
+            // Act
+            var result = RunGenerator(compilation!, ref driver);
+
+            // Assert
+            Assert.Empty(result.Diagnostics);
+            var generatedSource = Assert.Single(result.GeneratedSources);
+            var generatedCode = generatedSource.SourceText.ToString();
+
+            // Should NOT contain MVC-specific inject properties
+            Assert.DoesNotContain("RazorInjectAttribute", generatedCode);
+            Assert.DoesNotContain("IModelExpressionProvider", generatedCode);
+            Assert.DoesNotContain("IUrlHelper", generatedCode);
+            Assert.DoesNotContain("IViewComponentHelper", generatedCode);
+            Assert.DoesNotContain("IJsonHelper", generatedCode);
+            Assert.DoesNotContain("IHtmlHelper", generatedCode);
+
+            // Should NOT contain MVC-specific using directives
+            Assert.DoesNotContain("using global::Microsoft.AspNetCore.Mvc;", generatedCode);
+            Assert.DoesNotContain("using global::Microsoft.AspNetCore.Mvc.Rendering;", generatedCode);
+            Assert.DoesNotContain("using global::Microsoft.AspNetCore.Mvc.ViewFeatures;", generatedCode);
+
+            // Should still contain System using directives
+            Assert.Contains("using global::System;", generatedCode);
+            Assert.Contains("using global::System.Collections.Generic;", generatedCode);
+            Assert.Contains("using global::System.Linq;", generatedCode);
+            Assert.Contains("using global::System.Threading.Tasks;", generatedCode);
+
+            // Should still contain the page content
+            Assert.Contains("Hello world", generatedCode);
+        }
+
         [Fact, WorkItem("https://github.com/dotnet/razor/issues/7049")]
         public async Task SourceGenerator_CshtmlFiles_TagHelperInFunction()
         {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/MessagePack/Formatters/RazorConfigurationFormatter.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/MessagePack/Formatters/RazorConfigurationFormatter.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Razor.Serialization.MessagePack.Formatters;
 
 internal sealed class RazorConfigurationFormatter : ValueFormatter<RazorConfiguration>
 {
-    private const int SerializerPropertyCount = 7;
+    private const int SerializerPropertyCount = 8;
 
     public static readonly ValueFormatter<RazorConfiguration> Instance = new RazorConfigurationFormatter();
 
@@ -31,6 +31,7 @@ internal sealed class RazorConfigurationFormatter : ValueFormatter<RazorConfigur
         var suppressAddComponentParameter = reader.ReadBoolean();
         var useConsolidatedMvcViews = reader.ReadBoolean();
         var useRoslynTokenizer = reader.ReadBoolean();
+        var suppressMvcRazorImports = reader.ReadBoolean();
         var preprocessorSymbols = reader.Deserialize<ImmutableArray<string>>(options);
 
         count -= SerializerPropertyCount;
@@ -57,6 +58,7 @@ internal sealed class RazorConfigurationFormatter : ValueFormatter<RazorConfigur
             UseConsolidatedMvcViews: useConsolidatedMvcViews,
             SuppressAddComponentParameter: suppressAddComponentParameter,
             UseRoslynTokenizer: useRoslynTokenizer,
+            SuppressMvcRazorImports: suppressMvcRazorImports,
             PreprocessorSymbols: preprocessorSymbols);
     }
 
@@ -83,6 +85,7 @@ internal sealed class RazorConfigurationFormatter : ValueFormatter<RazorConfigur
         writer.Write(value.SuppressAddComponentParameter);
         writer.Write(value.UseConsolidatedMvcViews);
         writer.Write(value.UseRoslynTokenizer);
+        writer.Write(value.SuppressMvcRazorImports);
         writer.Serialize(value.PreprocessorSymbols, options);
 
         count -= SerializerPropertyCount;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Utilities/RazorProjectInfoFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Utilities/RazorProjectInfoFactory.cs
@@ -122,6 +122,8 @@ internal static class RazorProjectInfoFactory
 
         var suppressAddComponentParameter = compilation is not null && !compilation.HasAddComponentParameter();
 
+        globalOptions.TryGetValue("build_property.SuppressMvcRazorImports", out var suppressMvcRazorImportsValue);
+
         var csharpParseOptions = project.ParseOptions as CSharpParseOptions ?? CSharpParseOptions.Default;
 
         var razorConfiguration = new RazorConfiguration(
@@ -132,6 +134,7 @@ internal static class RazorProjectInfoFactory
             UseConsolidatedMvcViews: true,
             suppressAddComponentParameter,
             UseRoslynTokenizer: csharpParseOptions.UseRoslynTokenizer(),
+            SuppressMvcRazorImports: suppressMvcRazorImportsValue == "true",
             PreprocessorSymbols: csharpParseOptions.PreprocessorSymbolNames.ToImmutableArray());
 
         defaultNamespace = rootNamespace ?? "ASP"; // TODO: Source generator does this. Do we want it?

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/RazorConfigurationSerializationTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/RazorConfigurationSerializationTest.cs
@@ -22,6 +22,7 @@ public class RazorConfigurationSerializationTest(ITestOutputHelper testOutput) :
             UseConsolidatedMvcViews: false,
             SuppressAddComponentParameter: true,
             UseRoslynTokenizer: true,
+            SuppressMvcRazorImports: true,
             PreprocessorSymbols: ["DEBUG", "TRACE", "DAVID"]);
 
         // Act
@@ -42,6 +43,7 @@ public class RazorConfigurationSerializationTest(ITestOutputHelper testOutput) :
         Assert.Equal(configuration.UseConsolidatedMvcViews, obj.UseConsolidatedMvcViews);
         Assert.Equal(configuration.SuppressAddComponentParameter, obj.SuppressAddComponentParameter);
         Assert.Equal(configuration.UseRoslynTokenizer, obj.UseRoslynTokenizer);
+        Assert.Equal(configuration.SuppressMvcRazorImports, obj.SuppressMvcRazorImports);
         Assert.Collection(obj.PreprocessorSymbols,
             s => Assert.Equal("DEBUG", s),
             s => Assert.Equal("TRACE", s),

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders.cs
@@ -28,6 +28,7 @@ internal static partial class ObjectReaders
         var suppressAddComponentParameter = reader.ReadBooleanOrFalse(nameof(RazorConfiguration.SuppressAddComponentParameter));
         var useConsolidatedMvcViews = reader.ReadBooleanOrTrue(nameof(RazorConfiguration.UseConsolidatedMvcViews));
         var useRoslynTokenizer = reader.ReadBooleanOrFalse(nameof(RazorConfiguration.UseRoslynTokenizer));
+        var suppressMvcRazorImports = reader.ReadBooleanOrFalse(nameof(RazorConfiguration.SuppressMvcRazorImports));
         var preprocessorSymbols = reader.ReadImmutableArrayOrEmpty(nameof(RazorConfiguration.PreprocessorSymbols), r => r.ReadNonNullString());
         var extensions = reader.ReadImmutableArrayOrEmpty(nameof(RazorConfiguration.Extensions),
             static r =>
@@ -48,6 +49,7 @@ internal static partial class ObjectReaders
             UseConsolidatedMvcViews: useConsolidatedMvcViews,
             SuppressAddComponentParameter: suppressAddComponentParameter,
             UseRoslynTokenizer: useRoslynTokenizer,
+            SuppressMvcRazorImports: suppressMvcRazorImports,
             PreprocessorSymbols: preprocessorSymbols);
     }
 

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters.cs
@@ -35,6 +35,7 @@ internal static partial class ObjectWriters
         writer.WriteIfNotFalse(nameof(value.SuppressAddComponentParameter), value.SuppressAddComponentParameter);
         writer.WriteIfNotTrue(nameof(value.UseConsolidatedMvcViews), value.UseConsolidatedMvcViews);
         writer.WriteIfNotFalse(nameof(value.UseRoslynTokenizer), value.UseRoslynTokenizer);
+        writer.WriteIfNotFalse(nameof(value.SuppressMvcRazorImports), value.SuppressMvcRazorImports);
         writer.WriteArrayIfNotDefaultOrEmpty(nameof(value.PreprocessorSymbols), value.PreprocessorSymbols, static (w, v) => w.Write(v));
 
         writer.WriteArrayIfNotDefaultOrEmpty(nameof(value.Extensions), value.Extensions, static (w, v) => w.Write(v.ExtensionName));


### PR DESCRIPTION
## Summary

Adds a new `SuppressMvcRazorImports` MSBuild property that, when set to `true`, suppresses all MVC-specific default directives from the synthetic import in `MvcImportProjectFeature`.

Fixes dotnet/roslyn#85437

## Details

When enabled, the default import retains only the System `@using` directives:
```
@using global::System
@using global::System.Collections.Generic
@using global::System.Linq
@using global::System.Threading.Tasks
```

The following 11 MVC-specific directives are suppressed:
- 3 `@using Microsoft.AspNetCore.Mvc.*` directives
- 5 `@inject` directives (IHtmlHelper, IJsonHelper, IViewComponentHelper, IUrlHelper, IModelExpressionProvider)
- 3 `@addTagHelper` directives (UrlResolutionTagHelper, HeadTagHelper, BodyTagHelper)

Explicit `@inject`, `@using`, and `@addTagHelper` directives in `.cshtml` or `_ViewImports.cshtml` files continue to work regardless of this setting.

### Usage

```xml
<PropertyGroup>
  <SuppressMvcRazorImports>true</SuppressMvcRazorImports>
</PropertyGroup>
```

### Follow-up needed

A change in `dotnet/sdk` is needed to add `<CompilerVisibleProperty Include="SuppressMvcRazorImports" />` so this property flows from MSBuild to the source generator. Until then, users can set it via `.globalconfig`:

```
build_property.SuppressMvcRazorImports = true
```

### Changes

| File | Change |
|---|---|
| `RazorConfiguration.cs` | New `SuppressMvcRazorImports` bool parameter + equality/hash |
| `MvcImportProjectFeature.cs` | Conditional default import (full MVC vs System-only) |
| `RazorSourceGenerator.RazorProviders.cs` | Reads `build_property.SuppressMvcRazorImports` |
| `RazorProjectInfoFactory.cs` | Same for language server path |
| `RazorConfigurationFormatter.cs` | MessagePack serialization |
| `ObjectWriters.cs` / `ObjectReaders.cs` | JSON serialization |
| `MvcImportProjectFeatureTest.cs` | 2 new unit tests |
| `RazorSourceGeneratorTests.cs` | E2E source generator test |
| `RazorConfigurationSerializationTest.cs` | Round-trip test updated |