### PR TITLE
Clean up CollectionExpression and Select combined usage

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/FoldingRange/CohostFoldingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/FoldingRange/CohostFoldingRangeEndpoint.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -83,7 +82,7 @@ internal sealed class CohostFoldingRangeEndpoint(
         {
             _logger.LogDebug($"Got a total of {allRanges.Length} ranges back from OOP");
 
-            return [.. allRanges.Select(RemoteFoldingRange.ToLspFoldingRange)];
+            return allRanges.SelectAsPlainArray(RemoteFoldingRange.ToLspFoldingRange);
         }
 
         return null;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostDocumentFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostDocumentFormattingEndpoint.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -101,7 +100,7 @@ internal sealed class CohostDocumentFormattingEndpoint(
 
         _logger.LogDebug($"Got a total of {remoteResult.Length} ranges back from OOP");
 
-        return [.. remoteResult.Select(sourceText.GetTextEdit)];
+        return remoteResult.SelectAsPlainArray(sourceText.GetTextEdit);
     }
 
     private async Task<TextEdit[]?> TryGetHtmlFormattingEditsAsync(DocumentFormattingParams request, TextDocument razorDocument, CancellationToken cancellationToken)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostOnTypeFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostOnTypeFormattingEndpoint.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
@@ -128,7 +127,7 @@ internal sealed class CohostOnTypeFormattingEndpoint(
 
         _logger.LogDebug($"Got a total of {remoteResult.Length} ranges back from OOP");
 
-        return [.. remoteResult.Select(sourceText.GetTextEdit)];
+        return remoteResult.SelectAsPlainArray(sourceText.GetTextEdit);
     }
 
     private async Task<TextEdit[]?> TryGetHtmlFormattingEditsAsync(DocumentOnTypeFormattingParams request, TextDocument razorDocument, CancellationToken cancellationToken)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostRangeFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostRangeFormattingEndpoint.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -106,7 +105,7 @@ internal sealed class CohostRangeFormattingEndpoint(
 
         _logger.LogDebug($"Got a total of {remoteResult.Length} ranges back from OOP");
 
-        return [.. remoteResult.Select(sourceText.GetTextEdit)];
+        return remoteResult.SelectAsPlainArray(sourceText.GetTextEdit);
     }
 
     private async Task<TextEdit[]?> TryGetHtmlFormattingEditsAsync(DocumentRangeFormattingParams request, TextDocument razorDocument, CancellationToken cancellationToken)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/AbstractDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/AbstractDocumentMappingService.cs
@@ -20,8 +20,9 @@ internal abstract class AbstractDocumentMappingService(ILogger logger) : IDocume
 {
     protected readonly ILogger Logger = logger;
 
-    public IEnumerable<TextChange> GetRazorDocumentEdits(RazorCSharpDocument csharpDocument, ImmutableArray<TextChange> csharpChanges)
+    public ImmutableArray<TextChange> GetRazorDocumentEdits(RazorCSharpDocument csharpDocument, ImmutableArray<TextChange> csharpChanges)
     {
+        using var result = new PooledArrayBuilder<TextChange>();
         var csharpSourceText = csharpDocument.Text;
         var lastNewLineAddedToLine = 0;
 
@@ -47,7 +48,7 @@ internal abstract class AbstractDocumentMappingService(ILogger logger) : IDocume
                 // between this edit and the previous one, because the normalization will have swallowed it. See
                 // below for a more info.
                 var newText = (lastNewLineAddedToLine == startLine ? " " : "") + change.NewText;
-                yield return new TextChange(TextSpan.FromBounds(hostStartIndex, hostEndIndex), newText);
+                result.Add(new TextChange(TextSpan.FromBounds(hostStartIndex, hostEndIndex), newText));
                 continue;
             }
 
@@ -90,7 +91,7 @@ internal abstract class AbstractDocumentMappingService(ILogger logger) : IDocume
 
                 if (mappedStart && mappedEnd)
                 {
-                    yield return new TextChange(TextSpan.FromBounds(hostStartIndex, hostEndIndex), change.NewText[lastNewLine..]);
+                    result.Add(new TextChange(TextSpan.FromBounds(hostStartIndex, hostEndIndex), change.NewText[lastNewLine..]));
                     continue;
                 }
             }
@@ -119,7 +120,7 @@ internal abstract class AbstractDocumentMappingService(ILogger logger) : IDocume
                     // If there's a newline in the new text, only take the part before it
                     var firstNewLine = change.NewText.AssumeNotNull().IndexOfAny(['\n', '\r']);
                     var newText = firstNewLine >= 0 ? change.NewText[..firstNewLine] : change.NewText;
-                    yield return new TextChange(TextSpan.FromBounds(hostStartIndex, hostEndIndex), newText);
+                    result.Add(new TextChange(TextSpan.FromBounds(hostStartIndex, hostEndIndex), newText));
                     continue;
                 }
             }
