### PR TITLE
Fix formatting for self-closing multiline templates

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPass.CSharpDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPass.CSharpDocumentGenerator.cs
@@ -615,15 +615,8 @@ internal partial class CSharpFormattingPass
                 // about single-line elements here, because these Visit methods only ever see the first node on a line.
                 _builder.Append('}');
 
-                // If this is the last line of a multi-line CSharp template (ie, RenderFragment), and the semicolon that ends
-                // if is on the same line, then we need to close out the lambda expression that we started when we opened it.
-                // If the semicolon is on the next line, then we'll take care of that when we get to it.
-                if (node.Parent.Parent.Parent is CSharpTemplateBlockSyntax template &&
-                    GetLineNumber(template.GetLastToken()) == GetLineNumber(_currentToken) &&
-                    GetLineNumber(template.GetFirstToken()) != GetLineNumber(template.GetLastToken()) &&
-                    template.GetLastToken().GetNextToken() is { } semiColonToken &&
-                    semiColonToken.Content == ";" &&
-                    GetLineNumber(semiColonToken) == GetLineNumber(_currentToken))
+                // Close multiline template lambdas when the template ends on this line.
+                if (TryGetMultilineTemplateClosure(node, out var appendSemicolon) && appendSemicolon)
                 {
                     _builder.Append(';');
                 }
@@ -743,6 +736,14 @@ internal partial class CSharpFormattingPass
                 if (RazorSyntaxFacts.IsAttributeName(node, out var startTag))
                 {
                     GetAttributeIndentation(startTag, out var htmlIndentLevel, out var additionalIndentation);
+
+                    // Self-closing tags can be the last line of a multiline template, so emit the synthetic close here.
+                    if (startTag.IsSelfClosing() &&
+                        GetLineNumber(startTag.CloseAngle) == _currentLine.LineNumber &&
+                        TryGetMultilineTemplateClosure(startTag, out _))
+                    {
+                        return EmitSyntheticLambdaBodyCloseLine(startTag, htmlIndentLevel, additionalIndentation);
+                    }
 
                     if (ElementHasSignificantWhitespace(startTag) &&
                         GetLineNumber(node) == GetLineNumber(startTag.CloseAngle))
@@ -1147,6 +1148,21 @@ internal partial class CSharpFormattingPass
                 return CreateLineInfo(skipNextLineIfBrace: true);
             }
 
