### PR TITLE
Hopefully bring stability to completion integration tests

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/CompletionIntegrationTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/CompletionIntegrationTests.cs
@@ -643,11 +643,16 @@ public class CompletionIntegrationTests(ITestOutputHelper testOutputHelper) : Ab
     {
         var session = await TestServices.Editor.WaitForCompletionSessionAsync(HangMitigatingCancellationToken);
 
-        Assert.NotNull(session);
+        if (session is null)
+        {
+            Assert.Fail(await TestServices.Editor.GetCompletionSessionDebugInfoAsync(expectedSelectedItemLabel: null, HangMitigatingCancellationToken));
+        }
+
+        var completionSession = session ?? throw new InvalidOperationException("Completion session should have been available.");
         if (commitChar.HasValue)
         {
             // Commit using the specified commit character
-            session.Commit(commitChar.Value, HangMitigatingCancellationToken);
+            completionSession.Commit(commitChar.Value, HangMitigatingCancellationToken);
 
             // session.Commit call above commits as if the commit character was typed,
             // but doesn't actually insert the character into the buffer.
@@ -656,7 +661,7 @@ public class CompletionIntegrationTests(ITestOutputHelper testOutputHelper) : Ab
         }
         else
         {
-            Assert.True(session.CommitIfUnique(HangMitigatingCancellationToken));
+            Assert.True(completionSession.CommitIfUnique(HangMitigatingCancellationToken));
         }
 
         var textView = await TestServices.Editor.GetActiveTextViewAsync(HangMitigatingCancellationToken);
@@ -672,11 +677,16 @@ public class CompletionIntegrationTests(ITestOutputHelper testOutputHelper) : Ab
         // Actually open completion UI and wait for it have selected item we are interested in
         var session = await TestServices.Editor.OpenCompletionSessionAndWaitForItemAsync(TimeSpan.FromSeconds(10), expectedSelectedItemLabel, HangMitigatingCancellationToken);
 
-        Assert.NotNull(session);
+        if (session is null)
+        {
+            Assert.Fail(await TestServices.Editor.GetCompletionSessionDebugInfoAsync(expectedSelectedItemLabel, HangMitigatingCancellationToken));
+        }
+
+        var completionSession = session ?? throw new InvalidOperationException("Completion session should have been available.");
         if (commitChar is char commitCharValue)
         {
             // Commit using the specified commit character
-            session.Commit(commitCharValue, HangMitigatingCancellationToken);
+            completionSession.Commit(commitCharValue, HangMitigatingCancellationToken);
 
             // session.Commit call above commits as if the commit character was typed,
             // but doesn't actually insert the character into the buffer.
@@ -685,7 +695,7 @@ public class CompletionIntegrationTests(ITestOutputHelper testOutputHelper) : Ab
         }
         else
         {
-            Assert.True(session.CommitIfUnique(HangMitigatingCancellationToken));
+            Assert.True(completionSession.CommitIfUnique(HangMitigatingCancellationToken));
         }
 
         var textView = await TestServices.Editor.GetActiveTextViewAsync(HangMitigatingCancellationToken);

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/EditorInProcess_Completion.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/EditorInProcess_Completion.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Diagnostics;
+using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
@@ -144,5 +146,46 @@ internal partial class EditorInProcess
                 OpenOrUpdate(currentSession);
             }
         }
+    }
+
+    public async Task<string> GetCompletionSessionDebugInfoAsync(string? expectedSelectedItemLabel, CancellationToken cancellationToken)
+    {
+        await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+        var textView = await GetActiveTextViewAsync(cancellationToken);
+        var asyncCompletion = await TestServices.Shell.GetComponentModelServiceAsync<IAsyncCompletionBroker>(cancellationToken);
+        var session = asyncCompletion.GetSession(textView);
+        var caret = textView.Caret.Position.BufferPosition;
+        var currentLine = textView.TextSnapshot.GetLineFromPosition(caret).GetText();
+
+        var builder = new StringBuilder();
+        builder.AppendLine("Timed out waiting for completion session/item.");
+        builder.AppendLine($"Expected selected item: {expectedSelectedItemLabel ?? "<none>"}");
+        builder.AppendLine($"Caret position: {caret.Position}");
+        builder.AppendLine($"Current line text: {currentLine}");
+
+        if (session is null)
+        {
+            builder.AppendLine("No completion session was active.");
+            return builder.ToString();
+        }
+
+        builder.AppendLine($"Session dismissed: {session.IsDismissed}");
+
+        if (!session.IsDismissed)
+        {
+            var computedItems = session.GetComputedItems(cancellationToken);
+            builder.AppendLine($"Selected item: {computedItems.SelectedItem?.DisplayText ?? "<null>"}");
+
+            if (expectedSelectedItemLabel is not null)
+            {
+                builder.AppendLine($"Expected item present: {computedItems.Items.Any(i => i.DisplayText == expectedSelectedItemLabel)}");
+            }
+
+            var itemList = string.Join(", ", computedItems.Items.Take(10).Select(i => i.DisplayText));
+            builder.AppendLine($"First items: {itemList}");
+        }
+
+        return builder.ToString();
     }
 }


### PR DESCRIPTION
These changes got two green runs, which is not enough to give me confidence, but enough to open a PR. There is a bunch of debug logging that we'll get on failure too, so hopefully a positive step regardless.