### PR TITLE
Perf: Skip GetAttributes() for non-viable component properties

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelpers/Producers/ComponentTagHelperProducer.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelpers/Producers/ComponentTagHelperProducer.cs
@@ -645,31 +645,25 @@ internal sealed partial class ComponentTagHelperProducer : TagHelperProducer
                 }
 
                 var kind = PropertyKind.Default;
-                if (property.DeclaredAccessibility != Accessibility.Public)
+                if (property.DeclaredAccessibility != Accessibility.Public // Not public
+                    || property.Parameters.Length != 0 // Indexer
+                    || property.SetMethod == null // No setter
+                    || property.SetMethod.DeclaredAccessibility != Accessibility.Public // No public setter
+                    || property.IsStatic)
                 {
-                    // Not public
-                    kind = PropertyKind.Ignored;
-                }
+                    // For non-override properties, skip the expensive GetAttributes() call
+                    // since the property will be ignored regardless. GetAttributes() triggers
+                    // attribute binding and nullable analysis in the compiler, which is a
+                    // significant cost during tag helper discovery. Override properties still
+                    // need the check because [Parameter] determines whether to shadow or pass
+                    // through to the base class.
+                    if (!property.IsOverride)
+                    {
+                        names.Add(property.Name);
+                        results.Add((property, PropertyKind.Ignored));
+                        continue;
+                    }
 
-                if (property.Parameters.Length != 0)
-                {
-                    // Indexer
-                    kind = PropertyKind.Ignored;
-                }
-
-                if (property.SetMethod == null)
-                {
-                    // No setter
-                    kind = PropertyKind.Ignored;
-                }
-                else if (property.SetMethod.DeclaredAccessibility != Accessibility.Public)
-                {
-                    // No public setter
-                    kind = PropertyKind.Ignored;
-                }
-
-                if (property.IsStatic)
-                {
                     kind = PropertyKind.Ignored;
                 }
 


### PR DESCRIPTION
During tag helper discovery, ComponentTagHelperProducer.GetProperties() calls GetAttributes() on every property to check for [Parameter]. This triggers expensive attribute binding and NullableWalker analysis in the Roslyn compiler for each call.

Properties that are private, static, indexers, or lack a public setter will always be Ignored regardless of attributes. For non-override properties, we can skip GetAttributes() entirely.

In Speedometer's RazorEditingTests.CompletionInCohostingForComponents, tag helper discovery re-runs on every keystroke because the source assembly symbol changes per compilation. The GetAttributes() calls contribute significantly to the 281MB of CLR_BytesAllocated_NonDevenv allocations in the devhub process — particularly NullableWalker (50MB+), BoundAttribute (13MB), and related binding infrastructure.

Override properties still go through GetAttributes() since [Parameter] determines shadow-vs-passthrough behavior.