@@ -171,19 +172,21 @@ internal abstract class AbstractDocumentMappingService(ILogger logger) : IDocume
                         // If we already added a newline to this line, then we don't want to add another one, but
                         // we do need to add a space between this edit and the previous one, because the normalization
                         // will have swallowed it.
-                        yield return new TextChange(new TextSpan(hostEndIndex, 0), " " + change.NewText);
+                        result.Add(new TextChange(new TextSpan(hostEndIndex, 0), " " + change.NewText));
                     }
                     else
                     {
                         // Otherwise, add a newline and the real content, and remember where we added it
                         lastNewLineAddedToLine = startLine;
-                        yield return new TextChange(new TextSpan(hostEndIndex, 0), " " + Environment.NewLine + new string(' ', startChar) + change.NewText);
+                        result.Add(new TextChange(new TextSpan(hostEndIndex, 0), " " + Environment.NewLine + new string(' ', startChar) + change.NewText));
                     }
 
                     continue;
                 }
             }
         }
+
+        return result.ToImmutableAndClear();
     }
 
     public bool TryMapToRazorDocumentRange(RazorCSharpDocument csharpDocument, LinePositionSpan csharpRange, MappingBehavior mappingBehavior, out LinePositionSpan razorRange)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/AbstractEditMappingService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/AbstractEditMappingService.cs
@@ -3,8 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
@@ -88,15 +89,21 @@ internal abstract class AbstractEditMappingService(
             return;
         }
 
-        // entry.Edits is SumType<TextEdit, AnnotatedTextEdit> but AnnotatedTextEdit inherits from TextEdit, so we can just cast
-        var mappedEdits = await GetMappedTextEditsAsync(documentContext, [.. entry.Edits.Select(static e => (TextEdit)e)], cancellationToken).ConfigureAwait(false);
+        var edits = new TextEdit[entry.Edits.Length];
+        for (var i = 0; i < entry.Edits.Length; i++)
+        {
+            // entry.Edits is SumType<TextEdit, AnnotatedTextEdit> but AnnotatedTextEdit inherits from TextEdit, so we can just cast
+            edits[i] = (TextEdit)entry.Edits[i];
+        }
+
+        var mappedEdits = await GetMappedTextEditsAsync(documentContext, edits, cancellationToken).ConfigureAwait(false);
 
         // Update the entry in-place
         entry.TextDocument = new OptionalVersionedTextDocumentIdentifier()
         {
             DocumentUri = new(razorDocumentUri),
         };
-        entry.Edits = [.. mappedEdits.Select(static e => new SumType<TextEdit, AnnotatedTextEdit>(e))];
+        entry.Edits = mappedEdits.SelectAsPlainArray(static e => new SumType<TextEdit, AnnotatedTextEdit>(e));
     }
 
     private async Task<Dictionary<string, TextEdit[]>> MapDocumentEditsAsync(IDocumentSnapshot contextDocumentSnapshot, Dictionary<string, TextEdit[]> changes, CancellationToken cancellationToken)
@@ -139,13 +146,13 @@ internal abstract class AbstractEditMappingService(
                 continue;
             }
 
-            mappedChanges[razorDocumentUri.AbsoluteUri] = mappedEdits;
+            mappedChanges[razorDocumentUri.AbsoluteUri] = ImmutableCollectionsMarshal.AsArray(mappedEdits)!;
         }
 
         return mappedChanges;
     }
 
-    private async Task<TextEdit[]> GetMappedTextEditsAsync(DocumentContext documentContext, TextEdit[] edits, CancellationToken cancellationToken)
+    private async Task<ImmutableArray<TextEdit>> GetMappedTextEditsAsync(DocumentContext documentContext, TextEdit[] edits, CancellationToken cancellationToken)
     {
         var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
 
@@ -158,7 +165,7 @@ internal abstract class AbstractEditMappingService(
         });
         var mappedEdits = await RazorEditHelper.MapCSharpEditsAsync(textChanges, documentContext.Snapshot, _documentMappingService, _telemetryReporter, cancellationToken).ConfigureAwait(false);
 
