### PR TITLE
Remove Mariner 2.0 pipeline reference

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -237,7 +237,7 @@ stages:
 
       - job: Linux
         container:
-          image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0
+          image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-build-amd64
           options: --init # This ensures all the stray defunct processes are reaped.
         pool:
           name: NetCore-Public


### PR DESCRIPTION
> [!NOTE]
> This PR was AI/Copilot-generated.

## Summary
Update the remaining Razor pipeline container reference to the current Azure Linux build image.

- replace `mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0`
- with `mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-build-amd64`

Follow-up to dotnet/runtime#126528.