### PR TITLE
Fix NRE when remote call fails

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostDocumentFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostDocumentFormattingEndpoint.cs
@@ -94,14 +94,14 @@ internal sealed class CohostDocumentFormattingEndpoint(
             (service, solutionInfo, cancellationToken) => service.GetDocumentFormattingEditsAsync(solutionInfo, razorDocument.Id, htmlChanges, options, cancellationToken),
             cancellationToken).ConfigureAwait(false);
 
-        if (remoteResult.Length > 0)
+        if (remoteResult.IsDefaultOrEmpty)
         {
-            _logger.LogDebug($"Got a total of {remoteResult.Length} ranges back from OOP");
-
-            return [.. remoteResult.Select(sourceText.GetTextEdit)];
+            return null;
         }
 
-        return null;
+        _logger.LogDebug($"Got a total of {remoteResult.Length} ranges back from OOP");
+
+        return [.. remoteResult.Select(sourceText.GetTextEdit)];
     }
 
     private async Task<TextEdit[]?> TryGetHtmlFormattingEditsAsync(DocumentFormattingParams request, TextDocument razorDocument, CancellationToken cancellationToken)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostOnTypeFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostOnTypeFormattingEndpoint.cs
@@ -121,14 +121,14 @@ internal sealed class CohostOnTypeFormattingEndpoint(
             (service, solutionInfo, cancellationToken) => service.GetOnTypeFormattingEditsAsync(solutionInfo, razorDocument.Id, htmlChanges, request.Position.ToLinePosition(), request.Character, options, cancellationToken),
             cancellationToken).ConfigureAwait(false);
 
-        if (remoteResult.Length > 0)
+        if (remoteResult.IsDefaultOrEmpty)
         {
-            _logger.LogDebug($"Got a total of {remoteResult.Length} ranges back from OOP");
-
-            return [.. remoteResult.Select(sourceText.GetTextEdit)];
+            return null;
         }
 
-        return null;
+        _logger.LogDebug($"Got a total of {remoteResult.Length} ranges back from OOP");
+
+        return [.. remoteResult.Select(sourceText.GetTextEdit)];
     }
 
     private async Task<TextEdit[]?> TryGetHtmlFormattingEditsAsync(DocumentOnTypeFormattingParams request, TextDocument razorDocument, CancellationToken cancellationToken)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostRangeFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostRangeFormattingEndpoint.cs
@@ -99,14 +99,14 @@ internal sealed class CohostRangeFormattingEndpoint(
             (service, solutionInfo, cancellationToken) => service.GetRangeFormattingEditsAsync(solutionInfo, razorDocument.Id, htmlChanges, request.Range.ToLinePositionSpan(), options, cancellationToken),
             cancellationToken).ConfigureAwait(false);
 
-        if (remoteResult.Length > 0)
+        if (remoteResult.IsDefaultOrEmpty)
         {
-            _logger.LogDebug($"Got a total of {remoteResult.Length} ranges back from OOP");
-
-            return [.. remoteResult.Select(sourceText.GetTextEdit)];
+            return null;
         }
 
-        return null;
+        _logger.LogDebug($"Got a total of {remoteResult.Length} ranges back from OOP");
+
+        return [.. remoteResult.Select(sourceText.GetTextEdit)];
     }
 
     private async Task<TextEdit[]?> TryGetHtmlFormattingEditsAsync(DocumentRangeFormattingParams request, TextDocument razorDocument, CancellationToken cancellationToken)


### PR DESCRIPTION
Discovered this occuring in the logs when investigating https://developercommunity.visualstudio.com/t/StreamJsonRpcRemoteSerializationExcepti/11060782 which I believe is happening due to the arithmetic overflow.