-        return [.. mappedEdits.Select(e => LspFactory.CreateTextEdit(razorSourceText.GetLinePositionSpan(e.Span.ToTextSpan()), e.NewText.AssumeNotNull()))];
+        return mappedEdits.SelectAsArray(e => LspFactory.CreateTextEdit(razorSourceText.GetLinePositionSpan(e.Span.ToTextSpan()), e.NewText.AssumeNotNull()));
     }
 
     protected abstract bool TryGetDocumentContext(IDocumentSnapshot contextDocumentSnapshot, Uri razorDocumentUri, VSProjectContext? projectContext, [NotNullWhen(true)] out DocumentContext? documentContext);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/IDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/IDocumentMappingService.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Text;
@@ -10,7 +9,7 @@ namespace Microsoft.CodeAnalysis.Razor.DocumentMapping;
 
 internal interface IDocumentMappingService
 {
-    IEnumerable<TextChange> GetRazorDocumentEdits(RazorCSharpDocument csharpDocument, ImmutableArray<TextChange> csharpChanges);
+    ImmutableArray<TextChange> GetRazorDocumentEdits(RazorCSharpDocument csharpDocument, ImmutableArray<TextChange> csharpChanges);
 
     bool TryMapToRazorDocumentRange(RazorCSharpDocument csharpDocument, LinePositionSpan csharpRange, MappingBehavior mappingBehavior, out LinePositionSpan razorRange);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/IDocumentMappingServiceExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/IDocumentMappingServiceExtensions.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Text;
@@ -20,7 +20,7 @@ internal static class IDocumentMappingServiceExtensions
 
         var changes = csharpEdits.SelectAsArray(csharpSourceText.GetTextChange);
         var mappedChanges = service.GetRazorDocumentEdits(csharpDocument, changes);
-        return [.. mappedChanges.Select(documentText.GetTextEdit)];
+        return mappedChanges.SelectAsPlainArray(documentText.GetTextEdit);
     }
 
     public static bool TryMapToRazorDocumentRange(this IDocumentMappingService service, RazorCSharpDocument csharpDocument, LinePositionSpan csharpRange, out LinePositionSpan razorRange)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/LspExtensions_WorkspaceEdit.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/LspExtensions_WorkspaceEdit.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 
 namespace Roslyn.LanguageServer.Protocol;
