### PR TITLE
Fix NRE in CohostDocumentPullDiagnosticsEndpointBase.GetDiagnosticsAsync

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Diagnostics/CohostDocumentPullDiagnosticsEndpointBase.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Diagnostics/CohostDocumentPullDiagnosticsEndpointBase.cs
@@ -90,7 +90,7 @@ internal abstract class CohostDocumentPullDiagnosticsEndpointBase<TRequest, TRes
             (service, solutionInfo, cancellationToken) => service.GetDiagnosticsAsync(solutionInfo, razorDocument.Id, csharpDiagnostics, htmlDiagnostics, cancellationToken),
             cancellationToken).ConfigureAwait(false);
 
-        if (cancellationToken.IsCancellationRequested)
+        if (cancellationToken.IsCancellationRequested || diagnostics.IsDefault)
         {
             return null;
         }


### PR DESCRIPTION
When the remote service call fails, TryInvokeAsync catches the exception and returns default. For ImmutableArray<T>, default has a null internal array, so accessing .Length throws NullReferenceException. The existing guard only checked cancellationToken.IsCancellationRequested, which handles the cancellation path but not the error path.

 Add a diagnostics.IsDefault check to return null when the remote call fails, matching the existing cancellation behavior.

 Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2601367 -- (111K hits across 18.0-18.7).