### PR TITLE
Disable draft insertions on main after VS snap

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -14,7 +14,7 @@
         "NonShipping"
       ],
       "vsBranch": "main",
-      "insertionCreateDraftPR": true,
+      "insertionCreateDraftPR": false,
       "insertionTitlePrefix": "[InsidersVNext]"
     }
   }


### PR DESCRIPTION
Auto-generated by snap skill. Post-VS-snap PublishData.json follow-up: restore non-draft VS insertions on main.