### PR TITLE
Protect first C# diagnostic computation from cancellation to fix bimodal allocation in speedometer

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Diagnostics/CohostDocumentPullDiagnosticsEndpointBase.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Diagnostics/CohostDocumentPullDiagnosticsEndpointBase.cs
@@ -33,6 +33,14 @@ internal abstract class CohostDocumentPullDiagnosticsEndpointBase<TRequest, TRes
     private readonly ITelemetryReporter _telemetryReporter = telemetryReporter;
     private readonly ILogger _logger = logger;
 
+    // Tracks the first C# diagnostic computation for a document. The first successful completion
+    // bootstraps Roslyn's IncrementalMemberEditAnalyzer, making all subsequent analyses fast and
+    // incremental (~50ms vs ~1-3s). Only the first computation needs protection from cancellation.
+    // This is a single-entry cache because Roslyn's IncrementalMemberEditAnalyzer itself only
+    // caches the last document analyzed.
+    private volatile BootstrapDiagnosticComputation? _activeBootstrap;
+    private readonly object _bootstrapGate = new object();
+
     protected override bool MutatesSolutionState => false;
 
     protected override bool RequiresLSPSolution => true;
@@ -107,7 +115,7 @@ internal abstract class CohostDocumentPullDiagnosticsEndpointBase<TRequest, TRes
     private async Task<LspDiagnostic[]> GetCSharpDiagnosticsAsync(TextDocument razorDocument, Guid correletionId, CancellationToken cancellationToken)
     {
         var generatedDocument = await TryGetGeneratedDocumentAsync(razorDocument, cancellationToken).ConfigureAwait(false);
-        if (generatedDocument is null)
+        if (generatedDocument is null || razorDocument.FilePath is not string filePath)
         {
             return [];
         }
@@ -116,8 +124,70 @@ internal abstract class CohostDocumentPullDiagnosticsEndpointBase<TRequest, TRes
 
         using var _ = _telemetryReporter.TrackLspRequest(LspMethodName, "Razor.ExternalAccess", TelemetryThresholds.DiagnosticsSubLSPTelemetryThreshold, correletionId);
         var supportsVisualStudioExtensions = _clientCapabilitiesService.ClientCapabilities.SupportsVisualStudioExtensions;
-        var diagnostics = await ExternalHandlers.Diagnostics.GetDocumentDiagnosticsAsync(generatedDocument, supportsVisualStudioExtensions, cancellationToken).ConfigureAwait(false);
-        return [.. diagnostics];
+
+        // Check if this document already has a bootstrap computation. Once bootstrapped,
+        // Roslyn's IncrementalMemberEditAnalyzer makes subsequent analyses fast (~50ms),
+        // so they complete within the normal request lifetime and don't need protection.
+        var bootstrap = _activeBootstrap;
+        var isBootstrapRequest = false;
+        if (bootstrap?.FilePath != filePath)
+        {
+            lock (_bootstrapGate)
+            {
+                bootstrap = _activeBootstrap; // re-read
+                if (bootstrap?.FilePath != filePath)
+                {
+                    // First request for this document (or bootstrap was for a different doc).
+                    // Use AsyncLazy with CancellationToken.None to survive cancellation for the bootstrap request.
+                    var newLazy = AsyncLazy.Create(
+                        asynchronousComputeFunction: static (state, _) => ExternalHandlers.Diagnostics.GetDocumentDiagnosticsAsync(
+                            state.GeneratedDocument, state.SupportsVisualStudioExtensions, CancellationToken.None),
+                        arg: (GeneratedDocument: generatedDocument, SupportsVisualStudioExtensions: supportsVisualStudioExtensions));
+
+                    bootstrap = new BootstrapDiagnosticComputation(filePath, newLazy);
+                    _activeBootstrap = bootstrap;
+                    isBootstrapRequest = true;
+                }
+            }
+        }
+
+        try
+        {
+            // Pass cancellationToken so callers aren't blocked indefinitely. The AsyncLazy factory
+            // uses CancellationToken.None, so the underlying computation continues even if this
+            // caller is cancelled — ensuring the analyzer warmup side-effect still completes.
+            var bootstrapResult = await bootstrap.Diagnostics.GetValueAsync(cancellationToken).ConfigureAwait(false);
+            if (isBootstrapRequest)
+            {
+                return [.. bootstrapResult];
+            }
+        }
+        catch (Exception ex)
+        {
+            if (isBootstrapRequest)
+            {
+                // On cancellation, the AsyncLazy factory continues running with CancellationToken.None
+                // and will still warm up the analyzer. On a genuine fault, the computation is broken.
+                // Clear the cache so the next request can create a fresh bootstrap.
+                if (ex is not OperationCanceledException)
+                {
+                    lock (_bootstrapGate)
+                    {
+                        if (ReferenceEquals(_activeBootstrap, bootstrap))
+                        {
+                            _activeBootstrap = null;
+                        }
+                    }
+                }
+
+                // Our request failed, propagate the exception. Future requests will attempt to bootstrap again.
+                throw;
+            }
+        }
+
+        // Document is bootstrapped — use normal cancellation semantics with current document snapshot.
+        return [.. await ExternalHandlers.Diagnostics.GetDocumentDiagnosticsAsync(
+            generatedDocument, supportsVisualStudioExtensions, cancellationToken).ConfigureAwait(false)];
     }
 
     private async Task<LspDiagnostic[]> GetHtmlDiagnosticsAsync(TextDocument razorDocument, Guid correletionId, CancellationToken cancellationToken)
