### PR TITLE
Fix active Component Governance alerts

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -106,7 +106,7 @@
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataPackageVersion)" />
     <PackageVersion Include="System.Resources.Extensions" Version="10.0.1" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.2" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.3" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="10.0.1" />
     <PackageVersion Include="System.Text.Json" Version="10.0.1" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "10.0.105",
+    "dotnet": "10.0.106",
     "runtimes": {
       "dotnet": [
         "2.1.30",
@@ -16,7 +16,7 @@
     }
   },
   "sdk": {
-    "version": "10.0.105",
+    "version": "10.0.106",
     "allowPrerelease": false,
     "rollForward": "latestPatch"
   },


### PR DESCRIPTION
## Summary
- bump System.Security.Cryptography.Xml from 8.0.2 to 8.0.3
- update the pinned SDK/tools patch from 10.0.105 to 10.0.106
- address the active Component Governance alerts for Razor