+            private LineInfo EmitSyntheticLambdaBodyCloseLine(BaseMarkupStartTagSyntax startTag, int htmlIndentLevel, int? additionalIndentation)
+            {
+                _builder.Append('}');
+
+                // Preserve trailing C# like `/>);` for self-closing multiline templates.
+                var closeAngleEnd = startTag.CloseAngle.Position + startTag.CloseAngle.Content.Length;
+                if (closeAngleEnd < _currentLine.End)
+                {
+                    _builder.Append(_sourceText.ToString(TextSpan.FromBounds(closeAngleEnd, _currentLine.End)));
+                }
+
+                _builder.AppendLine();
+                return CreateLineInfo(htmlIndentLevel: htmlIndentLevel, additionalIndentation: additionalIndentation);
+            }
+
             private int AppendSyntheticLambdaBodyStart()
             {
                 _builder.AppendLine(SyntheticLambdaBodyStart);
@@ -1161,6 +1177,39 @@ internal partial class CSharpFormattingPass
                 return _csharpSyntaxFormattingOptions?.NewLines.IsFlagSet(RazorNewLinePlacement.BeforeOpenBraceInLambdaExpressionBody) ?? true
                     ? SyntheticLambdaSignatureLength
                     : SyntheticLambdaBodyStart.Length;
+            }
+
+            private bool TryGetMultilineTemplateClosure(RazorSyntaxNode node, out bool appendSemicolon)
+            {
+                appendSemicolon = false;
+
+                // Only the last line of a multiline C# template closes the synthetic lambda body.
+                if (GetContainingTemplate(node) is not { } template ||
+                    GetLineNumber(template.GetFirstToken()) == GetLineNumber(template.GetLastToken()) ||
+                    GetLineNumber(template.GetLastToken()) != _currentLine.LineNumber)
+                {
+                    return false;
+                }
+
+                // Preserve a same-line semicolon when the template ends as `</div>);` or `/>);`.
+                appendSemicolon = template.GetLastToken().GetNextToken() is { } semiColonToken &&
+                    semiColonToken.Content == ";" &&
+                    GetLineNumber(semiColonToken) == _currentLine.LineNumber;
+
+                return true;
+            }
+
+            private static CSharpTemplateBlockSyntax? GetContainingTemplate(RazorSyntaxNode node)
+            {
+                for (var current = node; current is not null; current = current.Parent as RazorSyntaxNode)
+                {
+                    if (current is CSharpTemplateBlockSyntax template)
+                    {
+                        return template;
+                    }
+                }
+
+                return null;
             }
 
             private LineInfo EmitOpenBraceLine()

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPass.CSharpDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPass.CSharpDocumentGenerator.cs
@@ -1152,7 +1152,8 @@ internal partial class CSharpFormattingPass
             {
                 _builder.Append('}');
 
-                // Preserve trailing C# like `/>);` for self-closing multiline templates.
+                // Preserve any same-line C# that follows the self-closing tag, such as the `);` in
+                // `Render(@<Component />);`.
                 var closeAngleEnd = startTag.CloseAngle.Position + startTag.CloseAngle.Content.Length;
                 if (closeAngleEnd < _currentLine.End)
                 {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPass.CSharpDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPass.CSharpDocumentGenerator.cs
@@ -762,6 +762,8 @@ internal partial class CSharpFormattingPass
             {
                 additionalIndentation = 0;
                 var startTagAddsIndentation = ElementCausesIndentation(startTag) && !ElementHasSignificantWhitespace(startTag);
+                var firstAttribute = startTag.Attributes[0];
+                var firstAttributeNameSpan = RazorSyntaxFacts.GetFullAttributeNameSpan(firstAttribute);
 
                 if (_attributeIndentStyle == AttributeIndentStyle.IndentByOne)
                 {
@@ -776,17 +778,14 @@ internal partial class CSharpFormattingPass
                 else if (_attributeIndentStyle == AttributeIndentStyle.AlignWithFirst)
                 {
                     // Align attributes with the first attribute in their tag.
-                    var firstAttribute = startTag.Attributes[0];
-                    var nameSpan = RazorSyntaxFacts.GetFullAttributeNameSpan(firstAttribute);
-
                     // We need to line up with the first attribute, but the start tag might not be the first thing on the line,
                     // so it's really relative to the first non-whitespace character on the line. We use the line that the attribute
                     // is on, just in case it's not on the same line as the start tag.
-                    var lineStart = _sourceText.Lines[GetLineNumber(nameSpan)].GetFirstNonWhitespacePosition().GetValueOrDefault();
-                    htmlIndentLevel = FormattingUtilities.GetIndentationLevel(nameSpan.Start - lineStart, _tabSize, out additionalIndentation);
+                    var lineStart = _sourceText.Lines[GetLineNumber(firstAttributeNameSpan)].GetFirstNonWhitespacePosition().GetValueOrDefault();
+                    htmlIndentLevel = FormattingUtilities.GetIndentationLevel(firstAttributeNameSpan.Start - lineStart, _tabSize, out additionalIndentation);
 
                     if (startTagAddsIndentation &&
-                        GetLineNumber(nameSpan) == GetLineNumber(startTag.Name))
+                        GetLineNumber(firstAttributeNameSpan) == GetLineNumber(startTag.Name))
                     {
                         // If the element has caused indentation, then we'll want to take one level off our attribute indentation to
                         // compensate.
@@ -797,6 +796,27 @@ internal partial class CSharpFormattingPass
                 {
                     throw new InvalidOperationException($"Unknown attribute indentation style '{_attributeIndentStyle}'.");
                 }
+
+                if (TemplateStartAddsIndentation(startTag, firstAttributeNameSpan) && htmlIndentLevel > 0)
+                {
+                    // Inline multiline templates already contribute a continuation indent through the synthetic lambda body.
+                    htmlIndentLevel--;
+                }
+            }
+
+            private bool TemplateStartAddsIndentation(BaseMarkupStartTagSyntax startTag, TextSpan firstAttributeNameSpan)
+            {
+                if (GetContainingTemplate(startTag) is not { } template ||
+                    !_sourceText.GetLinePositionSpan(template.Span).SpansMultipleLines() ||
+                    GetLineNumber(template.GetFirstToken()) != GetLineNumber(startTag.Name) ||
+                    GetLineNumber(firstAttributeNameSpan) != GetLineNumber(startTag.Name))
+                {
+                    return false;
+                }
+
+                var templateLine = _sourceText.Lines[GetLineNumber(template.GetFirstToken())];
+                return templateLine.GetFirstNonWhitespacePosition() is int firstNonWhitespacePosition &&
+                    template.GetFirstToken().Position > firstNonWhitespacePosition;
             }
 
             public override LineInfo VisitMarkupTransition(MarkupTransitionSyntax node)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPass.CSharpDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPass.CSharpDocumentGenerator.cs
@@ -1161,7 +1161,10 @@ internal partial class CSharpFormattingPass
                 }
 
                 _builder.AppendLine();
-                return CreateLineInfo(htmlIndentLevel: htmlIndentLevel, additionalIndentation: additionalIndentation);
+
+                // Roslyn indents the synthetic `}` one level shallower than the attribute lines it closes, so compensate
+                // here to keep the last attribute aligned with the preceding ones when we map indentation back to Razor.
+                return CreateLineInfo(htmlIndentLevel: htmlIndentLevel + 1, additionalIndentation: additionalIndentation);
             }
 
             private int AppendSyntheticLambdaBodyStart()

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.Test/Formatting/DocumentFormattingTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.Test/Formatting/DocumentFormattingTest.cs
@@ -10541,121 +10541,58 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
         await RunFormattingTestAsync(
             input: """
                 @code {
-                    private async Task FluentAutocomplete_SetParametersAsync_SelectedItemChanged_SyncsInternalState()
+                    [Fact]
+                    private void RenderFragment_First()
                     {
-                        // Arrange - Render with SelectedItem = "Three"
-                        var cut = Render(@<FluentAutocomplete Id="my-list"
+                        Render(@<FluentAutocomplete Id="my-list"
                                                     TOption="string"
                                                     TValue="string"
                                                     Multiple="false"
                                                     Items="@Digits"
-                                                SelectedItem="@("Three")" />);
+                                                    SelectedItem="@("Three")" />);
+                    }
 
-                        // Verify initial state: "Three" is displayed
-                        var badge = cut.Find("span.fluent-badge[alone]");
-                        Assert.Equal("Three", badge.GetAttribute("title"));
-
-                        // Act - Change the SelectedItem parameter externally to "Six"
-                        // This triggers SetParametersAsync where newSelectedItem ("Six") != currentSelectedItem ("Three")
-                        var component = cut.FindComponent<FluentAutocomplete<string, string>>().Instance;
-                        var newParameters = ParameterView.FromDictionary(new Dictionary<string, object?>
-                        {
-                        { nameof(FluentAutocomplete<string, string>.SelectedItem), "Six" }
-                        });
-                        await cut.InvokeAsync(() => component.SetParametersAsync(newParameters));
-
-                        // Assert - The badge now shows "Six" (internal state was synced)
-                        badge = cut.Find("span.fluent-badge[alone]");
-                        Assert.Equal("Six", badge.GetAttribute("title"));
-
-                        // Only one badge should be present
-                        var badges = cut.FindAll("span.fluent-badge");
-                        Assert.Single(badges);
-
-                        // Verify internal state
-                        Assert.Equal("Six", component.SelectedItem);
-                        Assert.Single(component.SelectedItems);
-                        Assert.Contains("Six", component.SelectedItems);
+                    [Fact]
+                    private void RenderFragment_Second()
+                    {
                     }
                 }
                 """,
             htmlFormatted: """
                 @code {
-                    private async Task FluentAutocomplete_SetParametersAsync_SelectedItemChanged_SyncsInternalState()
+                    [Fact]
+                    private void RenderFragment_First()
                     {
-                        // Arrange - Render with SelectedItem = "Three"
-                        var cut = Render(@<FluentAutocomplete Id="my-list"
+                        Render(@<FluentAutocomplete Id="my-list"
                         TOption="string"
                         TValue="string"
                         Multiple="false"
                         Items="@Digits"
                         SelectedItem="@("Three")" />);
+                    }
 
-                        // Verify initial state: "Three" is displayed
-                        var badge = cut.Find("span.fluent-badge[alone]");
-                        Assert.Equal("Three", badge.GetAttribute("title"));
-
-                        // Act - Change the SelectedItem parameter externally to "Six"
-                        // This triggers SetParametersAsync where newSelectedItem ("Six") != currentSelectedItem ("Three")
-                        var component = cut.FindComponent<FluentAutocomplete<string, string>>().Instance;
-                        var newParameters = ParameterView.FromDictionary(new Dictionary<string, object?>
-                        {
-                        { nameof(FluentAutocomplete<string, string>.SelectedItem), "Six" }
-                        });
-                        await cut.InvokeAsync(() => component.SetParametersAsync(newParameters));
-
-                        // Assert - The badge now shows "Six" (internal state was synced)
-                        badge = cut.Find("span.fluent-badge[alone]");
-                        Assert.Equal("Six", badge.GetAttribute("title"));
-
-                        // Only one badge should be present
-                        var badges = cut.FindAll("span.fluent-badge");
-                        Assert.Single(badges);
-
-                        // Verify internal state
-                        Assert.Equal("Six", component.SelectedItem);
-                        Assert.Single(component.SelectedItems);
-                        Assert.Contains("Six", component.SelectedItems);
+                    [Fact]
+                    private void RenderFragment_Second()
+                    {
                     }
                 }
                 """,
             expected: """
                 @code {
-                    private async Task FluentAutocomplete_SetParametersAsync_SelectedItemChanged_SyncsInternalState()
+                    [Fact]
+                    private void RenderFragment_First()
                     {
-                        // Arrange - Render with SelectedItem = "Three"
-                        var cut = Render(@<FluentAutocomplete Id="my-list"
-                                                                  TOption="string"
-                                                                  TValue="string"
-                                                                  Multiple="false"
-                                                                  Items="@Digits"
-                                                              SelectedItem="@("Three")" />);
+                        Render(@<FluentAutocomplete Id="my-list"
+                                                    TOption="string"
+                                                    TValue="string"
+                                                    Multiple="false"
+                                                    Items="@Digits"
+                                                    SelectedItem="@("Three")" />);
+                    }
 
-                        // Verify initial state: "Three" is displayed
-                        var badge = cut.Find("span.fluent-badge[alone]");
-                        Assert.Equal("Three", badge.GetAttribute("title"));
-
-                        // Act - Change the SelectedItem parameter externally to "Six"
-                        // This triggers SetParametersAsync where newSelectedItem ("Six") != currentSelectedItem ("Three")
-                        var component = cut.FindComponent<FluentAutocomplete<string, string>>().Instance;
-                        var newParameters = ParameterView.FromDictionary(new Dictionary<string, object?>
-                        {
-                        { nameof(FluentAutocomplete<string, string>.SelectedItem), "Six" }
-                        });
-                        await cut.InvokeAsync(() => component.SetParametersAsync(newParameters));
-
-                        // Assert - The badge now shows "Six" (internal state was synced)
-                        badge = cut.Find("span.fluent-badge[alone]");
-                        Assert.Equal("Six", badge.GetAttribute("title"));
-
-                        // Only one badge should be present
-                        var badges = cut.FindAll("span.fluent-badge");
-                        Assert.Single(badges);
-
-                        // Verify internal state
-                        Assert.Equal("Six", component.SelectedItem);
-                        Assert.Single(component.SelectedItems);
-                        Assert.Contains("Six", component.SelectedItems);
+                    [Fact]
+                    private void RenderFragment_Second()
+                    {
                     }
                 }
                 """);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.Test/Formatting/DocumentFormattingTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.Test/Formatting/DocumentFormattingTest.cs
@@ -10584,11 +10584,213 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
                     private void RenderFragment_First()
                     {
                         Render(@<FluentAutocomplete Id="my-list"
-                                                        TOption="string"
-                                                        TValue="string"
-                                                        Multiple="false"
-                                                        Items="@Digits"
-                                                        SelectedItem="@("Three")" />);
+                                                    TOption="string"
+                                                    TValue="string"
+                                                    Multiple="false"
+                                                    Items="@Digits"
+                                                    SelectedItem="@("Three")" />);
+                    }
+
+                    [Fact]
+                    private void RenderFragment_Second()
+                    {
+                    }
+                }
+                """);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13064")]
+    public async Task RenderFragment_Multiline_ComponentAttributesWithExplicitExpression_IndentByOne()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                @code {
+                    [Fact]
+                    private void RenderFragment_First()
+                    {
+                        Render(@<FluentAutocomplete Id="my-list"
+                                        TOption="string"
+                                TValue="string"
+                                              Multiple="false"
+                                   Items="@Digits"
+                                              SelectedItem="@("Three")" />);
+                    }
+
+                    [Fact]
+                    private void RenderFragment_Second()
+                    {
+                    }
+                }
+                """,
+            htmlFormatted: """
+                @code {
+                    [Fact]
+                    private void RenderFragment_First()
+                    {
+                        Render(@
+                <FluentAutocomplete Id="my-list"
+                                    TOption="string"
+                                    TValue="string"
+                                    Multiple="false"
+                                    Items="@Digits"
+                                    SelectedItem="@("Three")" />);
+                    }
+
+                    [Fact]
+                    private void RenderFragment_Second()
+                    {
+                    }
+                }
+                """,
+            expected: """
+                @code {
+                    [Fact]
+                    private void RenderFragment_First()
+                    {
+                        Render(@<FluentAutocomplete Id="my-list"
+                            TOption="string"
+                            TValue="string"
+                            Multiple="false"
+                            Items="@Digits"
+                            SelectedItem="@("Three")" />);
+                    }
+
+                    [Fact]
+                    private void RenderFragment_Second()
+                    {
+                    }
+                }
+                """,
+            attributeIndentStyle: AttributeIndentStyle.IndentByOne);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13064")]
+    public async Task RenderFragment_Multiline_ComponentAttributesWithExplicitExpression_IndentByTwo()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                @code {
+                    [Fact]
+                    private void RenderFragment_First()
+                    {
+                        Render(@<FluentAutocomplete Id="my-list"
+                                        TOption="string"
+                                TValue="string"
+                                              Multiple="false"
+                                   Items="@Digits"
+                                              SelectedItem="@("Three")" />);
+                    }
+
+                    [Fact]
+                    private void RenderFragment_Second()
+                    {
+                    }
+                }
+                """,
+            htmlFormatted: """
+                @code {
+                    [Fact]
+                    private void RenderFragment_First()
+                    {
+                        Render(@
+                <FluentAutocomplete Id="my-list"
+                                    TOption="string"
+                                    TValue="string"
+                                    Multiple="false"
+                                    Items="@Digits"
+                                    SelectedItem="@("Three")" />);
+                    }
+
+                    [Fact]
+                    private void RenderFragment_Second()
+                    {
+                    }
+                }
+                """,
+            expected: """
+                @code {
+                    [Fact]
+                    private void RenderFragment_First()
+                    {
+                        Render(@<FluentAutocomplete Id="my-list"
+                                TOption="string"
+                                TValue="string"
+                                Multiple="false"
+                                Items="@Digits"
+                                SelectedItem="@("Three")" />);
+                    }
+
+                    [Fact]
+                    private void RenderFragment_Second()
+                    {
+                    }
+                }
+                """,
+            attributeIndentStyle: AttributeIndentStyle.IndentByTwo);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13064")]
+    public async Task RenderFragment_Multiline_NestedComponentAttributesWithExplicitExpression()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                @code {
+                    [Fact]
+                    private void RenderFragment_First()
+                    {
+                        Render(@<div>
+                                <FluentAutocomplete Id="my-list"
+                                                TOption="string"
+                                        TValue="string"
+                                                      Multiple="false"
+                                           Items="@Digits"
+                                                      SelectedItem="@("Three")" />
+                        </div>);
+                    }
+
+                    [Fact]
+                    private void RenderFragment_Second()
+                    {
+                    }
+                }
+                """,
+            htmlFormatted: """
+                @code {
+                    [Fact]
+                    private void RenderFragment_First()
+                    {
+                        Render(@<div>
+                    <FluentAutocomplete Id="my-list"
+                                        TOption="string"
+                                        TValue="string"
+                                        Multiple="false"
+                                        Items="@Digits"
+                                        SelectedItem="@("Three")" />
+                </div>);
+                    }
+
+                    [Fact]
+                    private void RenderFragment_Second()
+                    {
+                    }
+                }
+                """,
+            expected: """
+                @code {
+                    [Fact]
+                    private void RenderFragment_First()
+                    {
+                        Render(@<div>
+                            <FluentAutocomplete Id="my-list"
+                                                TOption="string"
+                                                TValue="string"
+                                                Multiple="false"
+                                                Items="@Digits"
+                                                SelectedItem="@("Three")" />
+                        </div>);
                     }
 
                     [Fact]

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.Test/Formatting/DocumentFormattingTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.Test/Formatting/DocumentFormattingTest.cs
@@ -10545,11 +10545,11 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
                     private void RenderFragment_First()
                     {
                         Render(@<FluentAutocomplete Id="my-list"
-                                                    TOption="string"
-                                                    TValue="string"
-                                                    Multiple="false"
-                                                    Items="@Digits"
-                                                    SelectedItem="@("Three")" />);
+                                        TOption="string"
+                                TValue="string"
+                                              Multiple="false"
+                                   Items="@Digits"
+                                              SelectedItem="@("Three")" />);
                     }
 
                     [Fact]
@@ -10563,12 +10563,13 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
                     [Fact]
                     private void RenderFragment_First()
                     {
-                        Render(@<FluentAutocomplete Id="my-list"
-                        TOption="string"
-                        TValue="string"
-                        Multiple="false"
-                        Items="@Digits"
-                        SelectedItem="@("Three")" />);
+                        Render(@
+                <FluentAutocomplete Id="my-list"
+                                    TOption="string"
+                                    TValue="string"
+                                    Multiple="false"
+                                    Items="@Digits"
+                                    SelectedItem="@("Three")" />);
                     }
 
                     [Fact]
@@ -10583,11 +10584,11 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
                     private void RenderFragment_First()
                     {
                         Render(@<FluentAutocomplete Id="my-list"
-                                                    TOption="string"
-                                                    TValue="string"
-                                                    Multiple="false"
-                                                    Items="@Digits"
-                                                    SelectedItem="@("Three")" />);
+                                                        TOption="string"
+                                                        TValue="string"
+                                                        Multiple="false"
+                                                        Items="@Digits"
+                                                        SelectedItem="@("Three")" />);
                     }
 
                     [Fact]

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.Test/Formatting/DocumentFormattingTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.Test/Formatting/DocumentFormattingTest.cs
@@ -10535,6 +10535,133 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
     }
 
     [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13064")]
+    public async Task RenderFragment_Multiline_ComponentAttributesWithExplicitExpression()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                @code {
+                    private async Task FluentAutocomplete_SetParametersAsync_SelectedItemChanged_SyncsInternalState()
+                    {
+                        // Arrange - Render with SelectedItem = "Three"
+                        var cut = Render(@<FluentAutocomplete Id="my-list"
+                                                    TOption="string"
+                                                    TValue="string"
+                                                    Multiple="false"
+                                                    Items="@Digits"
+                                                SelectedItem="@("Three")" />);
+
+                        // Verify initial state: "Three" is displayed
+                        var badge = cut.Find("span.fluent-badge[alone]");
+                        Assert.Equal("Three", badge.GetAttribute("title"));
+
+                        // Act - Change the SelectedItem parameter externally to "Six"
+                        // This triggers SetParametersAsync where newSelectedItem ("Six") != currentSelectedItem ("Three")
+                        var component = cut.FindComponent<FluentAutocomplete<string, string>>().Instance;
+                        var newParameters = ParameterView.FromDictionary(new Dictionary<string, object?>
+                        {
+                        { nameof(FluentAutocomplete<string, string>.SelectedItem), "Six" }
+                        });
+                        await cut.InvokeAsync(() => component.SetParametersAsync(newParameters));
+
+                        // Assert - The badge now shows "Six" (internal state was synced)
+                        badge = cut.Find("span.fluent-badge[alone]");
+                        Assert.Equal("Six", badge.GetAttribute("title"));
+
+                        // Only one badge should be present
+                        var badges = cut.FindAll("span.fluent-badge");
+                        Assert.Single(badges);
+
+                        // Verify internal state
+                        Assert.Equal("Six", component.SelectedItem);
+                        Assert.Single(component.SelectedItems);
+                        Assert.Contains("Six", component.SelectedItems);
+                    }
+                }
+                """,
+            htmlFormatted: """
+                @code {
+                    private async Task FluentAutocomplete_SetParametersAsync_SelectedItemChanged_SyncsInternalState()
+                    {
+                        // Arrange - Render with SelectedItem = "Three"
+                        var cut = Render(@<FluentAutocomplete Id="my-list"
+                        TOption="string"
+                        TValue="string"
+                        Multiple="false"
+                        Items="@Digits"
+                        SelectedItem="@("Three")" />);
+
+                        // Verify initial state: "Three" is displayed
+                        var badge = cut.Find("span.fluent-badge[alone]");
+                        Assert.Equal("Three", badge.GetAttribute("title"));
+
+                        // Act - Change the SelectedItem parameter externally to "Six"
+                        // This triggers SetParametersAsync where newSelectedItem ("Six") != currentSelectedItem ("Three")
+                        var component = cut.FindComponent<FluentAutocomplete<string, string>>().Instance;
+                        var newParameters = ParameterView.FromDictionary(new Dictionary<string, object?>
+                        {
+                        { nameof(FluentAutocomplete<string, string>.SelectedItem), "Six" }
+                        });
+                        await cut.InvokeAsync(() => component.SetParametersAsync(newParameters));
+
+                        // Assert - The badge now shows "Six" (internal state was synced)
+                        badge = cut.Find("span.fluent-badge[alone]");
+                        Assert.Equal("Six", badge.GetAttribute("title"));
+
+                        // Only one badge should be present
+                        var badges = cut.FindAll("span.fluent-badge");
+                        Assert.Single(badges);
+
+                        // Verify internal state
+                        Assert.Equal("Six", component.SelectedItem);
+                        Assert.Single(component.SelectedItems);
+                        Assert.Contains("Six", component.SelectedItems);
+                    }
+                }
+                """,
+            expected: """
+                @code {
+                    private async Task FluentAutocomplete_SetParametersAsync_SelectedItemChanged_SyncsInternalState()
+                    {
+                        // Arrange - Render with SelectedItem = "Three"
+                        var cut = Render(@<FluentAutocomplete Id="my-list"
+                                                                  TOption="string"
+                                                                  TValue="string"
+                                                                  Multiple="false"
+                                                                  Items="@Digits"
+                                                              SelectedItem="@("Three")" />);
+
+                        // Verify initial state: "Three" is displayed
+                        var badge = cut.Find("span.fluent-badge[alone]");
+                        Assert.Equal("Three", badge.GetAttribute("title"));
+
+                        // Act - Change the SelectedItem parameter externally to "Six"
+                        // This triggers SetParametersAsync where newSelectedItem ("Six") != currentSelectedItem ("Three")
+                        var component = cut.FindComponent<FluentAutocomplete<string, string>>().Instance;
+                        var newParameters = ParameterView.FromDictionary(new Dictionary<string, object?>
+                        {
+                        { nameof(FluentAutocomplete<string, string>.SelectedItem), "Six" }
+                        });
+                        await cut.InvokeAsync(() => component.SetParametersAsync(newParameters));
+
+                        // Assert - The badge now shows "Six" (internal state was synced)
+                        badge = cut.Find("span.fluent-badge[alone]");
+                        Assert.Equal("Six", badge.GetAttribute("title"));
+
+                        // Only one badge should be present
+                        var badges = cut.FindAll("span.fluent-badge");
+                        Assert.Single(badges);
+
+                        // Verify internal state
+                        Assert.Equal("Six", component.SelectedItem);
+                        Assert.Single(component.SelectedItems);
+                        Assert.Contains("Six", component.SelectedItems);
+                    }
+                }
+                """);
+    }
+
+    [Fact]
     [WorkItem("https://github.com/dotnet/razor/issues/9119")]
     public async Task CollectionInitializers()
     {


### PR DESCRIPTION
Fixes #13064

Fix formatting when RenderFragments are self closing tags. Same as the fix a little while ago for RenderFragments in general, but I missed that the tags could be self-closing.