### PR TITLE
Improve SourceGeneratorTests test speed.

### DIFF
--- a/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorTestsBase.cs
+++ b/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorTestsBase.cs
@@ -296,15 +296,46 @@ public abstract class RazorSourceGeneratorTestsBase
         }
     }
 
-    private static Project CreateBaseProject(CSharpParseOptions? cSharpParseOptions)
+    // Cache the entire base project (workspace, compilation options, parse options, and all
+    // metadata references) so it is built once and shared across all tests. Project is
+    // immutable, so every AddDocument/AddAdditionalDocument call returns a new fork.
+    private static readonly Lazy<Project> s_cachedBaseProject = new(static () =>
     {
+        var references = new Dictionary<string, MetadataReference>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var defaultCompileLibrary in DependencyContext.Load(typeof(RazorSourceGeneratorTestsBase).Assembly)!.CompileLibraries)
+        {
+            foreach (var resolveReferencePath in defaultCompileLibrary.ResolveReferencePaths(new AppLocalResolver(AppContext.BaseDirectory)))
+            {
+                if (resolveReferencePath.Contains("Shim."))
+                {
+                    continue;
+                }
+
+                var name = Path.GetFileNameWithoutExtension(resolveReferencePath);
+                references.TryAdd(name, MetadataReference.CreateFromFile(resolveReferencePath));
+            }
+        }
+
+        // The deps file in the project is incorrect and does not contain "compile" nodes for some references.
+        // However these binaries are always present in the bin output. As a "temporary" workaround, we'll add
+        // every dll file that's present in the test's build output as a metadatareference.
+        foreach (var assembly in Directory.EnumerateFiles(AppContext.BaseDirectory, "*.dll"))
+        {
+            if (!assembly.Contains("Shim."))
+            {
+                var name = Path.GetFileNameWithoutExtension(assembly);
+                references.TryAdd(name, MetadataReference.CreateFromFile(assembly));
+            }
+        }
+
         var projectId = ProjectId.CreateNewId(debugName: "TestProject");
 
         var solution = new AdhocWorkspace()
            .CurrentSolution
            .AddProject(projectId, "TestProject", "TestProject", LanguageNames.CSharp);
 
-        var project = solution.Projects.Single()
+        return solution.Projects.Single()
             .WithCompilationOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary,
                 nullableContextOptions: NullableContextOptions.Enable,
                 specificDiagnosticOptions: new KeyValuePair<string, ReportDiagnostic>[]
@@ -314,42 +345,21 @@ public abstract class RazorSourceGeneratorTestsBase
                     new("CS1701", ReportDiagnostic.Suppress),
                     // Ignore warnings about unused usings, we don't attempt to trim them
                     new("CS8019", ReportDiagnostic.Suppress),
-                }));
+                }))
+            .WithParseOptions(CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview))
+            .AddMetadataReferences(references.Values);
+    });
 
-        project = project.WithParseOptions(cSharpParseOptions ?? ((CSharpParseOptions)project.ParseOptions!).WithLanguageVersion(LanguageVersion.Preview));
+    private static Project CreateBaseProject(CSharpParseOptions? cSharpParseOptions)
+    {
+        var project = s_cachedBaseProject.Value;
 
-        foreach (var defaultCompileLibrary in DependencyContext.Load(typeof(RazorSourceGeneratorTests).Assembly)!.CompileLibraries)
+        if (cSharpParseOptions is not null)
         {
-            foreach (var resolveReferencePath in defaultCompileLibrary.ResolveReferencePaths(new AppLocalResolver(AppContext.BaseDirectory)))
-            {
-                if (excludeReference(resolveReferencePath))
-                {
-                    continue;
-                }
-
-                project = project.AddMetadataReference(MetadataReference.CreateFromFile(resolveReferencePath));
-            }
-        }
-
-        // The deps file in the project is incorrect and does not contain "compile" nodes for some references.
-        // However these binaries are always present in the bin output. As a "temporary" workaround, we'll add
-        // every dll file that's present in the test's build output as a metadatareference.
-        foreach (var assembly in Directory.EnumerateFiles(AppContext.BaseDirectory, "*.dll"))
-        {
-            if (!excludeReference(assembly) &&
-                !project.MetadataReferences.Any(c => string.Equals(Path.GetFileNameWithoutExtension(c.Display), Path.GetFileNameWithoutExtension(assembly), StringComparison.OrdinalIgnoreCase)))
-            {
-                project = project.AddMetadataReference(MetadataReference.CreateFromFile(assembly));
-            }
+            project = project.WithParseOptions(cSharpParseOptions);
         }
 
         return project;
-
-        // In this project, we don't need shims, we reference the full ASP.NET Core DLLs.
-        static bool excludeReference(string path)
-        {
-            return path.Contains("Shim.");
-        }
     }
 
     protected sealed class TestAnalyzerConfigOptionsProvider : AnalyzerConfigOptionsProvider


### PR DESCRIPTION
## Summary

Cache the fully-constructed base `Project` in source generator tests so it is built once and shared across all ~85 test invocations, reducing test execution time by ~60%.

## Problem

`CreateBaseProject()` was called per-test, each time independently:
- Loading `DependencyContext` via reflection
- Scanning 200+ DLLs via `Directory.EnumerateFiles`
- Creating `MetadataReference.CreateFromFile()` for each DLL
- Performing O(n²) dedup via `.Any()` on all existing references
- Adding references one-at-a-time, creating new immutable `Solution` snapshots per add

The resulting reference set was identical every time.

## Fix

- Cache the entire base `Project` (workspace, compilation options, parse options, and all metadata references) in a `static Lazy<Project>`. Since `Project` is immutable, every `AddDocument`/`AddAdditionalDocument` call in individual tests returns a new fork without affecting the shared instance.
- The 2 tests that need custom `CSharpParseOptions` fork via `WithParseOptions()`.
- Replace the O(n²) dedup loop (`.Any()` per DLL) with `Dictionary.TryAdd` for O(1) lookups during the one-time initialization.

## Results

| Metric | Before | After |
|--------|--------|-------|
| Total time (incl. build) | ~51s | ~20s |
