### PR TITLE
Mop up a few remaining feedback items from #13016

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeRenderingContext.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeRenderingContext.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 
@@ -98,9 +97,16 @@ public sealed class CodeRenderingContext : IDisposable
 
         // Filter out diagnostics whose warning level exceeds the configured level.
         // Diagnostics with level 0 are always reported regardless of the configured level.
-        return _diagnostics
-            .Where(d => d.WarningLevel <= warningLevel)
-            .OrderByAsArray(static d => d.Span.AbsoluteIndex);
+        using var filtered = new PooledArrayBuilder<RazorDiagnostic>(capacity: _diagnostics.Count);
+        foreach (var diagnostic in _diagnostics)
+        {
+            if (diagnostic.WarningLevel <= warningLevel)
+            {
+                filtered.Add(diagnostic);
+            }
+        }
+
+        return filtered.ToImmutableOrderedBy(static d => d.Span.AbsoluteIndex);
     }
 
     public void AddSourceMappingFor(IntermediateNode node)

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorDiagnosticDescriptor.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorDiagnosticDescriptor.cs
@@ -43,6 +43,7 @@ public sealed record RazorDiagnosticDescriptor
         WarningLevel = warningLevel;
     }
 
-    private string DebuggerToString()
-        => $"""Error "{Id}" (level {WarningLevel}): "{MessageFormat}""";
+    private string DebuggerToString() => $"""
+        Error "{Id}" (level {WarningLevel}): "{MessageFormat}"
+        """;
 }


### PR DESCRIPTION
Address remaining review feedback from the warning waves PR (#13016):

- Revert GetDiagnostics to PooledArrayBuilder approach for better performance in high-traffic path
- Fix DebuggerToString to use multiline raw interpolated string matching original format