### PR TITLE
Fix Watson crash in ToRazorTextDocumentIdentifier when DocumentUri is unparseable

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/SignatureHelp/CohostSignatureHelpEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/SignatureHelp/CohostSignatureHelpEndpoint.cs
@@ -55,7 +55,7 @@ internal sealed class CohostSignatureHelpEndpoint(
     }
 
     protected override RazorTextDocumentIdentifier? GetRazorTextDocumentIdentifier(SignatureHelpParams request)
-        => new RazorTextDocumentIdentifier(request.TextDocument.DocumentUri.GetRequiredParsedUri(), (request.TextDocument as VSTextDocumentIdentifier)?.ProjectContext?.Id);
+        => request.TextDocument.ToRazorTextDocumentIdentifier();
 
     protected async override Task<SignatureHelp?> HandleRequestAsync(SignatureHelpParams request, TextDocument razorDocument, CancellationToken cancellationToken)
     {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/SignatureHelp/CohostSignatureHelpEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/SignatureHelp/CohostSignatureHelpEndpoint.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Cohost;
 using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Settings;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/LspExtensions_TextDocumentIdentifier.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/LspExtensions_TextDocumentIdentifier.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
-using Microsoft.CodeAnalysis.Razor;
 
 namespace Roslyn.LanguageServer.Protocol;
 
@@ -35,6 +34,10 @@ internal static partial class LspExtensions
         };
     }
 
-    public static RazorTextDocumentIdentifier ToRazorTextDocumentIdentifier(this TextDocumentIdentifier textDocumentIdentifier)
-        => new RazorTextDocumentIdentifier(textDocumentIdentifier.DocumentUri.GetRequiredParsedUri(), (textDocumentIdentifier as VSTextDocumentIdentifier)?.ProjectContext?.Id);
+    public static RazorTextDocumentIdentifier? ToRazorTextDocumentIdentifier(this TextDocumentIdentifier textDocumentIdentifier)
+    {
+        return textDocumentIdentifier.DocumentUri.ParsedUri is Uri parsedUri
+            ? new RazorTextDocumentIdentifier(parsedUri, (textDocumentIdentifier as VSTextDocumentIdentifier)?.ProjectContext?.Id)
+            : null;
+    }
 }

--- a/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Endpoints/RazorDocumentClosedEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Endpoints/RazorDocumentClosedEndpoint.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,7 +9,6 @@ using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Threading;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 
 namespace Microsoft.VisualStudioCode.RazorExtension.Endpoints;
@@ -30,7 +30,14 @@ internal class RazorDocumentClosedEndpoint(IHtmlDocumentSynchronizer htmlDocumen
 
     protected override Task<VoidResult> HandleRequestAsync(TextDocumentIdentifier textDocument, RazorCohostRequestContext requestContext, CancellationToken cancellationToken)
     {
-        _htmlDocumentSynchronizer.DocumentRemoved(textDocument.DocumentUri.GetRequiredParsedUri(), cancellationToken);
+        // ParsedUri can be null when the URI string from the client isn't parseable by System.Uri.
+        // This is safe to skip because HtmlDocumentSynchronizer only tracks documents that were
+        // opened with a valid URI (via TrySynchronizeAsync), so there's no entry to remove.
+        if (textDocument.DocumentUri.ParsedUri is Uri parsedUri)
+        {
+            _htmlDocumentSynchronizer.DocumentRemoved(parsedUri, cancellationToken);
+        }
+
         return SpecializedTasks.Default<VoidResult>();
     }
 }


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2900155

DocumentUri.ParsedUri can be null when System.Uri cannot parse the URI string received from the client (e.g. unusual URI schemes in VS Code). RazorDocumentClosedEndpoint.GetRazorTextDocumentIdentifier called GetRequiredParsedUri() which threw InvalidOperationException via AssumeNotNull.

Changes:
 - ToRazorTextDocumentIdentifier now returns null when ParsedUri is null instead of throwing
 - RazorDocumentClosedEndpoint.HandleRequestAsync guards the DocumentRemoved call, skipping it when ParsedUri is null. This is safe because HtmlDocumentSynchronizer only tracks documents opened with valid URIs via TrySynchronizeAsync.
 - CohostSignatureHelpEndpoint now uses ToRazorTextDocumentIdentifier instead of inlining the same logic with GetRequiredParsedUri