@@ -91,10 +90,16 @@ internal static partial class LspExtensions
             {
                 foreach (var (uri, textEdits) in edit.Changes)
                 {
+                    var edits = new SumType<TextEdit, AnnotatedTextEdit>[textEdits.Length];
+                    for (var i = 0; i < textEdits.Length; i++)
+                    {
+                        edits[i] = textEdits[i];
+                    }
+
                     var textDocumentEdit = new TextDocumentEdit
                     {
                         TextDocument = new OptionalVersionedTextDocumentIdentifier { DocumentUri = new(uri) },
-                        Edits = [.. textEdits.Select(te => (SumType<TextEdit, AnnotatedTextEdit>)te)]
+                        Edits = edits
                     };
                     builder.Add(new SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>(textDocumentEdit));
                 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/FormattingUtilities.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/FormattingUtilities.cs
@@ -338,25 +338,25 @@ internal static class FormattingUtilities
     public static TextEdit[] FixHtmlTextEdits(SourceText htmlSourceText, TextEdit[] edits)
     {
         // Avoid computing a minimal diff if we don't need to
-        if (!edits.Any(static e => e.NewText.Contains("~")))
+        if (!edits.Any(static e => e.NewText.Contains('~')))
             return edits;
 
         var changes = edits.SelectAsArray(htmlSourceText.GetTextChange);
 
         var fixedChanges = htmlSourceText.MinimizeTextChanges(changes);
-        return [.. fixedChanges.Select(htmlSourceText.GetTextEdit)];
+        return fixedChanges.SelectAsPlainArray(htmlSourceText.GetTextEdit);
     }
 
     internal static SumType<TextEdit, AnnotatedTextEdit>[] FixHtmlTextEdits(SourceText htmlSourceText, SumType<TextEdit, AnnotatedTextEdit>[] edits)
     {
         // Avoid computing a minimal diff if we don't need to
-        if (!edits.Any(static e => ((TextEdit)e).NewText.Contains("~")))
+        if (!edits.Any(static e => ((TextEdit)e).NewText.Contains('~')))
             return edits;
 
         var changes = edits.SelectAsArray(e => htmlSourceText.GetTextChange((TextEdit)e));
 
         var fixedChanges = htmlSourceText.MinimizeTextChanges(changes);
-        return [.. fixedChanges.Select(htmlSourceText.GetTextEdit)];
+        return fixedChanges.SelectAsPlainArray<TextChange, SumType<TextEdit, AnnotatedTextEdit>>(c => htmlSourceText.GetTextEdit(c));
     }
 
     public static void GetOriginalDocumentChangesFromLineInfo(FormattingContext context, SourceText originalText, ImmutableArray<LineInfo> formattedLineInfo, SourceText formattedText, ILogger logger, Func<int, bool>? shouldKeepInsertedNewlineAtPosition, ref PooledArrayBuilder<TextChange> formattingChanges, out int lastFormattedTextLine)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
@@ -211,7 +211,7 @@ internal sealed class CSharpOnTypeFormattingPass(
         if (context.AutomaticallyAddUsings)
         {
             // Because we need to parse the C# code twice for this operation, lets do a quick check to see if its even necessary
-            if (changes.Any(static e => e.NewText is not null && e.NewText.IndexOf("using") != -1))
+            if (changes.Any(static e => e.NewText is not null && e.NewText.Contains("using")))
             {
                 var usingEdits = await RazorEditHelper.GetEditsForCSharpLanguageFeaturesAsync(context.CurrentSnapshot, originalTextWithChanges, cancellationToken).ConfigureAwait(false);
                 var usingChanges = usingEdits.SelectAsArray(static e => e.ToTextChange());
@@ -223,7 +223,7 @@ internal sealed class CSharpOnTypeFormattingPass(
     }
 
     // Returns the minimal TextSpan that encompasses all the differences between the old and the new text.
-    private static SourceText ApplyChangesAndTrackChange(SourceText oldText, IEnumerable<TextChange> changes, out TextSpan spanBeforeChange, out TextSpan spanAfterChange)
+    private static SourceText ApplyChangesAndTrackChange(SourceText oldText, ImmutableArray<TextChange> changes, out TextSpan spanBeforeChange, out TextSpan spanAfterChange)
     {
         var newText = oldText.WithChanges(changes);
         var affectedRange = newText.GetEncompassingTextChangeRange(oldText);
@@ -234,7 +234,7 @@ internal sealed class CSharpOnTypeFormattingPass(
         return newText;
     }
 
-    private static ImmutableArray<TextChange> FilterCSharpTextChanges(FormattingContext context, IEnumerable<TextChange> changes)
+    private static ImmutableArray<TextChange> FilterCSharpTextChanges(FormattingContext context, ImmutableArray<TextChange> changes)
     {
         var indent = context.GetIndentationLevelString(1);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/InlayHints/RemoteInlayHintService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/InlayHints/RemoteInlayHintService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
@@ -78,23 +78,7 @@ internal static partial class ImmutableArrayExtensions
     ///  on each element of <paramref name="array"/>.
     /// </returns>
     public static ImmutableArray<TResult> SelectAsArray<T, TResult>(this ImmutableArray<T> array, Func<T, TResult> selector)
-    {
-        var length = array.Length;
-
-        if (length == 0)
-        {
-            return [];
-        }
-
-        var result = new TResult[length];
-
-        for (var i = 0; i < length; i++)
-        {
-            result[i] = selector(array[i]);
-        }
-
-        return ImmutableCollectionsMarshal.AsImmutableArray(result);
-    }
+        => ImmutableCollectionsMarshal.AsImmutableArray(SelectAsPlainArray(array, selector));
 
     /// <summary>
     ///  Projects each element of an <see cref="ImmutableArray{T}"/> into a new form by incorporating the element's index.
@@ -110,23 +94,7 @@ internal static partial class ImmutableArrayExtensions
     ///  on each element of <paramref name="array"/>.
     /// </returns>
     public static ImmutableArray<TResult> SelectAsArray<T, TResult>(this ImmutableArray<T> array, Func<T, int, TResult> selector)
-    {
-        var length = array.Length;
-
-        if (length == 0)
-        {
-            return [];
-        }
-
-        var result = new TResult[length];
-
-        for (var i = 0; i < length; i++)
-        {
-            result[i] = selector(array[i], i);
-        }
-
-        return ImmutableCollectionsMarshal.AsImmutableArray(result);
-    }
+        => ImmutableCollectionsMarshal.AsImmutableArray(SelectAsPlainArray(array, selector));
 
     /// <summary>
     ///  Projects each element of an <see cref="ImmutableArray{T}"/> into a new form.
@@ -142,23 +110,7 @@ internal static partial class ImmutableArrayExtensions
     ///  on each element of <paramref name="array"/>.
     /// </returns>
     public static ImmutableArray<TResult> SelectAsArray<T, TArg, TResult>(this ImmutableArray<T> array, TArg arg, Func<T, TArg, TResult> selector)
-    {
-        var length = array.Length;
-
-        if (length == 0)
-        {
-            return [];
-        }
-
-        var result = new TResult[length];
-
-        for (var i = 0; i < length; i++)
-        {
-            result[i] = selector(array[i], arg);
-        }
-
-        return ImmutableCollectionsMarshal.AsImmutableArray(result);
-    }
+        => ImmutableCollectionsMarshal.AsImmutableArray(SelectAsPlainArray(array, arg, selector));
 
     /// <summary>
     ///  Projects each element of an <see cref="ImmutableArray{T}"/> into a new form by incorporating the element's index.
@@ -176,6 +128,118 @@ internal static partial class ImmutableArrayExtensions
     ///  on each element of <paramref name="array"/>.
     /// </returns>
     public static ImmutableArray<TResult> SelectAsArray<T, TArg, TResult>(this ImmutableArray<T> array, TArg arg, Func<T, TArg, int, TResult> selector)
+        => ImmutableCollectionsMarshal.AsImmutableArray(SelectAsPlainArray(array, arg, selector));
+
+    /// <summary>
+    ///  Projects each element of an <see cref="ImmutableArray{T}"/> into a new form.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="array">An array of values to invoke a transform function on.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <returns>
+    ///  Returns a new array whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="array"/>.
+    /// </returns>
+    public static TResult[] SelectAsPlainArray<T, TResult>(this ImmutableArray<T> array, Func<T, TResult> selector)
+    {
+        var length = array.Length;
+
+        if (length == 0)
+        {
+            return [];
+        }
+
+        var result = new TResult[length];
+
+        for (var i = 0; i < length; i++)
+        {
+            result[i] = selector(array[i]);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="ImmutableArray{T}"/> into a new form by incorporating the element's index.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="array">An array of values to invoke a transform function on.</param>
+    /// <param name="selector">
+    ///  A transform function to apply to each element; the second parameter of the function represents the index of the element.
+    /// </param>
+    /// <returns>
+    ///  Returns a new array whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="array"/>.
+    /// </returns>
+    public static TResult[] SelectAsPlainArray<T, TResult>(this ImmutableArray<T> array, Func<T, int, TResult> selector)
+    {
+        var length = array.Length;
+
+        if (length == 0)
+        {
+            return [];
+        }
+
+        var result = new TResult[length];
+
+        for (var i = 0; i < length; i++)
+        {
+            result[i] = selector(array[i], i);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="ImmutableArray{T}"/> into a new form.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TArg">The type of the argument to pass to <paramref name="selector"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="array">An array of values to invoke a transform function on.</param>
+    /// <param name="arg">An argument to pass to <paramref name="selector"/>.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <returns>
+    ///  Returns a new array whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="array"/>.
+    /// </returns>
+    public static TResult[] SelectAsPlainArray<T, TArg, TResult>(this ImmutableArray<T> array, TArg arg, Func<T, TArg, TResult> selector)
+    {
+        var length = array.Length;
+
+        if (length == 0)
+        {
+            return [];
+        }
+
+        var result = new TResult[length];
+
+        for (var i = 0; i < length; i++)
+        {
+            result[i] = selector(array[i], arg);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="ImmutableArray{T}"/> into a new form by incorporating the element's index.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TArg">The type of the argument to pass to <paramref name="selector"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="array">An array of values to invoke a transform function on.</param>
+    /// <param name="arg">An argument to pass to <paramref name="selector"/>.</param>
+    /// <param name="selector">
+    ///  A transform function to apply to each element; the third parameter of the function represents the index of the element.
+    /// </param>
+    /// <returns>
+    ///  Returns a new array whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="array"/>.
+    /// </returns>
+    public static TResult[] SelectAsPlainArray<T, TArg, TResult>(this ImmutableArray<T> array, TArg arg, Func<T, TArg, int, TResult> selector)
     {
         var length = array.Length;
 
@@ -191,7 +255,7 @@ internal static partial class ImmutableArrayExtensions
             result[i] = selector(array[i], arg, i);
         }
 
-        return ImmutableCollectionsMarshal.AsImmutableArray(result);
+        return result;
     }
 
     public static ImmutableArray<TResult> SelectManyAsArray<TSource, TResult>(this IReadOnlyCollection<TSource>? source, Func<TSource, ImmutableArray<TResult>> selector)


### PR DESCRIPTION
There were several locations that had an immutable array, called select on it (getting back an IEnumerable) and then did a collection expression on that to get back an array. Instead, add a SelectAsPlainArray extension method on ImmutableArray that does this more efficiently.

Old way allocates iterator from IEnumerable, intermediate arrays while calculating select, and then allocated final array New way: only allocates final array

I noticed this from a code review I was doing, and not from perf traces, so I don't have evidence that this will make a tangible difference, but every bit helps.