### PR TITLE
Return empty incomplete list when HTML completion fails in Razor

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
@@ -146,14 +146,14 @@ internal sealed class CohostDocumentCompletionEndpoint(
         {
             htmlCompletionList = await GetHtmlCompletionListAsync(request, razorDocument, razorCompletionOptions, correlationId, cancellationToken).ConfigureAwait(false);
 
-            if (htmlCompletionList is { IsIncomplete: true, Items: [] })
+            if (htmlCompletionList is null)
             {
                 // HTML server failed to respond (e.g., not yet initialized on first document open).
-                // Return the incomplete empty list directly so the client retries, rather than
-                // continuing to merge with Razor results and showing partial Razor-only items
-                // that could cause the user to accidentally commit a wrong item.
+                // Return an incomplete empty list so the client retries, rather than continuing to
+                // merge with Razor results and showing partial Razor-only items that could cause
+                // the user to accidentally commit a wrong item.
                 _logger.LogDebug($"HTML completion failed for {razorDocument.FilePath}, returning incomplete list");
-                return htmlCompletionList;
+                return new RazorVSInternalCompletionList() { IsIncomplete = true, Items = [] };
             }
 
             existingHtmlCompletions.UnionWith(htmlCompletionList.Items.Select(i => i.Label));
@@ -214,7 +214,7 @@ internal sealed class CohostDocumentCompletionEndpoint(
         return combinedCompletionList;
     }
 
-    private async Task<RazorVSInternalCompletionList> GetHtmlCompletionListAsync(
+    private async Task<RazorVSInternalCompletionList?> GetHtmlCompletionListAsync(
         RazorVSInternalCompletionParams completionParams,
         TextDocument razorDocument,
         RazorCompletionOptions razorCompletionOptions,
@@ -228,6 +228,12 @@ internal sealed class CohostDocumentCompletionEndpoint(
             TelemetryThresholds.CompletionSubLSPTelemetryThreshold,
             correlationId,
             cancellationToken).ConfigureAwait(false);
+
+        if (result is null)
+        {
+            // HTML server didn't respond (e.g., not yet initialized, sync failure, or checksum mismatch).
+            return null;
+        }
 
         var rewrittenResponse = DelegatedCompletionHelper.RewriteHtmlResponse(result, razorCompletionOptions);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
@@ -146,10 +146,17 @@ internal sealed class CohostDocumentCompletionEndpoint(
         {
             htmlCompletionList = await GetHtmlCompletionListAsync(request, razorDocument, razorCompletionOptions, correlationId, cancellationToken).ConfigureAwait(false);
 
-            if (htmlCompletionList is not null)
+            if (htmlCompletionList is { IsIncomplete: true, Items: [] })
             {
-                existingHtmlCompletions.UnionWith(htmlCompletionList.Items.Select(i => i.Label));
+                // HTML server failed to respond (e.g., not yet initialized on first document open).
+                // Return the incomplete empty list directly so the client retries, rather than
+                // continuing to merge with Razor results and showing partial Razor-only items
+                // that could cause the user to accidentally commit a wrong item.
+                _logger.LogDebug($"HTML completion failed for {razorDocument.FilePath}, returning incomplete list");
+                return htmlCompletionList;
             }
+
+            existingHtmlCompletions.UnionWith(htmlCompletionList.Items.Select(i => i.Label));
         }
 
         _logger.LogDebug($"Calling OOP to get completion items at {request.Position} invoked by typing '{request.Context?.TriggerCharacter}'");
@@ -207,7 +214,7 @@ internal sealed class CohostDocumentCompletionEndpoint(
         return combinedCompletionList;
     }
 
-    private async Task<RazorVSInternalCompletionList?> GetHtmlCompletionListAsync(
+    private async Task<RazorVSInternalCompletionList> GetHtmlCompletionListAsync(
         RazorVSInternalCompletionParams completionParams,
         TextDocument razorDocument,
         RazorCompletionOptions razorCompletionOptions,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
@@ -133,18 +133,9 @@ internal static class DelegatedCompletionHelper
     }
 
     public static RazorVSInternalCompletionList RewriteHtmlResponse(
-        RazorVSInternalCompletionList? delegatedResponse,
+        RazorVSInternalCompletionList delegatedResponse,
         RazorCompletionOptions completionOptions)
     {
-        if (delegatedResponse?.Items is null)
-        {
-            // If we don't get a response from the delegated server, we have to make sure to return an incomplete completion
-            // list. When a user is typing quickly, the delegated request from the first keystroke will fail to synchronize,
-            // so if we return a "complete" list then the query won't re-query us for completion once the typing stops/slows
-            // so we'd only ever return Razor completion items.
-            return new RazorVSInternalCompletionList() { IsIncomplete = true, Items = [] };
-        }
-
         var rewrittenResponse = s_delegatedHtmlCompletionResponseRewriter.Rewrite(
             delegatedResponse,
             completionOptions);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.Test/Endpoints/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.Test/Endpoints/CohostDocumentCompletionEndpointTest.cs
@@ -428,6 +428,66 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
     }
 
     [Fact]
+    public async Task HtmlCompletionFailure_ReturnsIncompleteEmptyList()
+    {
+        // When the HTML language server fails to respond (e.g., not yet initialized on first document open),
+        // we should return an empty IsIncomplete list so the client retries, rather than showing partial
+        // Razor-only results that could cause the user to accidentally commit a wrong item.
+        var input = new TestCode("""
+            This is a Razor document.
+
+            <$$
+
+            The end.
+            """);
+
+        var document = CreateProjectAndRazorDocument(input.Text);
+        var sourceText = await document.GetTextAsync(DisposalToken);
+
+        // Use a TestHtmlRequestInvoker that returns null (simulating HTML server not ready)
+        var requestInvoker = new TestHtmlRequestInvoker((Methods.TextDocumentCompletionName, (object?)null));
+
+#if VSCODE
+        ISnippetCompletionItemProvider? snippetCompletionItemProvider = null;
+#else
+        var snippetCompletionItemProvider = new SnippetCompletionItemProvider(new SnippetCache());
+#endif
+
+        var completionListCache = new CompletionListCache();
+        var endpoint = new CohostDocumentCompletionEndpoint(
+            IncompatibleProjectService,
+            RemoteServiceInvoker,
+            ClientSettingsManager,
+            ClientCapabilitiesService,
+            snippetCompletionItemProvider,
+            requestInvoker,
+            completionListCache,
+            NoOpTelemetryReporter.Instance,
+            LoggerFactory);
+
+        var request = new RazorVSInternalCompletionParams()
+        {
+            TextDocument = new TextDocumentIdentifier()
+            {
+                DocumentUri = document.CreateDocumentUri()
+            },
+            Position = sourceText.GetPosition(input.Position),
+            Context = new VSInternalCompletionContext()
+            {
+                InvokeKind = VSInternalCompletionInvokeKind.Typing,
+                TriggerCharacter = "<",
+                TriggerKind = CompletionTriggerKind.TriggerCharacter
+            }
+        };
+
+        var result = await endpoint.GetTestAccessor().HandleRequestAsync(request, document, DisposalToken);
+
+        Assert.NotNull(result);
+        Assert.True(result.IsIncomplete);
+        Assert.Empty(result.Items);
+    }
+
+    [Fact]
     public async Task Component_FullyQualified()
     {
         await VerifyCompletionListAsync(


### PR DESCRIPTION
When the HTML language server fails to respond during Razor completion (e.g., not yet initialized on first document open), the endpoint previously continued to merge with Razor-only results. This caused users to see tag helper completions without expected HTML element completions, risking accidental wrong item commits.

DelegatedCompletionHelper.RewriteHtmlResponse already converts a null HTML response into an empty IsIncomplete list for exactly this scenario. Add an early return in HandleRequestAsync that detects this result and returns it directly, skipping the OOP call and merge step. Also make GetHtmlCompletionListAsync non-nullable since RewriteHtmlResponse always returns a value.

Partially fixes https://github.com/dotnet/razor/issues/12970
Partially fixes https://github.com/dotnet/razor/issues/9725