### PR TITLE
Add editor context menu support for Razor nested file commands

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/ViewCodeCommandHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/ViewCodeCommandHandler.cs
@@ -2,11 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Frozen;
 using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using Microsoft.AspNetCore.Razor;
+using Microsoft.AspNetCore.Mvc.Razor.Extensions;
+using Microsoft.AspNetCore.Razor.Language.Components;
+using Microsoft.AspNetCore.Razor.Utilities;
 using Microsoft.VisualStudio.Commanding;
 using Microsoft.VisualStudio.Razor.Extensions;
 using Microsoft.VisualStudio.Shell;
@@ -26,12 +27,6 @@ internal sealed partial class ViewCodeCommandHandler(
     ITextDocumentFactoryService textDocumentFactoryService,
     JoinableTaskContext joinableTaskContext) : ICommandHandler<ViewCodeCommandArgs>
 {
-    private static readonly FrozenSet<string> s_razorFileExtensions = new[]
-    {
-        RazorLSPConstants.CSHTMLFileExtension,
-        RazorLSPConstants.RazorFileExtension
-    }.ToFrozenSet(PathUtilities.OSSpecificPathComparer);
-
     private static readonly CommandState s_availableCommandState = new(isAvailable: true, displayText: SR.View_Code);
 
     private readonly IServiceProvider _serviceProvider = serviceProvider;
@@ -69,24 +64,19 @@ internal sealed partial class ViewCodeCommandHandler(
         // However, if that changes, we should assert because our FileExistsHelper will likely be corrupted.
         _joinableTaskContext.AssertUIThread();
 
+        // Exclude imports files — they don't have nested code files.
+        if (_textDocumentFactoryService.TryGetTextDocument(buffer, out var document)
+            && document?.FilePath is string filePath
+            && FileUtilities.IsAnyRazorFilePath(filePath, StringComparison.OrdinalIgnoreCase)
+            && Path.GetFileName(filePath) is string fileName
+            && !string.Equals(fileName, ComponentHelpers.ImportsFileName, StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(fileName, MvcImportProjectFeature.ImportsFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            codeFilePath = filePath + RazorLSPConstants.CSharpFileExtension;
+            return _helper.FileExists(codeFilePath);
+        }
+
         codeFilePath = null;
-
-        if (!_textDocumentFactoryService.TryGetTextDocument(buffer, out var document) ||
-            document?.FilePath is null)
-        {
-            return false;
-        }
-
-        var filePath = document.FilePath;
-        var extension = Path.GetExtension(filePath);
-
-        if (!s_razorFileExtensions.Contains(extension))
-        {
-            return false;
-        }
-
-        codeFilePath = Path.ChangeExtension(filePath, extension + RazorLSPConstants.CSharpFileExtension);
-
-        return _helper.FileExists(codeFilePath);
+        return false;
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/NestedFiles/NestedFileCommandHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/NestedFiles/NestedFileCommandHandler.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Razor.Extensions;
-using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.Utilities;
 using Microsoft.CodeAnalysis.Razor.NestedFiles;

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/NestedFiles/NestedFileCommandHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/NestedFiles/NestedFileCommandHandler.cs
@@ -4,36 +4,54 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Razor.Extensions;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Components;
+using Microsoft.AspNetCore.Razor.Utilities;
 using Microsoft.CodeAnalysis.Razor.NestedFiles;
 using Microsoft.CodeAnalysis.Razor.Protocol.NestedFiles;
 using Microsoft.VisualStudio.Razor.LanguageClient;
 using Microsoft.VisualStudio.Razor.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.RazorExtension.NestedFiles;
 
 /// <summary>
-/// Base class for handling Add/View nested file commands for Razor documents.
+/// Handles Add/View nested file commands for Razor documents from both Solution Explorer
+/// and editor context menus.
 /// When the file doesn't exist, sends an LSP request to the Razor language server
 /// to create it via workspace/applyEdit. When the file exists, just opens it.
 /// </summary>
+/// <param name="serviceProvider">VS service provider for accessing shell services.</param>
+/// <param name="fileExtension">The nested file extension to add/view (e.g., ".cs", ".css", ".js").</param>
+/// <param name="fileKind">The kind of nested file, used when creating new files via LSP.</param>
+/// <param name="requestInvoker">Lazy wrapper for sending LSP requests to the Razor language server.</param>
+/// <param name="allowExternalHandlers">
+/// When true, sets Supported = false instead of Visible = false when the command doesn't apply. 
+/// This tells VS that this handler does not own the command, allowing external handlers (e.g., the default 
+/// ViewCode/F7 handler) to take over.
+/// </param>
+/// <param name="hideWhenFileExists">
+/// When true, hides the command when the nested file already exists. Used for the editor-only
+/// "Add .cs" command (cmdidAddNestedCsFileEditor), which is hidden when the .cs file exists
+/// because cmdidViewCode with F7 handles the "View" case instead.
+/// </param>
 internal sealed class NestedFileCommandHandler(
     IServiceProvider serviceProvider,
     string fileExtension,
     NestedFileKind fileKind,
-    Lazy<LSPRequestInvokerWrapper> requestInvoker)
+    Lazy<LSPRequestInvokerWrapper> requestInvoker,
+    bool allowExternalHandlers = false,
+    bool hideWhenFileExists = false)
 {
     private readonly IServiceProvider _serviceProvider = serviceProvider;
     private readonly string _fileExtension = fileExtension;
     private readonly NestedFileKind _fileKind = fileKind;
     private readonly Lazy<LSPRequestInvokerWrapper> _requestInvoker = requestInvoker;
+    private readonly bool _allowExternalHandlers = allowExternalHandlers;
+    private readonly bool _hideWhenFileExists = hideWhenFileExists;
 
     /// <summary>
     /// Configures the command status and text based on whether the nested file exists.
@@ -46,32 +64,44 @@ internal sealed class NestedFileCommandHandler(
         }
 
         // Check if the Razor file context is active before doing expensive hierarchy queries
-        if (!IsRazorFileUIContextActive()
+        if (!SelectionHelper.IsRazorFileUIContextActive(_serviceProvider)
             || GetSelectedRazorFilePath() is not string razorFilePath)
         {
-            command.Visible = false;
+            if (_allowExternalHandlers)
+            {
+                command.Supported = false;
+            }
+            else
+            {
+                command.Visible = false;
+            }
+
             return;
         }
 
         var nestedFilePath = GetNestedFilePath(razorFilePath);
         var nestedFileExists = File.Exists(nestedFilePath);
+
+        if (_allowExternalHandlers && !nestedFileExists)
+        {
+            // yield so another handler can show "Add" (without F7 keybinding)
+            command.Supported = false;
+            return;
+        }
+
+        if (_hideWhenFileExists && nestedFileExists)
+        {
+            // The nested file exists and we've been told this command should be hidden in that case
+            command.Visible = false;
+            return;
+        }
+
         var nestedFileName = Path.GetFileName(nestedFilePath);
 
+        command.Supported = true;
         command.Visible = true;
         command.Enabled = true;
         command.Text = nestedFileExists ? Resources.FormatView_Nested_File(nestedFileName) : Resources.FormatAdd_Nested_File(nestedFileName);
-    }
-
-    private bool IsRazorFileUIContextActive()
-    {
-        ThreadHelper.ThrowIfNotOnUIThread();
-
-        var contextGuid = RazorPackage.GuidRazorFileContext;
-
-        return _serviceProvider.GetService(typeof(SVsShellMonitorSelection)) is IVsMonitorSelection monitorSelection
-            && monitorSelection.GetCmdUIContextCookie(ref contextGuid, out var cookie) == VSConstants.S_OK
-            && monitorSelection.IsCmdUIContextActive(cookie, out var isActive) == VSConstants.S_OK
-            && isActive != 0;
     }
 
     /// <summary>
@@ -139,70 +169,23 @@ internal sealed class NestedFileCommandHandler(
     }
 
     /// <summary>
-    /// Gets the file path of the currently selected Razor file in Solution Explorer.
+    /// Gets the file path of the currently selected/active Razor file.
+    /// This works for both Solution Explorer selection and the active editor document,
+    /// because IVsMonitorSelection tracks the active window frame's hierarchy item.
     /// </summary>
     private string? GetSelectedRazorFilePath()
     {
-        ThreadHelper.ThrowIfNotOnUIThread();
+        var filePath = SelectionHelper.GetCurrentSelectionPath(_serviceProvider);
 
-        if (_serviceProvider.GetService(typeof(SVsShellMonitorSelection)) is not IVsMonitorSelection monitorSelection)
+        if (filePath is not null
+            && FileUtilities.IsAnyRazorFilePath(filePath, StringComparison.OrdinalIgnoreCase)
+            && Path.GetFileName(filePath) is string fileName
+            && !string.Equals(fileName, ComponentHelpers.ImportsFileName, StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(fileName, MvcImportProjectFeature.ImportsFileName, StringComparison.OrdinalIgnoreCase))
         {
-            return null;
+            return filePath;
         }
 
-        monitorSelection.GetCurrentSelection(out var hierarchyPtr, out var itemId, out _, out var selectionContainerPtr);
-
-        try
-        {
-            if (itemId is VSConstants.VSITEMID_NIL or VSConstants.VSITEMID_ROOT or VSConstants.VSITEMID_SELECTION)
-            {
-                return null;
-            }
-
-            if (hierarchyPtr != IntPtr.Zero)
-            {
-                var hierarchy = Marshal.GetObjectForIUnknown(hierarchyPtr) as IVsHierarchy;
-                if (hierarchy is IVsProject project)
-                {
-                    project.GetMkDocument(itemId, out var filePath);
-
-                    if (filePath is not null)
-                    {
-                        if (filePath.EndsWith(FileKinds.ComponentFileExtension, StringComparison.OrdinalIgnoreCase))
-                        {
-                            // return all paths with extension .razor except for the special imports file
-                            var fileName = Path.GetFileNameWithoutExtension(filePath);
-                            if (!string.Equals(fileName, ComponentHelpers.ImportsFileName, StringComparison.OrdinalIgnoreCase))
-                            {
-                                return filePath;
-                            }
-                        }
-                        else if (filePath.EndsWith(FileKinds.LegacyFileExtension, StringComparison.OrdinalIgnoreCase))
-                        {
-                            // return all paths with extension .cshtml except for the special imports file
-                            var fileName = Path.GetFileNameWithoutExtension(filePath);
-                            if (!string.Equals(fileName, MvcImportProjectFeature.ImportsFileName, StringComparison.OrdinalIgnoreCase))
-                            {
-                                return filePath;
-                            }
-                        }
-                    }
-                }
-            }
-
-            return null;
-        }
-        finally
-        {
-            if (hierarchyPtr != IntPtr.Zero)
-            {
-                Marshal.Release(hierarchyPtr);
-            }
-
-            if (selectionContainerPtr != IntPtr.Zero)
-            {
-                Marshal.Release(selectionContainerPtr);
-            }
-        }
+        return null;
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/NestedFiles/NestedFileCommandHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/NestedFiles/NestedFileCommandHandler.cs
@@ -42,8 +42,8 @@ internal sealed class NestedFileCommandHandler(
     string fileExtension,
     NestedFileKind fileKind,
     Lazy<LSPRequestInvokerWrapper> requestInvoker,
-    bool allowExternalHandlers = false,
-    bool hideWhenFileExists = false)
+    bool allowExternalHandlers,
+    bool hideWhenFileExists)
 {
     private readonly IServiceProvider _serviceProvider = serviceProvider;
     private readonly string _fileExtension = fileExtension;

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/NestedFiles/SelectionHelper.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/NestedFiles/SelectionHelper.cs
@@ -1,0 +1,73 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.RazorExtension.NestedFiles;
+
+/// <summary>
+/// Shared helper for querying the current selection via <see cref="IVsMonitorSelection"/>.
+/// Works for both Solution Explorer selection and active editor documents, because
+/// <see cref="IVsMonitorSelection"/> tracks the active window frame's hierarchy item.
+/// </summary>
+internal static class SelectionHelper
+{
+    /// <summary>
+    /// Returns the file path of the currently selected/active hierarchy item, or null
+    /// if no single file item is selected.
+    /// </summary>
+    public static string? GetCurrentSelectionPath(IServiceProvider serviceProvider)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+
+        if (serviceProvider.GetService(typeof(SVsShellMonitorSelection)) is IVsMonitorSelection monitorSelection)
+        {
+            monitorSelection.GetCurrentSelection(out var hierarchyPtr, out var itemId, out _, out var selectionContainerPtr);
+
+            try
+            {
+                if (itemId is not VSConstants.VSITEMID_NIL and not VSConstants.VSITEMID_ROOT and not VSConstants.VSITEMID_SELECTION
+                    && hierarchyPtr != IntPtr.Zero
+                    && Marshal.GetObjectForIUnknown(hierarchyPtr) is IVsProject project
+                    && project.GetMkDocument(itemId, out var filePath) == VSConstants.S_OK)
+                {
+                    return filePath;
+                }
+            }
+            finally
+            {
+                if (hierarchyPtr != IntPtr.Zero)
+                {
+                    Marshal.Release(hierarchyPtr);
+                }
+
+                if (selectionContainerPtr != IntPtr.Zero)
+                {
+                    Marshal.Release(selectionContainerPtr);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns true if the <see cref="RazorPackage.GuidRazorFileContext"/> UIContext is active.
+    /// This context requires both the <c>DotNetCoreRazorProject</c> capability on the active
+    /// project and a matching Razor/nested file selection.
+    /// </summary>
+    public static bool IsRazorFileUIContextActive(IServiceProvider serviceProvider)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+
+        var contextGuid = RazorPackage.GuidRazorFileContext;
+
+        return serviceProvider.GetService(typeof(SVsShellMonitorSelection)) is IVsMonitorSelection monitorSelection
+            && monitorSelection.GetCmdUIContextCookie(ref contextGuid, out var cookie) == VSConstants.S_OK
+            && monitorSelection.IsCmdUIContextActive(cookie, out var isActive) == VSConstants.S_OK
+            && isActive != 0;
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/NestedFiles/ViewPageCommandHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/NestedFiles/ViewPageCommandHandler.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.RazorExtension.NestedFiles;
+
+/// <summary>
+/// Handles the "View Page" command from nested file editors (ie: foo.(cshtml|razor).(cs|css|js))
+/// to navigate back to the parent Razor file.
+/// </summary>
+internal sealed class ViewPageCommandHandler(IServiceProvider serviceProvider)
+{
+    private static readonly string[] s_nestedExtensions = [".cs", ".css", ".js"];
+    private static readonly string[] s_razorExtensions = [".cshtml", ".razor"];
+
+    private readonly IServiceProvider _serviceProvider = serviceProvider;
+
+    public void OnBeforeQueryStatus(object sender, EventArgs e)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+
+        if (sender is not OleMenuCommand command)
+        {
+            return;
+        }
+
+        if (!SelectionHelper.IsRazorFileUIContextActive(_serviceProvider)
+            || TryGetParentRazorFilePath() is null)
+        {
+            command.Visible = false;
+            return;
+        }
+
+        command.Supported = true;
+        command.Visible = true;
+        command.Enabled = true;
+        command.Text = Resources.View_Page;
+    }
+
+    public void Execute(object sender, EventArgs e)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+
+        if (TryGetParentRazorFilePath() is string parentFilePath)
+        {
+            VsShellUtilities.OpenDocument(_serviceProvider, parentFilePath);
+        }
+    }
+
+    /// <summary>
+    /// Gets the file path of the currently selected/active item via IVsMonitorSelection,
+    /// then checks if it's a nested Razor file and returns the parent path if so.
+    /// Works for both Solution Explorer selection and active editor documents
+    /// because IVsMonitorSelection tracks the active window frame's hierarchy item.
+    /// </summary>
+    private string? TryGetParentRazorFilePath()
+    {
+        var filePath = SelectionHelper.GetCurrentSelectionPath(_serviceProvider);
+
+        if (filePath is null)
+        {
+            return null;
+        }
+
+        // Check if the file has a nested extension (.cs, .css, .js)
+        var extension = Path.GetExtension(filePath).ToLowerInvariant();
+        if (!s_nestedExtensions.Contains(extension))
+        {
+            return null;
+        }
+
+        // Strip the nested extension to get the potential parent path
+        var parentPath = filePath.Substring(0, filePath.Length - extension.Length);
+
+        // Verify the parent has a Razor extension (.cshtml or .razor)
+        var parentExtension = Path.GetExtension(parentPath).ToLowerInvariant();
+
+        if (s_razorExtensions.Contains(parentExtension))
+        {
+            // Only show if the parent file exists
+            return File.Exists(parentPath) ? parentPath : null;
+        }
+
+        return null;
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorContextMenu.vsct
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorContextMenu.vsct
@@ -3,6 +3,7 @@
 
   <Extern href="stdidcmd.h"/>
   <Extern href="vsshlids.h"/>
+  <Include href="KnownImageIds.vsct"/>
 
   <Symbols>
     <GuidSymbol name="RazorPackage" value="{13b72f58-279e-49e0-a56d-296be02f0805}" />
@@ -25,14 +26,27 @@
 
     <!-- Command set GUID for Razor nested file commands -->
     <GuidSymbol name="guidRazorNestedFilesCmdSet" value="{8B2B3C5D-6E4A-4F9B-9C8D-1A2B3C4D5E6F}">
+      <!-- Groups -->
       <IDSymbol name="grpidRazorNestedFiles" value="0x1001" />
+      <IDSymbol name="grpidRazorNestedFilesEditor" value="0x1002" />
+
+      <!-- Nested file commands (cs is SolutionExplorer only; css and js are placed in both SolutionExplorer and editor via CommandPlacements) -->
       <IDSymbol name="cmdidAddOrViewNestedCsFile" value="0x0100" />
       <IDSymbol name="cmdidAddOrViewNestedCssFile" value="0x0101" />
       <IDSymbol name="cmdidAddOrViewNestedJsFile" value="0x0102" />
+
+      <!-- Editor-only commands -->
+      <IDSymbol name="cmdidViewPageEditor" value="0x0203" />
+      <IDSymbol name="cmdidAddNestedCsFileEditor" value="0x0204" />
     </GuidSymbol>
 
     <!-- UI Context GUID for Razor file selection -->
     <GuidSymbol name="guidRazorFileContext" value="{7C3F2F9E-8D4A-4B6C-9E1F-5A8D7C6B3E2D}" />
+
+    <!-- CSS editor context menu (from WebTools) -->
+    <GuidSymbol name="guidCssEditorCmdSet" value="{64DA400E-B4AD-4D67-AA92-4B7ACB01ECD5}">
+      <IDSymbol name="groupGotoCss" value="120" />
+    </GuidSymbol>
   </Symbols>
 
   <Commands package="RazorPackage">
@@ -45,6 +59,11 @@
       <!-- Nested file group parented to Solution Explorer item context menu -->
       <Group guid="guidRazorNestedFilesCmdSet" id="grpidRazorNestedFiles" priority="0x0310">
         <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE"/>
+      </Group>
+
+      <!-- Nested file group parented to the editor context menu -->
+      <Group guid="guidRazorNestedFilesCmdSet" id="grpidRazorNestedFilesEditor" priority="0x0310">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_CODEWIN"/>
       </Group>
     </Groups>
 
@@ -111,12 +130,16 @@
         </Strings>
       </Button>
 
-      <!-- Razor nested file commands -->
+      <!-- Razor nested file commands — default parent is Solution Explorer group;
+           CSS and JS are also placed in the editor group via CommandPlacements below.
+           CS in the editor uses the standard ViewCode (F7) command instead (see CommandPlacements). -->
       <Button guid="guidRazorNestedFilesCmdSet" id="cmdidAddOrViewNestedCsFile" priority="0x0100" type="Button">
         <Parent guid="guidRazorNestedFilesCmdSet" id="grpidRazorNestedFiles"/>
+        <Icon guid="ImageCatalogGuid" id="MarkupTag" />
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>TextChanges</CommandFlag>
+        <CommandFlag>IconIsMoniker</CommandFlag>
         <Strings>
           <ButtonText>Add or View Nested .cs File</ButtonText>
           <CanonicalName>AddOrViewNestedCsFile</CanonicalName>
@@ -127,9 +150,11 @@
 
       <Button guid="guidRazorNestedFilesCmdSet" id="cmdidAddOrViewNestedCssFile" priority="0x0101" type="Button">
         <Parent guid="guidRazorNestedFilesCmdSet" id="grpidRazorNestedFiles"/>
+        <Icon guid="ImageCatalogGuid" id="MarkupTag" />
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>TextChanges</CommandFlag>
+        <CommandFlag>IconIsMoniker</CommandFlag>
         <Strings>
           <ButtonText>Add or View Nested .css File</ButtonText>
           <CanonicalName>AddOrViewNestedCssFile</CanonicalName>
@@ -140,9 +165,11 @@
 
       <Button guid="guidRazorNestedFilesCmdSet" id="cmdidAddOrViewNestedJsFile" priority="0x0102" type="Button">
         <Parent guid="guidRazorNestedFilesCmdSet" id="grpidRazorNestedFiles"/>
+        <Icon guid="ImageCatalogGuid" id="MarkupTag" />
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>TextChanges</CommandFlag>
+        <CommandFlag>IconIsMoniker</CommandFlag>
         <Strings>
           <ButtonText>Add or View Nested .js File</ButtonText>
           <CanonicalName>AddOrViewNestedJsFile</CanonicalName>
@@ -150,14 +177,77 @@
           <CommandName>AddOrViewNestedJsFile</CommandName>
         </Strings>
       </Button>
+
+      <!-- Go To Page command - appears in nested file editors (.cshtml.cs, .cshtml.css, .cshtml.js, etc.)
+           to navigate back to the parent Razor file -->
+      <Button guid="guidRazorNestedFilesCmdSet" id="cmdidViewPageEditor" priority="0x0103" type="Button">
+        <Parent guid="guidRazorNestedFilesCmdSet" id="grpidRazorNestedFilesEditor"/>
+        <Icon guid="ImageCatalogGuid" id="MarkupTag" />
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <CommandFlag>TextChanges</CommandFlag>
+        <CommandFlag>IconIsMoniker</CommandFlag>
+        <Strings>
+          <ButtonText>View Page</ButtonText>
+          <CanonicalName>ViewPageEditor</CanonicalName>
+          <LocCanonicalName>ViewPageEditor</LocCanonicalName>
+          <CommandName>ViewPageEditor</CommandName>
+        </Strings>
+      </Button>
+
+      <!-- Editor-only command for adding a .cs file when it doesn't exist yet.
+           Uses a separate command ID from cmdidViewCode so it doesn't show the F7 keybinding. -->
+      <Button guid="guidRazorNestedFilesCmdSet" id="cmdidAddNestedCsFileEditor" priority="0x0100" type="Button">
+        <Parent guid="guidRazorNestedFilesCmdSet" id="grpidRazorNestedFilesEditor"/>
+        <Icon guid="ImageCatalogGuid" id="MarkupTag" />
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <CommandFlag>TextChanges</CommandFlag>
+        <CommandFlag>IconIsMoniker</CommandFlag>
+        <Strings>
+          <ButtonText>Add Nested .cs File</ButtonText>
+          <CanonicalName>AddNestedCsFileEditor</CanonicalName>
+          <LocCanonicalName>AddNestedCsFileEditor</LocCanonicalName>
+          <CommandName>AddNestedCsFileEditor</CommandName>
+        </Strings>
+      </Button>
     </Buttons>
   </Commands>
+
+  <!-- Place nested file commands also in the editor context menu group -->
+  <CommandPlacements>
+    <!-- Place the standard ViewCode (F7) command in the editor group so it shows with F7 keybinding.
+         Our handler intercepts it (with fallthrough to default ViewCode when not in a Razor file). -->
+    <CommandPlacement guid="guidVSStd97" id="cmdidViewCode" priority="0x0100">
+      <Parent guid="guidRazorNestedFilesCmdSet" id="grpidRazorNestedFilesEditor"/>
+    </CommandPlacement>
+    <CommandPlacement guid="guidRazorNestedFilesCmdSet" id="cmdidAddOrViewNestedCssFile" priority="0x0101">
+      <Parent guid="guidRazorNestedFilesCmdSet" id="grpidRazorNestedFilesEditor"/>
+    </CommandPlacement>
+    <CommandPlacement guid="guidRazorNestedFilesCmdSet" id="cmdidAddOrViewNestedJsFile" priority="0x0102">
+      <Parent guid="guidRazorNestedFilesCmdSet" id="grpidRazorNestedFilesEditor"/>
+    </CommandPlacement>
+    <CommandPlacement guid="guidRazorNestedFilesCmdSet" id="cmdidViewPageEditor" priority="0x0103">
+      <Parent guid="guidRazorNestedFilesCmdSet" id="grpidRazorNestedFiles"/>
+    </CommandPlacement>
+    <!-- Place View Page command on the CSS editor context menu -->
+    <CommandPlacement guid="guidRazorNestedFilesCmdSet" id="cmdidViewPageEditor" priority="0x0001">
+      <Parent guid="guidCssEditorCmdSet" id="groupGotoCss"/>
+    </CommandPlacement>
+  </CommandPlacements>
+
+  <!-- Declare that we handle the standard ViewCode command -->
+  <UsedCommands>
+    <UsedCommand guid="guidVSStd97" id="cmdidViewCode" />
+  </UsedCommands>
 
   <!-- Visibility constraints - nested file commands only appear when UI context is active -->
   <VisibilityConstraints>
     <VisibilityItem guid="guidRazorNestedFilesCmdSet" id="cmdidAddOrViewNestedCsFile" context="guidRazorFileContext" />
     <VisibilityItem guid="guidRazorNestedFilesCmdSet" id="cmdidAddOrViewNestedCssFile" context="guidRazorFileContext" />
     <VisibilityItem guid="guidRazorNestedFilesCmdSet" id="cmdidAddOrViewNestedJsFile" context="guidRazorFileContext" />
+    <VisibilityItem guid="guidRazorNestedFilesCmdSet" id="cmdidViewPageEditor" context="guidRazorFileContext" />
+    <VisibilityItem guid="guidRazorNestedFilesCmdSet" id="cmdidAddNestedCsFileEditor" context="guidRazorFileContext" />
   </VisibilityConstraints>
 
 </CommandTable>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
@@ -44,14 +44,14 @@ namespace Microsoft.VisualStudio.RazorExtension;
         expression: "RazorContentType",
         termNames: ["RazorContentType"],
         termValues: [$"ActiveEditorContentType:{RazorConstants.RazorLSPContentTypeName}"])]
-// Activate context menu commands when a .razor or .cshtml file is selected in Solution Explorer
+// Activate context menu commands when a .razor or .cshtml file (or their nested files) is selected or opened
 [ProvideAutoLoad(GuidRazorFileContextString, PackageAutoLoadFlags.BackgroundLoad)]
 [ProvideUIContextRule(
         contextGuid: GuidRazorFileContextString,
         name: "Razor File Selected",
-        expression: "DotNetCoreRazorProject & (RazorFile | CshtmlFile)",
-        termNames: ["DotNetCoreRazorProject", "RazorFile", "CshtmlFile"],
-        termValues: ["ActiveProjectCapability:DotNetCoreRazor", "HierSingleSelectionName:.razor$", "HierSingleSelectionName:.cshtml$"])]
+        expression: "DotNetCoreRazorProject & (RazorFile | CshtmlFile | RazorNestedFile | CshtmlNestedFile)",
+        termNames: ["DotNetCoreRazorProject", "RazorFile", "CshtmlFile", "RazorNestedFile", "CshtmlNestedFile"],
+        termValues: ["ActiveProjectCapability:DotNetCoreRazor", @"HierSingleSelectionName:\.razor$", @"HierSingleSelectionName:\.cshtml$", @"HierSingleSelectionName:\.razor\.", @"HierSingleSelectionName:\.cshtml\."])]
 internal sealed class RazorPackage : AsyncPackage
 {
     public const string PackageGuidString = "13b72f58-279e-49e0-a56d-296be02f0805";
@@ -63,9 +63,12 @@ internal sealed class RazorPackage : AsyncPackage
     // Razor nested files command set
     internal const string GuidRazorNestedFilesCmdSetString = "8B2B3C5D-6E4A-4F9B-9C8D-1A2B3C4D5E6F";
     internal static readonly Guid GuidRazorNestedFilesCmdSet = new Guid(GuidRazorNestedFilesCmdSetString);
+
     internal const uint CmdIdAddOrViewNestedCsFile = 0x0100;
     internal const uint CmdIdAddOrViewNestedCssFile = 0x0101;
     internal const uint CmdIdAddOrViewNestedJsFile = 0x0102;
+    internal const uint CmdIdViewPageEditor = 0x0203;
+    internal const uint CmdIdAddNestedCsFileEditor = 0x0204;
 
     // UI Context for when a .razor or .cshtml file is selected
     internal const string GuidRazorFileContextString = "7C3F2F9E-8D4A-4B6C-9E1F-5A8D7C6B3E2D";
@@ -162,7 +165,8 @@ internal sealed class RazorPackage : AsyncPackage
     }
 
     /// <summary>
-    /// Registers the nested file commands (CSS, C#, Javascript) in the menu command service.
+    /// Registers the nested file commands (CSS, C#, Javascript) in the menu command service
+    /// for both Solution Explorer and editor context menus.
     /// </summary>
     private void RegisterNestedFileCommands(OleMenuCommandService mcs)
     {
@@ -171,27 +175,39 @@ internal sealed class RazorPackage : AsyncPackage
         var componentModel = (IComponentModel)GetGlobalService(typeof(SComponentModel));
         var requestInvoker = new Lazy<LSPRequestInvokerWrapper>(() => componentModel.GetService<LSPRequestInvokerWrapper>());
 
-        // Create command handlers
-        var csharpHandler = new NestedFileCommandHandler(this, ".cs", NestedFileKind.CSharp, requestInvoker);
-        var cssHandler = new NestedFileCommandHandler(this, ".css", NestedFileKind.Css, requestInvoker);
-        var javascriptHandler = new NestedFileCommandHandler(this, ".js", NestedFileKind.JavaScript, requestInvoker);
+        // Add nested file commands
+        AddMenuNestedFileCommand(".cs", NestedFileKind.CSharp, (int)CmdIdAddOrViewNestedCsFile, GuidRazorNestedFilesCmdSet);
+        AddMenuNestedFileCommand(".css", NestedFileKind.Css, (int)CmdIdAddOrViewNestedCssFile, GuidRazorNestedFilesCmdSet);
+        AddMenuNestedFileCommand(".js", NestedFileKind.JavaScript, (int)CmdIdAddOrViewNestedJsFile, GuidRazorNestedFilesCmdSet);
 
-        // .cs Nested File Command
-        var csharpCommandId = new CommandID(GuidRazorNestedFilesCmdSet, (int)CmdIdAddOrViewNestedCsFile);
-        var csharpCommand = new OleMenuCommand(csharpHandler.Execute, csharpCommandId);
-        csharpCommand.BeforeQueryStatus += csharpHandler.OnBeforeQueryStatus;
-        mcs.AddCommand(csharpCommand);
+        // .cs View Code (Editor) — override standard ViewCode (F7) command so VS displays the F7
+        // keybinding annotation. Only shows when .cs file exists; yields when missing so the
+        // cmdidAddNestedCsFileEditor command (without F7) handles the "Add" case instead.
+        // When not in a Razor file, sets Supported = false to fall through to default ViewCode.
+        AddMenuNestedFileCommand(".cs", NestedFileKind.CSharp, (int)VSConstants.VSStd97CmdID.ViewCode, VSConstants.GUID_VSStandardCommandSet97, allowExternalHandlers: true);
 
-        // .css Nested File Command
-        var cssCommandId = new CommandID(GuidRazorNestedFilesCmdSet, (int)CmdIdAddOrViewNestedCssFile);
-        var cssCommand = new OleMenuCommand(cssHandler.Execute, cssCommandId);
-        cssCommand.BeforeQueryStatus += cssHandler.OnBeforeQueryStatus;
-        mcs.AddCommand(cssCommand);
+        // .cs Add Code (Editor) — shows "Add .cs file" only when the .cs doesn't exist yet.
+        // Uses a separate command ID from ViewCode so it doesn't display the F7 keybinding.
+        AddMenuNestedFileCommand(".cs", NestedFileKind.CSharp, (int)CmdIdAddNestedCsFileEditor, GuidRazorNestedFilesCmdSet, hideWhenFileExists: true);
 
-        // .js Nested File Command
-        var javascriptCommandId = new CommandID(GuidRazorNestedFilesCmdSet, (int)CmdIdAddOrViewNestedJsFile);
-        var javascriptCommand = new OleMenuCommand(javascriptHandler.Execute, javascriptCommandId);
-        javascriptCommand.BeforeQueryStatus += javascriptHandler.OnBeforeQueryStatus;
-        mcs.AddCommand(javascriptCommand);
+        // View Page Command (Editor) — appears in nested file editors (.cshtml.cs, etc.)
+        var viewPageHandler = new ViewPageCommandHandler(this);
+        AddMenuCommand((int)CmdIdViewPageEditor, GuidRazorNestedFilesCmdSet, viewPageHandler.Execute, viewPageHandler.OnBeforeQueryStatus);
+
+        return;
+
+        void AddMenuCommand(int cmdId, Guid cmdSet, EventHandler executeHandler, EventHandler queryStatusHandler)
+        {
+            var cmdID = new CommandID(cmdSet, cmdId);
+            var command = new OleMenuCommand(executeHandler, cmdID);
+            command.BeforeQueryStatus += queryStatusHandler;
+            mcs.AddCommand(command);
+        }
+
+        void AddMenuNestedFileCommand(string fileExtension, NestedFileKind fileKind, int cmdId, Guid cmdSet, bool allowExternalHandlers = false, bool hideWhenFileExists = false)
+        {
+            var handler = new NestedFileCommandHandler(this, fileExtension, fileKind, requestInvoker, allowExternalHandlers, hideWhenFileExists);
+            AddMenuCommand(cmdId, cmdSet, handler.Execute, handler.OnBeforeQueryStatus);
+        }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
@@ -176,19 +176,19 @@ internal sealed class RazorPackage : AsyncPackage
         var requestInvoker = new Lazy<LSPRequestInvokerWrapper>(() => componentModel.GetService<LSPRequestInvokerWrapper>());
 
         // Add nested file commands
-        AddMenuNestedFileCommand(".cs", NestedFileKind.CSharp, (int)CmdIdAddOrViewNestedCsFile, GuidRazorNestedFilesCmdSet);
-        AddMenuNestedFileCommand(".css", NestedFileKind.Css, (int)CmdIdAddOrViewNestedCssFile, GuidRazorNestedFilesCmdSet);
-        AddMenuNestedFileCommand(".js", NestedFileKind.JavaScript, (int)CmdIdAddOrViewNestedJsFile, GuidRazorNestedFilesCmdSet);
+        AddMenuNestedFileCommand(".cs", NestedFileKind.CSharp, (int)CmdIdAddOrViewNestedCsFile, GuidRazorNestedFilesCmdSet, allowExternalHandlers: false, hideWhenFileExists: false);
+        AddMenuNestedFileCommand(".css", NestedFileKind.Css, (int)CmdIdAddOrViewNestedCssFile, GuidRazorNestedFilesCmdSet, allowExternalHandlers: false, hideWhenFileExists: false);
+        AddMenuNestedFileCommand(".js", NestedFileKind.JavaScript, (int)CmdIdAddOrViewNestedJsFile, GuidRazorNestedFilesCmdSet, allowExternalHandlers: false, hideWhenFileExists: false);
 
         // .cs View Code (Editor) — override standard ViewCode (F7) command so VS displays the F7
         // keybinding annotation. Only shows when .cs file exists; yields when missing so the
         // cmdidAddNestedCsFileEditor command (without F7) handles the "Add" case instead.
         // When not in a Razor file, sets Supported = false to fall through to default ViewCode.
-        AddMenuNestedFileCommand(".cs", NestedFileKind.CSharp, (int)VSConstants.VSStd97CmdID.ViewCode, VSConstants.GUID_VSStandardCommandSet97, allowExternalHandlers: true);
+        AddMenuNestedFileCommand(".cs", NestedFileKind.CSharp, (int)VSConstants.VSStd97CmdID.ViewCode, VSConstants.GUID_VSStandardCommandSet97, allowExternalHandlers: true, hideWhenFileExists: false);
 
         // .cs Add Code (Editor) — shows "Add .cs file" only when the .cs doesn't exist yet.
         // Uses a separate command ID from ViewCode so it doesn't display the F7 keybinding.
-        AddMenuNestedFileCommand(".cs", NestedFileKind.CSharp, (int)CmdIdAddNestedCsFileEditor, GuidRazorNestedFilesCmdSet, hideWhenFileExists: true);
+        AddMenuNestedFileCommand(".cs", NestedFileKind.CSharp, (int)CmdIdAddNestedCsFileEditor, GuidRazorNestedFilesCmdSet, allowExternalHandlers: false, hideWhenFileExists: true);
 
         // View Page Command (Editor) — appears in nested file editors (.cshtml.cs, etc.)
         var viewPageHandler = new ViewPageCommandHandler(this);
@@ -204,7 +204,7 @@ internal sealed class RazorPackage : AsyncPackage
             mcs.AddCommand(command);
         }
 
-        void AddMenuNestedFileCommand(string fileExtension, NestedFileKind fileKind, int cmdId, Guid cmdSet, bool allowExternalHandlers = false, bool hideWhenFileExists = false)
+        void AddMenuNestedFileCommand(string fileExtension, NestedFileKind fileKind, int cmdId, Guid cmdSet, bool allowExternalHandlers, bool hideWhenFileExists)
         {
             var handler = new NestedFileCommandHandler(this, fileExtension, fileKind, requestInvoker, allowExternalHandlers, hideWhenFileExists);
             AddMenuCommand(cmdId, cmdSet, handler.Execute, handler.OnBeforeQueryStatus);

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Resources.resx
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Resources.resx
@@ -126,4 +126,7 @@
   <data name="View_Nested_File" xml:space="preserve">
     <value>View {0}</value>
   </data>
+  <data name="View_Page" xml:space="preserve">
+    <value>View Page</value>
+  </data>
 </root>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.cs.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.cs.xlf
@@ -17,6 +17,21 @@
         <target state="translated">Zobrazit odkazované pomocné elementy značek</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|ButtonText">
+        <source>Add Nested .cs File</source>
+        <target state="new">Add Nested .cs File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|CommandName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|LocCanonicalName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidAddOrViewNestedCsFile|ButtonText">
         <source>Add or View Nested .cs File</source>
         <target state="translated">Přidat nebo zobrazit vnořený soubor .cs</target>
@@ -85,6 +100,21 @@
       <trans-unit id="cmdidShowGeneratedHtml|ButtonText">
         <source>Show Generated HTML</source>
         <target state="translated">Zobrazit vygenerovaný kód HTML</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|ButtonText">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|CommandName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|LocCanonicalName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
         <note />
       </trans-unit>
       <trans-unit id="menuidToolWindowToolbar|ButtonText">

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.de.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.de.xlf
@@ -17,6 +17,21 @@
         <target state="translated">Referenzierte Tag-Hilfsprogramme anzeigen</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|ButtonText">
+        <source>Add Nested .cs File</source>
+        <target state="new">Add Nested .cs File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|CommandName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|LocCanonicalName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidAddOrViewNestedCsFile|ButtonText">
         <source>Add or View Nested .cs File</source>
         <target state="translated">Geschachtelte .cs-Datei hinzufügen oder anzeigen</target>
@@ -85,6 +100,21 @@
       <trans-unit id="cmdidShowGeneratedHtml|ButtonText">
         <source>Show Generated HTML</source>
         <target state="translated">Generiertes HTML anzeigen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|ButtonText">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|CommandName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|LocCanonicalName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
         <note />
       </trans-unit>
       <trans-unit id="menuidToolWindowToolbar|ButtonText">

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.es.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.es.xlf
@@ -17,6 +17,21 @@
         <target state="translated">Mostrar asistentes de etiquetas a los que se hace referencia</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|ButtonText">
+        <source>Add Nested .cs File</source>
+        <target state="new">Add Nested .cs File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|CommandName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|LocCanonicalName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidAddOrViewNestedCsFile|ButtonText">
         <source>Add or View Nested .cs File</source>
         <target state="translated">Agregar o ver archivo de .cs anidado</target>
@@ -85,6 +100,21 @@
       <trans-unit id="cmdidShowGeneratedHtml|ButtonText">
         <source>Show Generated HTML</source>
         <target state="translated">Mostrar HTML generado</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|ButtonText">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|CommandName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|LocCanonicalName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
         <note />
       </trans-unit>
       <trans-unit id="menuidToolWindowToolbar|ButtonText">

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.fr.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.fr.xlf
@@ -17,6 +17,21 @@
         <target state="translated">Afficher les application d’assistance de balise référencée</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|ButtonText">
+        <source>Add Nested .cs File</source>
+        <target state="new">Add Nested .cs File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|CommandName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|LocCanonicalName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidAddOrViewNestedCsFile|ButtonText">
         <source>Add or View Nested .cs File</source>
         <target state="translated">Ajouter ou afficher un fichier .cs imbriqué</target>
@@ -85,6 +100,21 @@
       <trans-unit id="cmdidShowGeneratedHtml|ButtonText">
         <source>Show Generated HTML</source>
         <target state="translated">Afficher le code HTML généré</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|ButtonText">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|CommandName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|LocCanonicalName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
         <note />
       </trans-unit>
       <trans-unit id="menuidToolWindowToolbar|ButtonText">

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.it.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.it.xlf
@@ -17,6 +17,21 @@
         <target state="translated">Mostra gli helper tag di riferimento</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|ButtonText">
+        <source>Add Nested .cs File</source>
+        <target state="new">Add Nested .cs File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|CommandName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|LocCanonicalName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidAddOrViewNestedCsFile|ButtonText">
         <source>Add or View Nested .cs File</source>
         <target state="translated">Aggiungere o visualizzare un file .cs annidato</target>
@@ -85,6 +100,21 @@
       <trans-unit id="cmdidShowGeneratedHtml|ButtonText">
         <source>Show Generated HTML</source>
         <target state="translated">Mostra HTML generato</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|ButtonText">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|CommandName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|LocCanonicalName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
         <note />
       </trans-unit>
       <trans-unit id="menuidToolWindowToolbar|ButtonText">

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.ja.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.ja.xlf
@@ -17,6 +17,21 @@
         <target state="translated">参照タグ ヘルパーの表示</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|ButtonText">
+        <source>Add Nested .cs File</source>
+        <target state="new">Add Nested .cs File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|CommandName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|LocCanonicalName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidAddOrViewNestedCsFile|ButtonText">
         <source>Add or View Nested .cs File</source>
         <target state="translated">入れ子になった .cs ファイルの追加または表示</target>
@@ -85,6 +100,21 @@
       <trans-unit id="cmdidShowGeneratedHtml|ButtonText">
         <source>Show Generated HTML</source>
         <target state="translated">生成された HTML を表示</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|ButtonText">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|CommandName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|LocCanonicalName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
         <note />
       </trans-unit>
       <trans-unit id="menuidToolWindowToolbar|ButtonText">

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.ko.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.ko.xlf
@@ -17,6 +17,21 @@
         <target state="translated">참조된 태그 도우미 표시</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|ButtonText">
+        <source>Add Nested .cs File</source>
+        <target state="new">Add Nested .cs File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|CommandName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|LocCanonicalName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidAddOrViewNestedCsFile|ButtonText">
         <source>Add or View Nested .cs File</source>
         <target state="translated">중첩된 .cs 파일 추가 또는 보기</target>
@@ -85,6 +100,21 @@
       <trans-unit id="cmdidShowGeneratedHtml|ButtonText">
         <source>Show Generated HTML</source>
         <target state="translated">생성된 HTML 표시</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|ButtonText">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|CommandName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|LocCanonicalName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
         <note />
       </trans-unit>
       <trans-unit id="menuidToolWindowToolbar|ButtonText">

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.pl.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.pl.xlf
@@ -17,6 +17,21 @@
         <target state="translated">Pokaż pomocników tagów, których dotyczy odwołanie</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|ButtonText">
+        <source>Add Nested .cs File</source>
+        <target state="new">Add Nested .cs File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|CommandName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|LocCanonicalName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidAddOrViewNestedCsFile|ButtonText">
         <source>Add or View Nested .cs File</source>
         <target state="translated">Dodaj lub wyświetl zagnieżdżony plik .cs</target>
@@ -85,6 +100,21 @@
       <trans-unit id="cmdidShowGeneratedHtml|ButtonText">
         <source>Show Generated HTML</source>
         <target state="translated">Pokaż wygenerowany kod HTML</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|ButtonText">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|CommandName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|LocCanonicalName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
         <note />
       </trans-unit>
       <trans-unit id="menuidToolWindowToolbar|ButtonText">

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.pt-BR.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.pt-BR.xlf
@@ -17,6 +17,21 @@
         <target state="translated">Mostrar auxiliares de marcas referenciados</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|ButtonText">
+        <source>Add Nested .cs File</source>
+        <target state="new">Add Nested .cs File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|CommandName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|LocCanonicalName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidAddOrViewNestedCsFile|ButtonText">
         <source>Add or View Nested .cs File</source>
         <target state="translated">Adicionar ou Exibir Arquivo .cs Aninhado</target>
@@ -85,6 +100,21 @@
       <trans-unit id="cmdidShowGeneratedHtml|ButtonText">
         <source>Show Generated HTML</source>
         <target state="translated">Mostrar HTML Gerado</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|ButtonText">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|CommandName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|LocCanonicalName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
         <note />
       </trans-unit>
       <trans-unit id="menuidToolWindowToolbar|ButtonText">

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.ru.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.ru.xlf
@@ -17,6 +17,21 @@
         <target state="translated">Показать указанные тег-хелперы</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|ButtonText">
+        <source>Add Nested .cs File</source>
+        <target state="new">Add Nested .cs File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|CommandName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|LocCanonicalName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidAddOrViewNestedCsFile|ButtonText">
         <source>Add or View Nested .cs File</source>
         <target state="translated">Добавить или просмотреть вложенный CS-файл</target>
@@ -85,6 +100,21 @@
       <trans-unit id="cmdidShowGeneratedHtml|ButtonText">
         <source>Show Generated HTML</source>
         <target state="translated">Показать созданный HTML</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|ButtonText">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|CommandName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|LocCanonicalName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
         <note />
       </trans-unit>
       <trans-unit id="menuidToolWindowToolbar|ButtonText">

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.tr.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.tr.xlf
@@ -17,6 +17,21 @@
         <target state="translated">Başvurulan Etiket Yardımcılarını Göster</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|ButtonText">
+        <source>Add Nested .cs File</source>
+        <target state="new">Add Nested .cs File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|CommandName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|LocCanonicalName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidAddOrViewNestedCsFile|ButtonText">
         <source>Add or View Nested .cs File</source>
         <target state="translated">İç İçe .cs Dosyası Ekle veya Görüntüle</target>
@@ -85,6 +100,21 @@
       <trans-unit id="cmdidShowGeneratedHtml|ButtonText">
         <source>Show Generated HTML</source>
         <target state="translated">Oluşturan HTML’yi Göster</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|ButtonText">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|CommandName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|LocCanonicalName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
         <note />
       </trans-unit>
       <trans-unit id="menuidToolWindowToolbar|ButtonText">

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.zh-Hans.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.zh-Hans.xlf
@@ -17,6 +17,21 @@
         <target state="translated">显示引用的标记帮助程序</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|ButtonText">
+        <source>Add Nested .cs File</source>
+        <target state="new">Add Nested .cs File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|CommandName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|LocCanonicalName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidAddOrViewNestedCsFile|ButtonText">
         <source>Add or View Nested .cs File</source>
         <target state="translated">添加或查看嵌套的 .cs 文件</target>
@@ -85,6 +100,21 @@
       <trans-unit id="cmdidShowGeneratedHtml|ButtonText">
         <source>Show Generated HTML</source>
         <target state="translated">显示生成的 HTML</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|ButtonText">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|CommandName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|LocCanonicalName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
         <note />
       </trans-unit>
       <trans-unit id="menuidToolWindowToolbar|ButtonText">

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.zh-Hant.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/RazorContextMenu.vsct.zh-Hant.xlf
@@ -17,6 +17,21 @@
         <target state="translated">顯示參照的標籤協助程式</target>
         <note />
       </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|ButtonText">
+        <source>Add Nested .cs File</source>
+        <target state="new">Add Nested .cs File</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|CommandName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNestedCsFileEditor|LocCanonicalName">
+        <source>AddNestedCsFileEditor</source>
+        <target state="new">AddNestedCsFileEditor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cmdidAddOrViewNestedCsFile|ButtonText">
         <source>Add or View Nested .cs File</source>
         <target state="translated">新增或檢視巢狀 .cs 檔案</target>
@@ -85,6 +100,21 @@
       <trans-unit id="cmdidShowGeneratedHtml|ButtonText">
         <source>Show Generated HTML</source>
         <target state="translated">顯示已產生的 HTML</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|ButtonText">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|CommandName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidViewPageEditor|LocCanonicalName">
+        <source>ViewPageEditor</source>
+        <target state="new">ViewPageEditor</target>
         <note />
       </trans-unit>
       <trans-unit id="menuidToolWindowToolbar|ButtonText">

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.cs.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.cs.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Zobrazit {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Page">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.de.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.de.xlf
@@ -17,6 +17,11 @@
         <target state="translated">{0} anzeigen</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Page">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.es.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.es.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Ver {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Page">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.fr.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.fr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Afficher {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Page">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.it.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.it.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Visualizzare {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Page">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.ja.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.ja.xlf
@@ -17,6 +17,11 @@
         <target state="translated">{0} の表示</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Page">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.ko.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.ko.xlf
@@ -17,6 +17,11 @@
         <target state="translated">{0} 보기</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Page">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.pl.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.pl.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Wyświetl {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Page">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.pt-BR.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.pt-BR.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Exibir {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Page">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.ru.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.ru.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Просмотреть {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Page">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.tr.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.tr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">{0} öğesini görüntüle</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Page">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.zh-Hans.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.zh-Hans.xlf
@@ -17,6 +17,11 @@
         <target state="translated">查看 {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Page">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.zh-Hant.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/Resources.zh-Hant.xlf
@@ -17,6 +17,11 @@
         <target state="translated">檢視 {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="View_Page">
+        <source>View Page</source>
+        <target state="new">View Page</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/ViewCodeCommandHandlerTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/ViewCodeCommandHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -74,6 +74,30 @@ public class ViewCodeCommandHandlerTests(ITestOutputHelper testOutput) : Tooling
     public void RazorFile_NoCSharpFile_NotAvailable()
     {
         var razorFilePath = "nonexistent.razor";
+
+        var (handler, args) = CreateHandlerAndArgs(razorFilePath);
+
+        var result = handler.GetCommandState(args);
+
+        Assert.False(result.IsAvailable);
+    }
+
+    [UIFact]
+    public void ImportsRazorFile_NotAvailable()
+    {
+        using var _ = CreateTestFiles("_Imports.razor", out var razorFilePath);
+
+        var (handler, args) = CreateHandlerAndArgs(razorFilePath);
+
+        var result = handler.GetCommandState(args);
+
+        Assert.False(result.IsAvailable);
+    }
+
+    [UIFact]
+    public void ViewImportsCshtmlFile_NotAvailable()
+    {
+        using var _ = CreateTestFiles("_ViewImports.cshtml", out var razorFilePath);
 
         var (handler, args) = CreateHandlerAndArgs(razorFilePath);
 


### PR DESCRIPTION
Finishes work for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1903761 Earlier PRs in support of this ticket:
  https://github.com/dotnet/razor/pull/12981
  https://devdiv.visualstudio.com/DevDiv/_git/WebTools/pullrequest/725194
  https://devdiv.visualstudio.com/DevDiv/_git/WebTools/pullrequest/725955

Add editor context menu commands for Razor nested files alongside the existing Solution Explorer commands. Uses VSCT CommandPlacements to share CSS/JS command IDs across both menus, and IVsMonitorSelection.GetCurrentSelection to resolve the active file (which tracks the active window frame, not just Solution Explorer tree selection).

Key changes:

 - Unified NestedFileCommandHandler serves both Solution Explorer and editor menus via shared command IDs and SelectionHelper for selection/UIContext queries
 - Added editor context menu group (grpidRazorNestedFilesEditor) on IDM_VS_CTXT_CODEWIN with CSS/JS commands placed via CommandPlacements
 - For .cs in editor: intercept standard ViewCode (F7) command via UsedCommands so the F7 keybinding indicator displays automatically. Handler yields (Supported=false) to fall through to default ViewCode when not in a Razor file
 - Added separate cmdidAddNestedCsFileEditor for the "Add .cs" case in editor, so it appears without the F7 keybinding when the .cs file doesn't exist
 - Added "View Page" command for navigating from nested files back to the parent Razor file, placed in editor, Solution Explorer, and CSS editor context menus
 - Extended UIContextRule to activate for nested files (.razor.* and .cshtml.*) in addition to .razor and .cshtml
 - ViewCodeCommandHandler (MEF F7 handler): returns Unavailable when .cs doesn't exist, excludes _Imports.razor and _ViewImports.cshtml, uses FileExistsHelper cache for per-keystroke performance
 - Added View_Page resource with translations, cleaned up unused Add_Code resource
 - Updated tests for new constructor signature and behavior