@@ -138,5 +208,11 @@ internal abstract class CohostDocumentPullDiagnosticsEndpointBase<TRequest, TRes
         }
 
         return ExtractHtmlDiagnostics(result);
+    }
+
+    private sealed class BootstrapDiagnosticComputation(string filePath, AsyncLazy<ImmutableArray<LspDiagnostic>> diagnostics)
+    {
+        public string FilePath { get; } = filePath;
+        public AsyncLazy<ImmutableArray<LspDiagnostic>> Diagnostics { get; } = diagnostics;
     }
 }


### PR DESCRIPTION
*** In draft mode until I get several speedometer runs indicating this addresses the issue ***

The RazorEditingTests.CompletionInCohostingForComponents speedometer test exhibits bimodal CLR_BytesAllocated_NonDevenv behavior for the html completion scenario. This behavior has existed since the creation of the test. Most speedometer sessions don't experience any bad runs, but sometimes 1 or 2 bad runs occur where there is a marked increase in non-devenv allocations SDK insertions seemingly hit this hard, with all five runs experiencing the poor allocation behavior.

Inspection of the traces leads to a large number of operation cancelled exceptions in the bad traces, leading to partially completed diagnostic requests to be tossed. AI indicated that Roslyn's IncrementalMemberEditAnalyzer has a heavy performance cost until it's completed once for a file. With the test hammering away typing and committing completions, the diagnostic requests get cancelled before any can complete.

*** AI's description of this change ***
The root cause is a bistable race condition in Roslyn's IncrementalMemberEditAnalyzer. This analyzer caches the last successfully analyzed document in a single WeakReference<Document?> field. When cached,  subsequent analyses are incremental (~50ms). When not cached, every analysis is a full recomputation (~1-3s). The problem: full analyses are slow enough to be cancelled by the next incoming diagnostic request, preventing the cache from ever being set — a self-reinforcing failure mode.

Razor bypasses Roslyn's pull diagnostics infrastructure (which has its own protections) and calls DiagnosticAnalyzerService.GetDiagnosticsForSpanAsync directly with the caller's cancellation token. The VS LSP client cancels in-flight diagnostic requests whenever a new request is issued, creating the rapid cancellation cycle.

The fix uses AsyncLazy to ensure the first diagnostic computation per document runs with CancellationToken.None, allowing it to complete and bootstrap the analyzer. Subsequent requests pass through with normal cancellation semantics since the analyzer is now fast. A double-checked locking pattern with a volatile field guards the single-entry bootstrap cache. The initiator returns the bootstrap result directly; concurrent callers await the shared computation then make their own fresh call. On cancellation, the bootstrap is preserved (the factory continues running). On fault, it is cleared under a ReferenceEquals identity guard to avoid clobbering a different document's bootstrap.

*** Speedometer graph from the last several days of runs ***
<img width="1627" height="733" alt="image" src="https://github.com/user-attachments/assets/469af563-a5f2-4523-9135-b13d64146c82" />