### PR TITLE
Parallelize HTML and OOP completion requests in Razor cohost endpoint

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
@@ -21,6 +20,7 @@ using Microsoft.CodeAnalysis.Razor.Protocol.Completion;
 using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Razor.Telemetry;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Settings;
+using CompletionResponse = Microsoft.CodeAnalysis.Razor.Remote.RemoteResponse<Microsoft.CodeAnalysis.Razor.Protocol.Completion.CompletionResult>;
 using Response = Microsoft.CodeAnalysis.Razor.Remote.RemoteResponse<Roslyn.LanguageServer.Protocol.RazorVSInternalCompletionList?>;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
@@ -136,7 +136,7 @@ internal sealed class CohostDocumentCompletionEndpoint(
 
         _logger.LogDebug($"Calling OOP to get completion items at {request.Position} invoked by typing '{request.Context?.TriggerCharacter}'");
 
-        var razorCompletionTask = _remoteServiceInvoker.TryInvokeAsync<IRemoteCompletionService, Response>(
+        var razorCompletionTask = _remoteServiceInvoker.TryInvokeAsync<IRemoteCompletionService, CompletionResponse>(
             razorDocument.Project.Solution,
             (service, solutionInfo, cancellationToken)
                 => service.GetCompletionAsync(
@@ -154,8 +154,9 @@ internal sealed class CohostDocumentCompletionEndpoint(
             _triggerAndCommitCharacters.IsValidHtmlTrigger(completionContext))
         {
             // Fire HTML request concurrently with the OOP request already in flight.
-            // The OOP call no longer receives existing HTML labels for dedup — we handle
-            // that in the merge step below.
+            // Phase 1 OOP call excludes providers that need HTML labels (e.g., tag helper
+            // element completions). After HTML completes, a lightweight phase 2 OOP call
+            // runs only those providers with the HTML labels available.
             var htmlTask = GetHtmlCompletionListAsync(request, razorDocument, razorCompletionOptions, correlationId, cancellationToken);
 
             await Task.WhenAll(htmlTask, razorCompletionTask).ConfigureAwait(false);
@@ -173,22 +174,26 @@ internal sealed class CohostDocumentCompletionEndpoint(
             }
         }
 
-        var data = await razorCompletionTask.ConfigureAwait(false);
+        var razorCompletionResponse = await razorCompletionTask.ConfigureAwait(false);
 
-        if (data.StopHandling)
+        if (razorCompletionResponse.StopHandling)
         {
             return null;
         }
 
-        var combinedCompletionList = htmlCompletionList;
-        if (htmlCompletionList is null)
+        var razorCompletionResult = razorCompletionResponse.Result;
+
+        // If HTML completed successfully and the initial Razor call indicated that some providers
+        // were skipped because they need HTML labels, run those providers now.
+        RazorVSInternalCompletionList? razorHtmlDependentCompletionList = null;
+        if (htmlCompletionList is not null && razorCompletionResult.NeedsHtmlDependentPhase)
         {
-            combinedCompletionList = data.Result;
+            razorHtmlDependentCompletionList = await GetHtmlDependentCompletionsAsync(
+                htmlCompletionList, razorDocument, completionPositionInfo,
+                completionContext, razorCompletionOptions, cancellationToken).ConfigureAwait(false);
         }
-        else if (data.Result is { } oopCompletionList)
-        {
-            combinedCompletionList = GetCombinedCompletionList(htmlCompletionList, oopCompletionList);
-        }
+
+        var combinedCompletionList = MergeCompletionLists(htmlCompletionList, razorCompletionResult.CompletionList, razorHtmlDependentCompletionList);
 
         if (completionPositionInfo.ShouldIncludeDelegationSnippets &&
             _snippetCompletionItemProvider is not null)
@@ -210,35 +215,86 @@ internal sealed class CohostDocumentCompletionEndpoint(
         return combinedCompletionList;
     }
 
-    private static RazorVSInternalCompletionList GetCombinedCompletionList(RazorVSInternalCompletionList htmlCompletionList, RazorVSInternalCompletionList oopCompletionList)
+    /// <summary>
+    /// Merges up to three completion lists: HTML, Razor (C# + Razor items), and Razor HTML-dependent
+    /// (tag helper element completions). Razor items are deduped against HTML labels before merging.
+    /// Any null lists are skipped.
+    /// </summary>
+    private static RazorVSInternalCompletionList? MergeCompletionLists(
+        RazorVSInternalCompletionList? htmlCompletionList,
+        RazorVSInternalCompletionList? razorCompletionList,
+        RazorVSInternalCompletionList? razorHtmlDependentCompletionList)
     {
-        // OOP no longer deduplicates against HTML labels, so remove any Razor items
-        // whose labels already appear in the HTML completion list before merging.
-        using var _ = HashSetPool<string>.GetPooledObject(out var htmlLabels);
-        foreach (var item in htmlCompletionList.Items)
+        // When HTML is present, remove any Razor items whose labels duplicate HTML items.
+        if (htmlCompletionList is not null && razorCompletionList is not null)
         {
-            htmlLabels.Add(item.Label);
-        }
-
-        // If there are any razor completion items matching an html completion item,
-        // then we need to remove them from oopCompletionList before merging.
-        var duplicateCount = oopCompletionList.Items.Count(htmlLabels, static (item, htmlLabels) => htmlLabels.Contains(item.Label));
-        if (duplicateCount > 0)
-        {
-            var filtered = new VSInternalCompletionItem[oopCompletionList.Items.Length - duplicateCount];
-            var index = 0;
-            foreach (var item in oopCompletionList.Items)
+            using var _ = HashSetPool<string>.GetPooledObject(out var htmlLabels);
+            foreach (var item in htmlCompletionList.Items)
             {
-                if (!htmlLabels.Contains(item.Label))
-                {
-                    filtered[index++] = item;
-                }
+                htmlLabels.Add(item.Label);
             }
 
-            oopCompletionList.Items = filtered;
+            var duplicateCount = razorCompletionList.Items.Count(htmlLabels, static (item, htmlLabels) => htmlLabels.Contains(item.Label));
+            if (duplicateCount > 0)
+            {
+                var filtered = new VSInternalCompletionItem[razorCompletionList.Items.Length - duplicateCount];
+                var index = 0;
+                foreach (var item in razorCompletionList.Items)
+                {
+                    if (!htmlLabels.Contains(item.Label))
+                    {
+                        filtered[index++] = item;
+                    }
+                }
+
+                razorCompletionList.Items = filtered;
+            }
         }
 
-        return CompletionListMerger.Merge(oopCompletionList, htmlCompletionList);
+        // Merge all non-null lists together. Razor lists are passed as the first argument to
+        // CompletionListMerger.Merge so their commit characters take precedence at the list
+        // level, matching the pre-parallel behavior where the Razor list was always first.
+        var result = CompletionListMerger.Merge(razorCompletionList, htmlCompletionList);
+        return CompletionListMerger.Merge(result, razorHtmlDependentCompletionList);
+    }
+
+    /// <summary>
+    /// Phase 2: runs only the HTML-dependent completion providers (e.g., tag helper element
+    /// completions) with the HTML labels available for deduplication.
+    /// </summary>
+    private async Task<RazorVSInternalCompletionList?> GetHtmlDependentCompletionsAsync(
+        RazorVSInternalCompletionList htmlCompletionList,
+        TextDocument razorDocument,
+        CompletionPositionInfo completionPositionInfo,
+        VSInternalCompletionContext completionContext,
+        RazorCompletionOptions razorCompletionOptions,
+        CancellationToken cancellationToken)
+    {
+        var htmlLabels = new string[htmlCompletionList.Items.Length];
+        for (var i = 0; i < htmlCompletionList.Items.Length; i++)
+        {
+            htmlLabels[i] = htmlCompletionList.Items[i].Label;
+        }
+
+        var htmlDependentResponse = await _remoteServiceInvoker.TryInvokeAsync<IRemoteCompletionService, Response>(
+            razorDocument.Project.Solution,
+            (service, solutionInfo, cancellationToken)
+                => service.GetHtmlDependentCompletionsAsync(
+                        solutionInfo,
+                        razorDocument.Id,
+                        completionPositionInfo,
+                        completionContext,
+                        razorCompletionOptions,
+                        htmlLabels,
+                        cancellationToken),
+            cancellationToken).ConfigureAwait(false);
+
+        if (htmlDependentResponse is { StopHandling: false, Result: { } htmlDependentCompletionList })
+        {
+            return htmlDependentCompletionList;
+        }
+
+        return null;
     }
 
     private async Task<RazorVSInternalCompletionList?> GetHtmlCompletionListAsync(

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
@@ -220,21 +220,17 @@ internal sealed class CohostDocumentCompletionEndpoint(
     /// (tag helper element completions).
     /// </summary>
     /// <remarks>
-    /// No dedup is performed here. The only label-based filtering happens inside
-    /// <see cref="TagHelperCompletionService.GetElementCompletions"/>, which uses HTML labels
-    /// as an inclusion filter (not for dedup) to decide which tag helpers to offer.
-    /// That filtering is handled by phase 2 via <see cref="RazorHtmlDependentCompletionContext.HtmlLabels"/>.
+    /// Both Razor lists are merged first, then merged once against HTML. This ensures Razor
+    /// commit characters take precedence at the list level, matching the pre-parallel behavior
+    /// where the Razor list was always the first argument to <see cref="CompletionListMerger.Merge"/>.
     /// </remarks>
     private static RazorVSInternalCompletionList? MergeCompletionLists(
         RazorVSInternalCompletionList? htmlCompletionList,
         RazorVSInternalCompletionList? razorCompletionList,
         RazorVSInternalCompletionList? razorHtmlDependentCompletionList)
     {
-        // Merge all non-null lists together. Razor lists are passed as the first argument to
-        // CompletionListMerger.Merge so their commit characters take precedence at the list
-        // level, matching the pre-parallel behavior where the Razor list was always first.
-        var result = CompletionListMerger.Merge(razorCompletionList, htmlCompletionList);
-        return CompletionListMerger.Merge(result, razorHtmlDependentCompletionList);
+        var combinedRazorList = CompletionListMerger.Merge(razorCompletionList, razorHtmlDependentCompletionList);
+        return CompletionListMerger.Merge(combinedRazorList, htmlCompletionList);
     }
 
     /// <summary>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
@@ -217,40 +217,19 @@ internal sealed class CohostDocumentCompletionEndpoint(
 
     /// <summary>
     /// Merges up to three completion lists: HTML, Razor (C# + Razor items), and Razor HTML-dependent
-    /// (tag helper element completions). Razor items are deduped against HTML labels before merging.
-    /// Any null lists are skipped.
+    /// (tag helper element completions).
     /// </summary>
+    /// <remarks>
+    /// No dedup is performed here. The only label-based filtering happens inside
+    /// <see cref="TagHelperCompletionService.GetElementCompletions"/>, which uses HTML labels
+    /// as an inclusion filter (not for dedup) to decide which tag helpers to offer.
+    /// That filtering is handled by phase 2 via <see cref="RazorHtmlDependentCompletionContext.HtmlLabels"/>.
+    /// </remarks>
     private static RazorVSInternalCompletionList? MergeCompletionLists(
         RazorVSInternalCompletionList? htmlCompletionList,
         RazorVSInternalCompletionList? razorCompletionList,
         RazorVSInternalCompletionList? razorHtmlDependentCompletionList)
     {
-        // When HTML is present, remove any Razor items whose labels duplicate HTML items.
-        if (htmlCompletionList is not null && razorCompletionList is not null)
-        {
-            using var _ = HashSetPool<string>.GetPooledObject(out var htmlLabels);
-            foreach (var item in htmlCompletionList.Items)
-            {
-                htmlLabels.Add(item.Label);
-            }
-
-            var duplicateCount = razorCompletionList.Items.Count(htmlLabels, static (item, htmlLabels) => htmlLabels.Contains(item.Label));
-            if (duplicateCount > 0)
-            {
-                var filtered = new VSInternalCompletionItem[razorCompletionList.Items.Length - duplicateCount];
-                var index = 0;
-                foreach (var item in razorCompletionList.Items)
-                {
-                    if (!htmlLabels.Contains(item.Label))
-                    {
-                        filtered[index++] = item;
-                    }
-                }
-
-                razorCompletionList.Items = filtered;
-            }
-        }
-
         // Merge all non-null lists together. Razor lists are passed as the first argument to
         // CompletionListMerger.Merge so their commit characters take precedence at the list
         // level, matching the pre-parallel behavior where the Razor list was always first.

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Completion/CohostDocumentCompletionEndpoint.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
@@ -128,23 +128,39 @@ internal sealed class CohostDocumentCompletionEndpoint(
             completionContext = rewrittenContext;
         }
 
-        // First of all, see if we in HTML and get HTML completions before calling OOP to get Razor completions.
-        // Razor completion provider needs a set of existing HTML item labels.
-
-        RazorVSInternalCompletionList? htmlCompletionList = null;
         var razorCompletionOptions = new RazorCompletionOptions(
             SnippetsSupported: true, // always true in non-legacy Razor, always false in legacy Razor
             AutoInsertAttributeQuotes: clientSettings.AdvancedSettings.AutoInsertAttributeQuotes,
             CommitElementsWithSpace: clientSettings.AdvancedSettings.CommitElementsWithSpace,
             UseVsCodeCompletionCommitCharacters: !_clientCapabilitiesService.ClientCapabilities.SupportsVisualStudioExtensions);
-        using var _ = HashSetPool<string>.GetPooledObject(out var existingHtmlCompletions);
 
-        // We can just blindly call HTML LSP because if we are in C#, generated HTML seen by HTML LSP may return
-        // results we don't want to show. So we want to call HTML LSP only if we know we are in HTML content.
+        _logger.LogDebug($"Calling OOP to get completion items at {request.Position} invoked by typing '{request.Context?.TriggerCharacter}'");
+
+        var razorCompletionTask = _remoteServiceInvoker.TryInvokeAsync<IRemoteCompletionService, Response>(
+            razorDocument.Project.Solution,
+            (service, solutionInfo, cancellationToken)
+                => service.GetCompletionAsync(
+                        solutionInfo,
+                        razorDocument.Id,
+                        completionPositionInfo,
+                        completionContext,
+                        razorCompletionOptions,
+                        correlationId,
+                        cancellationToken),
+            cancellationToken).AsTask();
+
+        RazorVSInternalCompletionList? htmlCompletionList = null;
         if (documentPositionInfo.LanguageKind == RazorLanguageKind.Html &&
             _triggerAndCommitCharacters.IsValidHtmlTrigger(completionContext))
         {
-            htmlCompletionList = await GetHtmlCompletionListAsync(request, razorDocument, razorCompletionOptions, correlationId, cancellationToken).ConfigureAwait(false);
+            // Fire HTML request concurrently with the OOP request already in flight.
+            // The OOP call no longer receives existing HTML labels for dedup — we handle
+            // that in the merge step below.
+            var htmlTask = GetHtmlCompletionListAsync(request, razorDocument, razorCompletionOptions, correlationId, cancellationToken);
+
+            await Task.WhenAll(htmlTask, razorCompletionTask).ConfigureAwait(false);
+
+            htmlCompletionList = await htmlTask.ConfigureAwait(false);
 
             if (htmlCompletionList is null)
             {
@@ -155,43 +171,23 @@ internal sealed class CohostDocumentCompletionEndpoint(
                 _logger.LogDebug($"HTML completion failed for {razorDocument.FilePath}, returning incomplete list");
                 return new RazorVSInternalCompletionList() { IsIncomplete = true, Items = [] };
             }
-
-            existingHtmlCompletions.UnionWith(htmlCompletionList.Items.Select(i => i.Label));
         }
 
-        _logger.LogDebug($"Calling OOP to get completion items at {request.Position} invoked by typing '{request.Context?.TriggerCharacter}'");
-
-        var data = await _remoteServiceInvoker.TryInvokeAsync<IRemoteCompletionService, Response>(
-            razorDocument.Project.Solution,
-            (service, solutionInfo, cancellationToken)
-                => service.GetCompletionAsync(
-                        solutionInfo,
-                        razorDocument.Id,
-                        completionPositionInfo,
-                        completionContext,
-                        razorCompletionOptions,
-                        existingHtmlCompletions,
-                        correlationId,
-                        cancellationToken),
-            cancellationToken).ConfigureAwait(false);
+        var data = await razorCompletionTask.ConfigureAwait(false);
 
         if (data.StopHandling)
         {
             return null;
         }
 
-        RazorVSInternalCompletionList? combinedCompletionList = null;
-        if (data.Result is { } oopCompletionList)
+        var combinedCompletionList = htmlCompletionList;
+        if (htmlCompletionList is null)
         {
-            combinedCompletionList = htmlCompletionList is { Items: [_, ..] }
-                // If we have HTML completions, that means OOP completion list is really just Razor completion list
-                ? CompletionListMerger.Merge(oopCompletionList, htmlCompletionList)
-                : oopCompletionList;
+            combinedCompletionList = data.Result;
         }
-        else
+        else if (data.Result is { } oopCompletionList)
         {
-            // Didn't get anything from OOP, so just return HTML completion list or null
-            combinedCompletionList = htmlCompletionList;
+            combinedCompletionList = GetCombinedCompletionList(htmlCompletionList, oopCompletionList);
         }
 
         if (completionPositionInfo.ShouldIncludeDelegationSnippets &&
@@ -212,6 +208,37 @@ internal sealed class CohostDocumentCompletionEndpoint(
         RazorCompletionResolveData.Wrap(combinedCompletionList, originalTextDocumentIdentifier, _clientCapabilitiesService.ClientCapabilities);
 
         return combinedCompletionList;
+    }
+
+    private static RazorVSInternalCompletionList GetCombinedCompletionList(RazorVSInternalCompletionList htmlCompletionList, RazorVSInternalCompletionList oopCompletionList)
+    {
+        // OOP no longer deduplicates against HTML labels, so remove any Razor items
+        // whose labels already appear in the HTML completion list before merging.
+        using var _ = HashSetPool<string>.GetPooledObject(out var htmlLabels);
+        foreach (var item in htmlCompletionList.Items)
+        {
+            htmlLabels.Add(item.Label);
+        }
+
+        // If there are any razor completion items matching an html completion item,
+        // then we need to remove them from oopCompletionList before merging.
+        var duplicateCount = oopCompletionList.Items.Count(htmlLabels, static (item, htmlLabels) => htmlLabels.Contains(item.Label));
+        if (duplicateCount > 0)
+        {
+            var filtered = new VSInternalCompletionItem[oopCompletionList.Items.Length - duplicateCount];
+            var index = 0;
+            foreach (var item in oopCompletionList.Items)
+            {
+                if (!htmlLabels.Contains(item.Label))
+                {
+                    filtered[index++] = item;
+                }
+            }
+
+            oopCompletionList.Items = filtered;
+        }
+
+        return CompletionListMerger.Merge(oopCompletionList, htmlCompletionList);
     }
 
     private async Task<RazorVSInternalCompletionList?> GetHtmlCompletionListAsync(

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/AbstractRazorCompletionFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/AbstractRazorCompletionFactsService.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -21,24 +20,46 @@ internal abstract class AbstractRazorCompletionFactsService(ImmutableArray<IRazo
 {
     private readonly ImmutableArray<IRazorCompletionItemProvider> _providers = providers;
 
-    public ImmutableArray<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context)
+    public (ImmutableArray<RazorCompletionItem> Items, bool AnyHtmlDependentSkipped) GetCompletionItems(RazorCompletionContext context)
     {
-        if (context is null)
+        ArgHelper.ThrowIfNull(context);
+        ArgHelper.ThrowIfNull(context.TagHelperDocumentContext);
+
+        var anyHtmlDependentSkipped = false;
+        using var completions = new PooledArrayBuilder<RazorCompletionItem>();
+
+        foreach (var provider in _providers)
         {
-            throw new ArgumentNullException(nameof(context));
+            if (provider is IHtmlDependentCompletionItemProvider htmlDependent
+                && htmlDependent.NeedsHtmlCompletions(context))
+            {
+                anyHtmlDependentSkipped = true;
+            }
+            else
+            {
+                var items = provider.GetCompletionItems(context);
+                completions.AddRange(items);
+            }
         }
 
-        if (context.TagHelperDocumentContext is null)
-        {
-            throw new ArgumentNullException(nameof(context.TagHelperDocumentContext));
-        }
+        return (completions.ToImmutableAndClear(), anyHtmlDependentSkipped);
+    }
+
+    public ImmutableArray<RazorCompletionItem> GetHtmlDependentCompletionItems(RazorHtmlDependentCompletionContext context)
+    {
+        ArgHelper.ThrowIfNull(context);
+        ArgHelper.ThrowIfNull(context.TagHelperDocumentContext);
 
         using var completions = new PooledArrayBuilder<RazorCompletionItem>();
 
         foreach (var provider in _providers)
         {
-            var items = provider.GetCompletionItems(context);
-            completions.AddRange(items);
+            if (provider is IHtmlDependentCompletionItemProvider htmlDependent
+                && htmlDependent.NeedsHtmlCompletions(context))
+            {
+                var items = htmlDependent.GetHtmlDependentCompletionItems(context);
+                completions.AddRange(items);
+            }
         }
 
         return completions.ToImmutableAndClear();

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/AbstractRazorCompletionFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/AbstractRazorCompletionFactsService.cs
@@ -20,7 +20,7 @@ internal abstract class AbstractRazorCompletionFactsService(ImmutableArray<IRazo
 {
     private readonly ImmutableArray<IRazorCompletionItemProvider> _providers = providers;
 
-    public (ImmutableArray<RazorCompletionItem> Items, bool AnyHtmlDependentSkipped) GetCompletionItems(RazorCompletionContext context)
+    public CompletionItemsResult GetCompletionItems(RazorCompletionContext context)
     {
         ArgHelper.ThrowIfNull(context);
         ArgHelper.ThrowIfNull(context.TagHelperDocumentContext);
@@ -42,7 +42,7 @@ internal abstract class AbstractRazorCompletionFactsService(ImmutableArray<IRazo
             }
         }
 
-        return (completions.ToImmutableAndClear(), anyHtmlDependentSkipped);
+        return new CompletionItemsResult(completions.ToImmutableAndClear(), anyHtmlDependentSkipped);
     }
 
     public ImmutableArray<RazorCompletionItem> GetHtmlDependentCompletionItems(RazorHtmlDependentCompletionContext context)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/AbstractRazorCompletionFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/AbstractRazorCompletionFactsService.cs
@@ -25,7 +25,7 @@ internal abstract class AbstractRazorCompletionFactsService(ImmutableArray<IRazo
         ArgHelper.ThrowIfNull(context);
         ArgHelper.ThrowIfNull(context.TagHelperDocumentContext);
 
-        var anyHtmlDependentSkipped = false;
+        var needsHtmlDependentCompletionItems = false;
         using var completions = new PooledArrayBuilder<RazorCompletionItem>();
 
         foreach (var provider in _providers)
@@ -33,7 +33,7 @@ internal abstract class AbstractRazorCompletionFactsService(ImmutableArray<IRazo
             if (provider is IHtmlDependentCompletionItemProvider htmlDependent
                 && htmlDependent.NeedsHtmlCompletions(context))
             {
-                anyHtmlDependentSkipped = true;
+                needsHtmlDependentCompletionItems = true;
             }
             else
             {
@@ -42,7 +42,7 @@ internal abstract class AbstractRazorCompletionFactsService(ImmutableArray<IRazo
             }
         }
 
-        return new CompletionItemsResult(completions.ToImmutableAndClear(), anyHtmlDependentSkipped);
+        return new CompletionItemsResult(completions.ToImmutableAndClear(), needsHtmlDependentCompletionItems);
     }
 
     public ImmutableArray<RazorCompletionItem> GetHtmlDependentCompletionItems(RazorHtmlDependentCompletionContext context)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionItemsResult.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionItemsResult.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion;
+
+internal readonly record struct CompletionItemsResult(
+    ImmutableArray<RazorCompletionItem> Items,
+    bool AnyHtmlDependentSkipped);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionItemsResult.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionItemsResult.cs
@@ -7,4 +7,4 @@ namespace Microsoft.CodeAnalysis.Razor.Completion;
 
 internal readonly record struct CompletionItemsResult(
     ImmutableArray<RazorCompletionItem> Items,
-    bool AnyHtmlDependentSkipped);
+    bool NeedsHtmlDependentCompletionItems);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionListMerger.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionListMerger.cs
@@ -37,7 +37,7 @@ internal static class CompletionListMerger
         EnsureMergeableData(razorCompletionList, delegatedCompletionList);
 
         var mergedIsIncomplete = razorCompletionList.IsIncomplete || delegatedCompletionList.IsIncomplete;
-        var mergedItems = [.. razorCompletionList.Items, .. delegatedCompletionList.Items];
+        VSInternalCompletionItem[] mergedItems = [.. razorCompletionList.Items, .. delegatedCompletionList.Items];
         var mergedData = MergeData(razorCompletionList.Data, delegatedCompletionList.Data);
         var mergedCommitCharacters = razorCompletionList.CommitCharacters
             ?? delegatedCompletionList.CommitCharacters;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionListMerger.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionListMerger.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Razor.PooledObjects;
@@ -29,7 +28,7 @@ internal static class CompletionListMerger
             return delegatedCompletionList;
         }
 
-        if (delegatedCompletionList?.Items is null)
+        if (delegatedCompletionList is null || delegatedCompletionList.Items.Length == 0)
         {
             return razorCompletionList;
         }
@@ -38,7 +37,7 @@ internal static class CompletionListMerger
         EnsureMergeableData(razorCompletionList, delegatedCompletionList);
 
         var mergedIsIncomplete = razorCompletionList.IsIncomplete || delegatedCompletionList.IsIncomplete;
-        var mergedItems = razorCompletionList.Items.Concat(delegatedCompletionList.Items).ToArray();
+        var mergedItems = [.. razorCompletionList.Items, .. delegatedCompletionList.Items];
         var mergedData = MergeData(razorCompletionList.Data, delegatedCompletionList.Data);
         var mergedCommitCharacters = razorCompletionList.CommitCharacters
             ?? delegatedCompletionList.CommitCharacters;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/IHtmlDependentCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/IHtmlDependentCompletionItemProvider.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion;
+
+/// <summary>
+/// An <see cref="IRazorCompletionItemProvider"/> that can produce additional completion items
+/// when HTML completion labels are available.  Providers implementing this interface are
+/// excluded from the initial (concurrent) completion pass and instead run in a second pass
+/// after HTML completions have been obtained.
+/// </summary>
+internal interface IHtmlDependentCompletionItemProvider : IRazorCompletionItemProvider
+{
+    /// <summary>
+    /// Returns <see langword="true"/> if this provider needs HTML completion labels for the
+    /// given <paramref name="context"/>.  When <see langword="false"/>, the phase-2 call can
+    /// be skipped entirely.
+    /// </summary>
+    bool NeedsHtmlCompletions(RazorCompletionContext context);
+
+    /// <summary>
+    /// Returns completion items that depend on HTML completion labels for deduplication or
+    /// discovery.
+    /// </summary>
+    ImmutableArray<RazorCompletionItem> GetHtmlDependentCompletionItems(RazorHtmlDependentCompletionContext context);
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/IRazorCompletionFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/IRazorCompletionFactsService.cs
@@ -12,11 +12,11 @@ internal interface IRazorCompletionFactsService
     /// <see cref="IHtmlDependentCompletionItemProvider"/>.
     /// </summary>
     /// <returns>
-    /// A tuple of the completion items and a flag indicating whether any HTML-dependent provider
+    /// The completion items and a flag indicating whether any HTML-dependent provider
     /// was skipped because it needs HTML completions.  The caller can use this to decide whether
     /// a follow-up <see cref="GetHtmlDependentCompletionItems"/> call is necessary.
     /// </returns>
-    (ImmutableArray<RazorCompletionItem> Items, bool AnyHtmlDependentSkipped) GetCompletionItems(RazorCompletionContext razorCompletionContext);
+    CompletionItemsResult GetCompletionItems(RazorCompletionContext razorCompletionContext);
 
     /// <summary>
     /// Returns completion items from <see cref="IHtmlDependentCompletionItemProvider"/>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/IRazorCompletionFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/IRazorCompletionFactsService.cs
@@ -7,5 +7,20 @@ namespace Microsoft.CodeAnalysis.Razor.Completion;
 
 internal interface IRazorCompletionFactsService
 {
-    ImmutableArray<RazorCompletionItem> GetCompletionItems(RazorCompletionContext razorCompletionContext);
+    /// <summary>
+    /// Returns completion items from all providers that are not
+    /// <see cref="IHtmlDependentCompletionItemProvider"/>.
+    /// </summary>
+    /// <returns>
+    /// A tuple of the completion items and a flag indicating whether any HTML-dependent provider
+    /// was skipped because it needs HTML completions.  The caller can use this to decide whether
+    /// a follow-up <see cref="GetHtmlDependentCompletionItems"/> call is necessary.
+    /// </returns>
+    (ImmutableArray<RazorCompletionItem> Items, bool AnyHtmlDependentSkipped) GetCompletionItems(RazorCompletionContext razorCompletionContext);
+
+    /// <summary>
+    /// Returns completion items from <see cref="IHtmlDependentCompletionItemProvider"/>
+    /// instances, with HTML labels available via the <paramref name="context"/>.
+    /// </summary>
+    ImmutableArray<RazorCompletionItem> GetHtmlDependentCompletionItems(RazorHtmlDependentCompletionContext context);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
@@ -12,6 +12,10 @@ using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Razor.Logging;
 
+#pragma warning disable IDE0065 // Misplaced using directive
+using RazorSyntaxNode = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode;
+#pragma warning restore IDE0065 // Misplaced using directive
+
 namespace Microsoft.CodeAnalysis.Razor.Completion;
 
 internal class RazorCompletionListProvider(
@@ -29,13 +33,93 @@ internal class RazorCompletionListProvider(
     };
 
     // virtual for tests
-    public virtual RazorVSInternalCompletionList? GetCompletionList(
+    public virtual (RazorVSInternalCompletionList? CompletionList, bool NeedsHtmlDependentPhase) GetCompletionList(
         RazorCodeDocument codeDocument,
         int absoluteIndex,
         VSInternalCompletionContext completionContext,
         VSInternalClientCapabilities clientCapabilities,
-        HashSet<string>? existingCompletions,
         RazorCompletionOptions completionOptions)
+    {
+        var razorCompletionContext = CreateCompletionContext(codeDocument, absoluteIndex, completionContext, completionOptions);
+
+        var (razorCompletionItems, needsHtmlDependentPhase) = _completionFactsService.GetCompletionItems(razorCompletionContext);
+
+        _logger.LogTrace($"Resolved {razorCompletionItems.Length} completion items.");
+
+        if (razorCompletionItems.Length == 0)
+        {
+            return (null, needsHtmlDependentPhase);
+        }
+
+        var completionList = CreateAndCacheCompletionList(codeDocument, razorCompletionItems, clientCapabilities);
+        return (completionList, needsHtmlDependentPhase);
+    }
+
+    // virtual for tests
+    public virtual RazorVSInternalCompletionList? GetHtmlDependentCompletionList(
+        RazorCodeDocument codeDocument,
+        int absoluteIndex,
+        VSInternalCompletionContext completionContext,
+        VSInternalClientCapabilities clientCapabilities,
+        RazorCompletionOptions completionOptions,
+        HashSet<string> htmlLabels)
+    {
+        var razorCompletionContext = CreateHtmlDependentCompletionContext(codeDocument, absoluteIndex, completionContext, completionOptions, htmlLabels);
+
+        var razorCompletionItems = _completionFactsService.GetHtmlDependentCompletionItems(razorCompletionContext);
+
+        _logger.LogTrace($"Resolved {razorCompletionItems.Length} HTML-dependent completion items.");
+
+        if (razorCompletionItems.Length == 0)
+        {
+            return null;
+        }
+
+        return CreateAndCacheCompletionList(codeDocument, razorCompletionItems, clientCapabilities);
+    }
+
+    private static RazorCompletionContext CreateCompletionContext(
+        RazorCodeDocument codeDocument,
+        int absoluteIndex,
+        VSInternalCompletionContext completionContext,
+        RazorCompletionOptions completionOptions)
+    {
+        var (reason, syntaxTree, tagHelperContext, owner) = ResolveCompletionParts(codeDocument, absoluteIndex, completionContext);
+
+        return new RazorCompletionContext(
+            codeDocument,
+            absoluteIndex,
+            owner,
+            syntaxTree,
+            tagHelperContext,
+            reason,
+            completionOptions);
+    }
+
+    private static RazorHtmlDependentCompletionContext CreateHtmlDependentCompletionContext(
+        RazorCodeDocument codeDocument,
+        int absoluteIndex,
+        VSInternalCompletionContext completionContext,
+        RazorCompletionOptions completionOptions,
+        HashSet<string> htmlLabels)
+    {
+        var (reason, syntaxTree, tagHelperContext, owner) = ResolveCompletionParts(codeDocument, absoluteIndex, completionContext);
+
+        return new RazorHtmlDependentCompletionContext(
+            codeDocument,
+            absoluteIndex,
+            owner,
+            syntaxTree,
+            tagHelperContext,
+            htmlLabels,
+            reason,
+            completionOptions);
+    }
+
+    private static (CompletionReason Reason, RazorSyntaxTree SyntaxTree, TagHelperDocumentContext TagHelperContext, RazorSyntaxNode? Owner) ResolveCompletionParts(
+        RazorCodeDocument codeDocument,
+        int absoluteIndex,
+        VSInternalCompletionContext completionContext)
     {
         var reason = completionContext.TriggerKind switch
         {
@@ -51,26 +135,14 @@ internal class RazorCompletionListProvider(
         var owner = syntaxTree.Root.FindInnermostNode(absoluteIndex, includeWhitespace: true, walkMarkersBack: true);
         owner = AbstractRazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, absoluteIndex);
 
-        var razorCompletionContext = new RazorCompletionContext(
-            codeDocument,
-            absoluteIndex,
-            owner,
-            syntaxTree,
-            tagHelperContext,
-            reason,
-            completionOptions,
-            existingCompletions);
+        return (reason, syntaxTree, tagHelperContext, owner);
+    }
 
-        var razorCompletionItems = _completionFactsService.GetCompletionItems(razorCompletionContext);
-
-        _logger.LogTrace($"Resolved {razorCompletionItems.Length} completion items.");
-
-        // No point caching or setting data for an empty completion list.
-        if (razorCompletionItems.Length == 0)
-        {
-            return null;
-        }
-
+    private RazorVSInternalCompletionList CreateAndCacheCompletionList(
+        RazorCodeDocument codeDocument,
+        ImmutableArray<RazorCompletionItem> razorCompletionItems,
+        VSInternalClientCapabilities clientCapabilities)
+    {
         var completionList = CreateLSPCompletionList(razorCompletionItems, clientCapabilities);
 
         // The completion list is cached and can be retrieved via this result id to enable the resolve completion functionality.

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
@@ -44,11 +44,11 @@ internal class RazorCompletionListProvider(
 
         if (result.Items.Length == 0)
         {
-            return (null, result.AnyHtmlDependentSkipped);
+            return (null, result.NeedsHtmlDependentCompletionItems);
         }
 
         var completionList = CreateAndCacheCompletionList(codeDocument, result.Items, clientCapabilities);
-        return (completionList, result.AnyHtmlDependentSkipped);
+        return (completionList, result.NeedsHtmlDependentCompletionItems);
     }
 
     // virtual for tests

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
@@ -12,10 +12,6 @@ using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Razor.Logging;
 
-#pragma warning disable IDE0065 // Misplaced using directive
-using RazorSyntaxNode = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode;
-#pragma warning restore IDE0065 // Misplaced using directive
-
 namespace Microsoft.CodeAnalysis.Razor.Completion;
 
 internal class RazorCompletionListProvider(
@@ -42,17 +38,17 @@ internal class RazorCompletionListProvider(
     {
         var razorCompletionContext = CreateCompletionContext(codeDocument, absoluteIndex, completionContext, completionOptions);
 
-        var (razorCompletionItems, needsHtmlDependentPhase) = _completionFactsService.GetCompletionItems(razorCompletionContext);
+        var result = _completionFactsService.GetCompletionItems(razorCompletionContext);
 
-        _logger.LogTrace($"Resolved {razorCompletionItems.Length} completion items.");
+        _logger.LogTrace($"Resolved {result.Items.Length} completion items.");
 
-        if (razorCompletionItems.Length == 0)
+        if (result.Items.Length == 0)
         {
-            return (null, needsHtmlDependentPhase);
+            return (null, result.AnyHtmlDependentSkipped);
         }
 
-        var completionList = CreateAndCacheCompletionList(codeDocument, razorCompletionItems, clientCapabilities);
-        return (completionList, needsHtmlDependentPhase);
+        var completionList = CreateAndCacheCompletionList(codeDocument, result.Items, clientCapabilities);
+        return (completionList, result.AnyHtmlDependentSkipped);
     }
 
     // virtual for tests
@@ -64,7 +60,8 @@ internal class RazorCompletionListProvider(
         RazorCompletionOptions completionOptions,
         HashSet<string> htmlLabels)
     {
-        var razorCompletionContext = CreateHtmlDependentCompletionContext(codeDocument, absoluteIndex, completionContext, completionOptions, htmlLabels);
+        var baseContext = CreateCompletionContext(codeDocument, absoluteIndex, completionContext, completionOptions);
+        var razorCompletionContext = new RazorHtmlDependentCompletionContext(baseContext, htmlLabels);
 
         var razorCompletionItems = _completionFactsService.GetHtmlDependentCompletionItems(razorCompletionContext);
 
@@ -84,43 +81,6 @@ internal class RazorCompletionListProvider(
         VSInternalCompletionContext completionContext,
         RazorCompletionOptions completionOptions)
     {
-        var (reason, syntaxTree, tagHelperContext, owner) = ResolveCompletionParts(codeDocument, absoluteIndex, completionContext);
-
-        return new RazorCompletionContext(
-            codeDocument,
-            absoluteIndex,
-            owner,
-            syntaxTree,
-            tagHelperContext,
-            reason,
-            completionOptions);
-    }
-
-    private static RazorHtmlDependentCompletionContext CreateHtmlDependentCompletionContext(
-        RazorCodeDocument codeDocument,
-        int absoluteIndex,
-        VSInternalCompletionContext completionContext,
-        RazorCompletionOptions completionOptions,
-        HashSet<string> htmlLabels)
-    {
-        var (reason, syntaxTree, tagHelperContext, owner) = ResolveCompletionParts(codeDocument, absoluteIndex, completionContext);
-
-        return new RazorHtmlDependentCompletionContext(
-            codeDocument,
-            absoluteIndex,
-            owner,
-            syntaxTree,
-            tagHelperContext,
-            htmlLabels,
-            reason,
-            completionOptions);
-    }
-
-    private static (CompletionReason Reason, RazorSyntaxTree SyntaxTree, TagHelperDocumentContext TagHelperContext, RazorSyntaxNode? Owner) ResolveCompletionParts(
-        RazorCodeDocument codeDocument,
-        int absoluteIndex,
-        VSInternalCompletionContext completionContext)
-    {
         var reason = completionContext.TriggerKind switch
         {
             CompletionTriggerKind.TriggerForIncompleteCompletions => CompletionReason.Invoked,
@@ -135,7 +95,14 @@ internal class RazorCompletionListProvider(
         var owner = syntaxTree.Root.FindInnermostNode(absoluteIndex, includeWhitespace: true, walkMarkersBack: true);
         owner = AbstractRazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, absoluteIndex);
 
-        return (reason, syntaxTree, tagHelperContext, owner);
+        return new RazorCompletionContext(
+            codeDocument,
+            absoluteIndex,
+            owner,
+            syntaxTree,
+            tagHelperContext,
+            reason,
+            completionOptions);
     }
 
     private RazorVSInternalCompletionList CreateAndCacheCompletionList(

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorHtmlDependentCompletionContext.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorHtmlDependentCompletionContext.cs
@@ -1,18 +1,21 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
 using RazorSyntaxNode = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion;
 
-internal record RazorCompletionContext(
+internal record RazorHtmlDependentCompletionContext(
     RazorCodeDocument CodeDocument,
     int AbsoluteIndex,
     RazorSyntaxNode? Owner,
     RazorSyntaxTree SyntaxTree,
     TagHelperDocumentContext TagHelperDocumentContext,
+    HashSet<string> HtmlLabels,
     CompletionReason Reason = CompletionReason.Invoked,
     RazorCompletionOptions Options = default)
+    : RazorCompletionContext(CodeDocument, AbsoluteIndex, Owner, SyntaxTree, TagHelperDocumentContext, Reason, Options)
 {
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorHtmlDependentCompletionContext.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorHtmlDependentCompletionContext.cs
@@ -2,20 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using Microsoft.AspNetCore.Razor.Language;
-using RazorSyntaxNode = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion;
 
-internal record RazorHtmlDependentCompletionContext(
-    RazorCodeDocument CodeDocument,
-    int AbsoluteIndex,
-    RazorSyntaxNode? Owner,
-    RazorSyntaxTree SyntaxTree,
-    TagHelperDocumentContext TagHelperDocumentContext,
-    HashSet<string> HtmlLabels,
-    CompletionReason Reason = CompletionReason.Invoked,
-    RazorCompletionOptions Options = default)
-    : RazorCompletionContext(CodeDocument, AbsoluteIndex, Owner, SyntaxTree, TagHelperDocumentContext, Reason, Options)
+internal record RazorHtmlDependentCompletionContext : RazorCompletionContext
 {
+    public HashSet<string> HtmlLabels { get; }
+
+    public RazorHtmlDependentCompletionContext(RazorCompletionContext baseContext, HashSet<string> htmlLabels)
+        : base(baseContext.CodeDocument, baseContext.AbsoluteIndex, baseContext.Owner, baseContext.SyntaxTree,
+               baseContext.TagHelperDocumentContext, baseContext.Reason, baseContext.Options)
+    {
+        HtmlLabels = htmlLabels;
+    }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionProvider.cs
@@ -31,6 +31,13 @@ internal class TagHelperCompletionProvider(ITagHelperCompletionService tagHelper
 
     public bool NeedsHtmlCompletions(RazorCompletionContext context)
     {
+        // .razor files never need HTML-dependent completions — tag helpers targeting HTML
+        // schema elements and OutputElementHint are legacy (.cshtml) concepts only.
+        if (context.CodeDocument.FileKind != RazorFileKind.Legacy)
+        {
+            return false;
+        }
+
         // Only the element completion path uses HTML labels to decide which tag helpers to
         // surface. The attribute path does not depend on HTML labels at all.
         var owner = CompletionContextHelper.AdjustSyntaxNodeForCompletion(context.Owner);
@@ -42,8 +49,6 @@ internal class TagHelperCompletionProvider(ITagHelperCompletionService tagHelper
             // completion visibility depends on HTML labels. This includes:
             // 1. Tag helpers targeting HTML schema elements (e.g., InputTagHelper targeting <input>)
             // 2. Tag helpers with a TagOutputHint (visibility depends on ExistingCompletions)
-            // Pure Blazor/component projects have neither, so all component completions can
-            // be served in phase 1.
             // Directive attribute descriptors (e.g., @bind on input) are excluded — they target HTML
             // element names but don't contribute element completions (same filter as
             // TagHelperCompletionService.GetElementCompletions).
@@ -115,7 +120,8 @@ internal class TagHelperCompletionProvider(ITagHelperCompletionService tagHelper
             // produces the right results.
             var stringifiedAttributes = TagHelperFacts.StringifyAttributes(elementAttributes);
             var containingElement = owner.Parent;
-            return GetElementCompletions(containingElement, containingTagNameToken.Content, stringifiedAttributes, context, []);
+            HashSet<string> noHtmlLabels = [];
+            return GetElementCompletions(containingElement, containingTagNameToken.Content, stringifiedAttributes, context, noHtmlLabels);
         }
 
         if (HtmlFacts.TryGetAttributeInfo(

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionProvider.cs
@@ -34,9 +34,35 @@ internal class TagHelperCompletionProvider(ITagHelperCompletionService tagHelper
         // Only the element completion path uses HTML labels to decide which tag helpers to
         // surface. The attribute path does not depend on HTML labels at all.
         var owner = CompletionContextHelper.AdjustSyntaxNodeForCompletion(context.Owner);
-        return owner is not null
+        if (owner is not null
             && HtmlFacts.TryGetElementInfo(owner, out var containingTagNameToken, out _, out _)
-            && containingTagNameToken.Span.IntersectsWith(context.AbsoluteIndex);
+            && containingTagNameToken.Span.IntersectsWith(context.AbsoluteIndex))
+        {
+            // Phase 2 is only needed when the document contains tag helpers whose element
+            // completion visibility depends on HTML labels. This includes:
+            // 1. Tag helpers targeting HTML schema elements (e.g., InputTagHelper targeting <input>)
+            // 2. Tag helpers with a TagOutputHint (visibility depends on ExistingCompletions)
+            // Pure Blazor/component projects have neither, so all component completions can
+            // be served in phase 1.
+            // Directive attribute descriptors (e.g., @bind on input) are excluded — they target HTML
+            // element names but don't contribute element completions (same filter as
+            // TagHelperCompletionService.GetElementCompletions).
+            foreach (var descriptor in context.TagHelperDocumentContext.TagHelpers)
+            {
+                if (descriptor.BoundAttributes.Any(static ba => ba.IsDirectiveAttribute))
+                {
+                    continue;
+                }
+
+                if (descriptor.TagOutputHint is not null
+                    || descriptor.TagMatchingRules.Any(static rule => HtmlFacts.IsHtmlTagName(rule.TagName)))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     public ImmutableArray<RazorCompletionItem> GetHtmlDependentCompletionItems(RazorHtmlDependentCompletionContext context)
@@ -80,14 +106,16 @@ internal class TagHelperCompletionProvider(ITagHelperCompletionService tagHelper
             return [];
         }
 
-        if (HtmlFacts.TryGetElementInfo(owner, out var containingTagNameToken, out _, out _) &&
+        if (HtmlFacts.TryGetElementInfo(owner, out var containingTagNameToken, out var elementAttributes, out _) &&
             containingTagNameToken.Span.IntersectsWith(context.AbsoluteIndex))
         {
-            // Element completions are handled by GetHtmlDependentCompletionItems in phase 2.
-            // This branch should not be reached because NeedsHtmlCompletions returns true
-            // for element positions, causing the caller to skip this method.
-            Debug.Fail("GetCompletionItems should not be called for element positions.");
-            return [];
+            // When NeedsHtmlCompletions returned false (pure Blazor/component scenario),
+            // element completions run here in phase 1 with no HTML labels. Component
+            // completions are always included regardless of HTML labels, so this still
+            // produces the right results.
+            var stringifiedAttributes = TagHelperFacts.StringifyAttributes(elementAttributes);
+            var containingElement = owner.Parent;
+            return GetElementCompletions(containingElement, containingTagNameToken.Content, stringifiedAttributes, context, []);
         }
 
         if (HtmlFacts.TryGetAttributeInfo(

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionProvider.cs
@@ -49,16 +49,8 @@ internal class TagHelperCompletionProvider(ITagHelperCompletionService tagHelper
             // completion visibility depends on HTML labels. This includes:
             // 1. Tag helpers targeting HTML schema elements (e.g., InputTagHelper targeting <input>)
             // 2. Tag helpers with a TagOutputHint (visibility depends on ExistingCompletions)
-            // Directive attribute descriptors (e.g., @bind on input) are excluded — they target HTML
-            // element names but don't contribute element completions (same filter as
-            // TagHelperCompletionService.GetElementCompletions).
             foreach (var descriptor in context.TagHelperDocumentContext.TagHelpers)
             {
-                if (descriptor.BoundAttributes.Any(static ba => ba.IsDirectiveAttribute))
-                {
-                    continue;
-                }
-
                 if (descriptor.TagOutputHint is not null
                     || descriptor.TagMatchingRules.Any(static rule => HtmlFacts.IsHtmlTagName(rule.TagName)))
                 {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionProvider.cs
@@ -112,8 +112,7 @@ internal class TagHelperCompletionProvider(ITagHelperCompletionService tagHelper
             // produces the right results.
             var stringifiedAttributes = TagHelperFacts.StringifyAttributes(elementAttributes);
             var containingElement = owner.Parent;
-            HashSet<string> noHtmlLabels = [];
-            return GetElementCompletions(containingElement, containingTagNameToken.Content, stringifiedAttributes, context, noHtmlLabels);
+            return GetElementCompletions(containingElement, containingTagNameToken.Content, stringifiedAttributes, context, htmlLabels: []);
         }
 
         if (HtmlFacts.TryGetAttributeInfo(

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionProvider.cs
@@ -17,7 +17,7 @@ using RazorSyntaxNode = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion;
 
-internal class TagHelperCompletionProvider(ITagHelperCompletionService tagHelperCompletionService) : IRazorCompletionItemProvider
+internal class TagHelperCompletionProvider(ITagHelperCompletionService tagHelperCompletionService) : IRazorCompletionItemProvider, IHtmlDependentCompletionItemProvider
 {
     // Internal for testing
     internal static readonly ImmutableArray<RazorCommitCharacter> MinimizedAttributeCommitCharacters = RazorCommitCharacter.CreateArray(["=", " "]);
@@ -29,7 +29,17 @@ internal class TagHelperCompletionProvider(ITagHelperCompletionService tagHelper
 
     private readonly ITagHelperCompletionService _tagHelperCompletionService = tagHelperCompletionService;
 
-    public ImmutableArray<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context)
+    public bool NeedsHtmlCompletions(RazorCompletionContext context)
+    {
+        // Only the element completion path uses HTML labels to decide which tag helpers to
+        // surface. The attribute path does not depend on HTML labels at all.
+        var owner = CompletionContextHelper.AdjustSyntaxNodeForCompletion(context.Owner);
+        return owner is not null
+            && HtmlFacts.TryGetElementInfo(owner, out var containingTagNameToken, out _, out _)
+            && containingTagNameToken.Span.IntersectsWith(context.AbsoluteIndex);
+    }
+
+    public ImmutableArray<RazorCompletionItem> GetHtmlDependentCompletionItems(RazorHtmlDependentCompletionContext context)
     {
         var owner = context.Owner;
         if (owner is null)
@@ -47,11 +57,35 @@ internal class TagHelperCompletionProvider(ITagHelperCompletionService tagHelper
         if (HtmlFacts.TryGetElementInfo(owner, out var containingTagNameToken, out var attributes, out _) &&
             containingTagNameToken.Span.IntersectsWith(context.AbsoluteIndex))
         {
-            // Trying to complete the element type
             var stringifiedAttributes = TagHelperFacts.StringifyAttributes(attributes);
             var containingElement = owner.Parent;
-            var elementCompletions = GetElementCompletions(containingElement, containingTagNameToken.Content, stringifiedAttributes, context);
-            return elementCompletions;
+            return GetElementCompletions(containingElement, containingTagNameToken.Content, stringifiedAttributes, context, context.HtmlLabels);
+        }
+
+        return [];
+    }
+
+    public ImmutableArray<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context)
+    {
+        var owner = context.Owner;
+        if (owner is null)
+        {
+            Debug.Fail("Owner should never be null.");
+            return [];
+        }
+
+        owner = CompletionContextHelper.AdjustSyntaxNodeForCompletion(owner);
+        if (owner is null)
+        {
+            return [];
+        }
+
+        if (HtmlFacts.TryGetElementInfo(owner, out var containingTagNameToken, out _, out _) &&
+            containingTagNameToken.Span.IntersectsWith(context.AbsoluteIndex))
+        {
+            // Element completions are handled by GetHtmlDependentCompletionItems in phase 2,
+            // where HTML labels are available for deduplication.
+            return [];
         }
 
         if (HtmlFacts.TryGetAttributeInfo(
@@ -60,7 +94,7 @@ internal class TagHelperCompletionProvider(ITagHelperCompletionService tagHelper
                 out var prefixLocation,
                 out var selectedAttributeName,
                 out var selectedAttributeNameLocation,
-                out attributes) &&
+                out var attributes) &&
             (selectedAttributeName is null ||
             selectedAttributeNameLocation?.IntersectsWith(context.AbsoluteIndex) == true ||
             (prefixLocation?.IntersectsWith(context.AbsoluteIndex) ?? false)))
@@ -207,13 +241,14 @@ internal class TagHelperCompletionProvider(ITagHelperCompletionService tagHelper
         RazorSyntaxNode containingElement,
         string containingTagName,
         ImmutableArray<KeyValuePair<string, string>> attributes,
-        RazorCompletionContext context)
+        RazorCompletionContext context,
+        HashSet<string> htmlLabels)
     {
         var ancestors = containingElement.Ancestors();
         var (ancestorTagName, ancestorIsTagHelper) = TagHelperFacts.GetNearestAncestorTagInfo(ancestors);
         var elementCompletionContext = new ElementCompletionContext(
             context.TagHelperDocumentContext,
-            context.ExistingCompletions,
+            htmlLabels,
             containingTagName,
             attributes,
             ancestorTagName,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionProvider.cs
@@ -83,8 +83,10 @@ internal class TagHelperCompletionProvider(ITagHelperCompletionService tagHelper
         if (HtmlFacts.TryGetElementInfo(owner, out var containingTagNameToken, out _, out _) &&
             containingTagNameToken.Span.IntersectsWith(context.AbsoluteIndex))
         {
-            // Element completions are handled by GetHtmlDependentCompletionItems in phase 2,
-            // where HTML labels are available for deduplication.
+            // Element completions are handled by GetHtmlDependentCompletionItems in phase 2.
+            // This branch should not be reached because NeedsHtmlCompletions returns true
+            // for element positions, causing the caller to skip this method.
+            Debug.Fail("GetCompletionItems should not be called for element positions.");
             return [];
         }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/TagHelperCompletionService.cs
@@ -179,6 +179,13 @@ internal class TagHelperCompletionService : ITagHelperCompletionService
 
         foreach (var possibleDescriptor in possibleChildTagHelpers)
         {
+            if (possibleDescriptor.BoundAttributes.Any(static boundAttribute => boundAttribute.IsDirectiveAttribute))
+            {
+                // Directive attribute tag helpers (e.g., @bind, @ref, @key) don't contribute element names
+                // to completion — they stand on their own as attribute completions.
+                continue;
+            }
+
             var addRuleCompletions = false;
             var checkAttributeRules = true;
             var outputHint = possibleDescriptor.TagOutputHint;
@@ -255,14 +262,6 @@ internal class TagHelperCompletionService : ITagHelperCompletionService
 
         static void UpdateCompletions(string tagName, TagHelperDescriptor possibleDescriptor, Dictionary<string, HashSet<TagHelperDescriptor>> elementCompletions, HashSet<TagHelperDescriptor>? tagHelperDescriptors = null)
         {
-            if (possibleDescriptor.BoundAttributes.Any(static boundAttribute => boundAttribute.IsDirectiveAttribute))
-            {
-                // This is a TagHelper that ultimately represents a DirectiveAttribute. In classic Razor TagHelper land TagHelpers with bound attribute descriptors
-                // are valuable to show in the completion list to understand what was possible for a certain tag; however, with Blazor directive attributes stand
-                // on their own and shouldn't be indicated at the element level completion.
-                return;
-            }
-
             HashSet<TagHelperDescriptor>? existingRuleDescriptors;
             if (tagHelperDescriptors is not null)
             {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/Completion/CompletionResult.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/Completion/CompletionResult.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis.Razor.Remote;
+
+namespace Microsoft.CodeAnalysis.Razor.Protocol.Completion;
+
+/// <summary>
+/// The result of a phase-1 completion call, carrying both the completion list and
+/// a flag indicating whether a follow-up phase-2 call is needed for HTML-dependent
+/// providers.
+/// </summary>
+/// <remarks>
+/// Static helpers are on <see cref="CompletionResults"/> to avoid a self-referential
+/// value type (struct containing <c>RemoteResponse&lt;CompletionResult&gt;</c>) which
+/// causes a <see cref="System.TypeLoadException"/> on .NET Framework.
+/// </remarks>
+internal record struct CompletionResult(
+    [property: JsonPropertyName("completionList")] RazorVSInternalCompletionList? CompletionList,
+    [property: JsonPropertyName("needsHtmlDependentPhase")] bool NeedsHtmlDependentPhase);
+
+/// <summary>
+/// Factory helpers for <see cref="CompletionResult"/> responses. Separated from the
+/// struct itself to avoid a self-referential generic value type layout cycle on .NET Framework.
+/// </summary>
+internal static class CompletionResults
+{
+    public static readonly RemoteResponse<CompletionResult> CallHtml
+        = new(StopHandling: false, new CompletionResult(null, NeedsHtmlDependentPhase: false));
+
+    public static RemoteResponse<CompletionResult> Create(RazorVSInternalCompletionList? completionList, bool needsHtmlDependentPhase)
+        => new(StopHandling: false, new CompletionResult(completionList, needsHtmlDependentPhase));
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteCompletionService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteCompletionService.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
@@ -27,7 +26,6 @@ internal interface IRemoteCompletionService : IRemoteJsonService
         CompletionPositionInfo positionInfo,
         VSInternalCompletionContext completionContext,
         RazorCompletionOptions razorCompletionOptions,
-        HashSet<string> existingHtmlCompletions,
         Guid correlationId,
         CancellationToken cancellationToken);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteCompletionService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteCompletionService.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.CodeAnalysis.Razor.Protocol.Completion;
 using Response = Microsoft.CodeAnalysis.Razor.Remote.RemoteResponse<Roslyn.LanguageServer.Protocol.RazorVSInternalCompletionList?>;
+using CompletionResponse = Microsoft.CodeAnalysis.Razor.Remote.RemoteResponse<Microsoft.CodeAnalysis.Razor.Protocol.Completion.CompletionResult>;
 
 namespace Microsoft.CodeAnalysis.Razor.Remote;
 
@@ -20,7 +21,7 @@ internal interface IRemoteCompletionService : IRemoteJsonService
         Position position,
         CancellationToken cancellationToken);
 
-    ValueTask<Response> GetCompletionAsync(
+    ValueTask<CompletionResponse> GetCompletionAsync(
         JsonSerializableRazorPinnedSolutionInfoWrapper solutionInfo,
         JsonSerializableDocumentId documentId,
         CompletionPositionInfo positionInfo,
@@ -33,5 +34,14 @@ internal interface IRemoteCompletionService : IRemoteJsonService
         JsonSerializableRazorPinnedSolutionInfoWrapper solutionInfo,
         JsonSerializableDocumentId id,
         VSInternalCompletionItem request,
+        CancellationToken cancellationToken);
+
+    ValueTask<Response> GetHtmlDependentCompletionsAsync(
+        JsonSerializableRazorPinnedSolutionInfoWrapper solutionInfo,
+        JsonSerializableDocumentId documentId,
+        CompletionPositionInfo positionInfo,
+        VSInternalCompletionContext completionContext,
+        RazorCompletionOptions razorCompletionOptions,
+        string[] htmlLabels,
         CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,6 +23,7 @@ using Microsoft.CodeAnalysis.Razor.Workspaces.Settings;
 using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
 using Response = Microsoft.CodeAnalysis.Razor.Remote.RemoteResponse<Roslyn.LanguageServer.Protocol.RazorVSInternalCompletionList?>;
+using CompletionResponse = Microsoft.CodeAnalysis.Razor.Remote.RemoteResponse<Microsoft.CodeAnalysis.Razor.Protocol.Completion.CompletionResult>;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor;
 
@@ -87,7 +86,7 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
         return new CompletionPositionInfo(ProvisionalTextEdit: null, positionInfo, shouldIncludeSnippets);
     }
 
-    public ValueTask<Response> GetCompletionAsync(
+    public ValueTask<CompletionResponse> GetCompletionAsync(
         JsonSerializableRazorPinnedSolutionInfoWrapper solutionInfo,
         JsonSerializableDocumentId documentId,
         CompletionPositionInfo positionInfo,
@@ -107,7 +106,7 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
                 cancellationToken),
             cancellationToken);
 
-    private async ValueTask<Response> GetCompletionAsync(
+    private async ValueTask<CompletionResponse> GetCompletionAsync(
         RemoteDocumentContext remoteDocumentContext,
         CompletionPositionInfo positionInfo,
         VSInternalCompletionContext completionContext,
@@ -125,7 +124,7 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
         if (!isCSharpTrigger && !isRazorTrigger)
         {
             // We don't have a valid trigger, so we can't provide completions.
-            return Response.CallHtml;
+            return CompletionResults.CallHtml;
         }
 
         var documentSnapshot = remoteDocumentContext.Snapshot;
@@ -154,32 +153,78 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
         }
 
         RazorVSInternalCompletionList? razorCompletionList = null;
+        var needsHtmlDependentPhase = false;
 
         if (isRazorTrigger)
         {
-            using var _ = HashSetPool<string>.GetPooledObject(out var existingCompletions);
-            if (csharpCompletionList is not null)
-            {
-                existingCompletions.UnionWith(csharpCompletionList.Items.Select((item) => item.Label));
-            }
-
-            razorCompletionList = _razorCompletionListProvider.GetCompletionList(
+            (razorCompletionList, needsHtmlDependentPhase) = _razorCompletionListProvider.GetCompletionList(
                 codeDocument,
                 documentPositionInfo.HostDocumentIndex,
                 completionContext,
                 _clientCapabilitiesService.ClientCapabilities,
-                existingCompletions,
                 razorCompletionOptions);
         }
 
-        // Merge won't return anything only if both completion lists passed in are null,
-        // in which case client should just proceed with HTML completion.
-        if (CompletionListMerger.Merge(razorCompletionList, csharpCompletionList) is not { } mergedCompletionList)
+        return CompletionResults.Create(
+            CompletionListMerger.Merge(razorCompletionList, csharpCompletionList),
+            needsHtmlDependentPhase);
+    }
+
+    public ValueTask<Response> GetHtmlDependentCompletionsAsync(
+        JsonSerializableRazorPinnedSolutionInfoWrapper solutionInfo,
+        JsonSerializableDocumentId documentId,
+        CompletionPositionInfo positionInfo,
+        VSInternalCompletionContext completionContext,
+        RazorCompletionOptions razorCompletionOptions,
+        string[] htmlLabels,
+        CancellationToken cancellationToken)
+        => RunServiceAsync(
+            solutionInfo,
+            documentId,
+            context => GetHtmlDependentCompletionsAsync(
+                context,
+                positionInfo,
+                completionContext,
+                razorCompletionOptions,
+                htmlLabels,
+                cancellationToken),
+            cancellationToken);
+
+    private async ValueTask<Response> GetHtmlDependentCompletionsAsync(
+        RemoteDocumentContext remoteDocumentContext,
+        CompletionPositionInfo positionInfo,
+        VSInternalCompletionContext completionContext,
+        RazorCompletionOptions razorCompletionOptions,
+        string[] htmlLabels,
+        CancellationToken cancellationToken)
+    {
+        var documentPositionInfo = positionInfo.DocumentPositionInfo;
+
+        if (!_triggerAndCommitCharacters.IsValidRazorTrigger(completionContext))
         {
             return Response.CallHtml;
         }
 
-        return Response.Results(mergedCompletionList);
+        var documentSnapshot = remoteDocumentContext.Snapshot;
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+
+        using var _ = HashSetPool<string>.GetPooledObject(out var existingCompletions);
+        existingCompletions.UnionWith(htmlLabels);
+
+        var razorCompletionList = _razorCompletionListProvider.GetHtmlDependentCompletionList(
+            codeDocument,
+            documentPositionInfo.HostDocumentIndex,
+            completionContext,
+            _clientCapabilitiesService.ClientCapabilities,
+            razorCompletionOptions,
+            existingCompletions);
+
+        if (razorCompletionList is null)
+        {
+            return Response.CallHtml;
+        }
+
+        return Response.Results(razorCompletionList);
     }
 
     private async ValueTask<RazorVSInternalCompletionList?> GetCSharpCompletionAsync(

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.CodeAnalysis.Razor.Completion.Delegation;
@@ -92,7 +93,6 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
         CompletionPositionInfo positionInfo,
         VSInternalCompletionContext completionContext,
         RazorCompletionOptions razorCompletionOptions,
-        HashSet<string> existingHtmlCompletions,
         Guid correlationId,
         CancellationToken cancellationToken)
         => RunServiceAsync(
@@ -103,7 +103,6 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
                 positionInfo,
                 completionContext,
                 razorCompletionOptions,
-                existingHtmlCompletions,
                 correlationId,
                 cancellationToken),
             cancellationToken);
@@ -113,7 +112,6 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
         CompletionPositionInfo positionInfo,
         VSInternalCompletionContext completionContext,
         RazorCompletionOptions razorCompletionOptions,
-        HashSet<string> existingDelegatedCompletions,
         Guid correlationId,
         CancellationToken cancellationToken)
     {
@@ -153,24 +151,24 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
                 positionInfo.ProvisionalTextEdit,
                 cancellationToken)
                 .ConfigureAwait(false);
-
-            if (csharpCompletionList is not null)
-            {
-                Debug.Assert(existingDelegatedCompletions.Count == 0, "Delegated completion should be either C# or HTML, not both");
-                existingDelegatedCompletions.UnionWith(csharpCompletionList.Items.Select((item) => item.Label));
-            }
         }
 
         RazorVSInternalCompletionList? razorCompletionList = null;
 
         if (isRazorTrigger)
         {
+            using var _ = HashSetPool<string>.GetPooledObject(out var existingCompletions);
+            if (csharpCompletionList is not null)
+            {
+                existingCompletions.UnionWith(csharpCompletionList.Items.Select((item) => item.Label));
+            }
+
             razorCompletionList = _razorCompletionListProvider.GetCompletionList(
                 codeDocument,
                 documentPositionInfo.HostDocumentIndex,
                 completionContext,
                 _clientCapabilitiesService.ClientCapabilities,
-                existingCompletions: existingDelegatedCompletions,
+                existingCompletions,
                 razorCompletionOptions);
         }
 

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.Test/Endpoints/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.Test/Endpoints/CohostDocumentCompletionEndpointTest.cs
@@ -428,6 +428,81 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
     }
 
     [Fact]
+    public async Task OutputElementHintTagHelper_ShownWhenHintElementIsPresent()
+    {
+        // A tag helper with [OutputElementHint("strong")] should appear in completions
+        // when HTML completions include "strong".
+        await VerifyCompletionListAsync(
+            input: """
+                @addTagHelper *, SomeProject
+                <$$
+                """,
+            completionContext: new VSInternalCompletionContext()
+            {
+                InvokeKind = VSInternalCompletionInvokeKind.Typing,
+                TriggerCharacter = "<",
+                TriggerKind = CompletionTriggerKind.TriggerCharacter
+            },
+            expectedItemLabels: ["my-bold", "strong"],
+            htmlItemLabels: ["strong"],
+            fileKind: RazorFileKind.Legacy,
+            additionalFiles: [("TestTagHelper.cs", """
+                using Microsoft.AspNetCore.Razor.TagHelpers;
+
+                namespace SomeProject
+                {
+                    [OutputElementHint("strong")]
+                    [HtmlTargetElement("my-bold")]
+                    public class BoldTagHelper : TagHelper
+                    {
+                        public override void Process(TagHelperContext context, TagHelperOutput output)
+                        {
+                            output.TagName = "strong";
+                        }
+                    }
+                }
+                """)]);
+    }
+
+    [Fact]
+    public async Task OutputElementHintTagHelper_NotShownWhenHintElementIsAbsent()
+    {
+        // A tag helper with [OutputElementHint("strong")] should NOT appear in completions
+        // when HTML completions do not include "strong".
+        await VerifyCompletionListAsync(
+            input: """
+                @addTagHelper *, SomeProject
+                <$$
+                """,
+            completionContext: new VSInternalCompletionContext()
+            {
+                InvokeKind = VSInternalCompletionInvokeKind.Typing,
+                TriggerCharacter = "<",
+                TriggerKind = CompletionTriggerKind.TriggerCharacter
+            },
+            expectedItemLabels: ["div"],
+            unexpectedItemLabels: ["my-bold"],
+            htmlItemLabels: ["div"],
+            fileKind: RazorFileKind.Legacy,
+            additionalFiles: [("TestTagHelper.cs", """
+                using Microsoft.AspNetCore.Razor.TagHelpers;
+
+                namespace SomeProject
+                {
+                    [OutputElementHint("strong")]
+                    [HtmlTargetElement("my-bold")]
+                    public class BoldTagHelper : TagHelper
+                    {
+                        public override void Process(TagHelperContext context, TagHelperOutput output)
+                        {
+                            output.TagName = "strong";
+                        }
+                    }
+                }
+                """)]);
+    }
+
+    [Fact]
     public async Task HtmlCompletionFailure_ReturnsIncompleteEmptyList()
     {
         // When the HTML language server fails to respond (e.g., not yet initialized on first document open),
@@ -1216,9 +1291,10 @@ public partial class CohostDocumentCompletionEndpointTest(ITestOutputHelper test
         bool autoInsertAttributeQuotes = true,
         bool commitElementsWithSpace = true,
         RazorFileKind? fileKind = null,
-        TimeSpan? retryTimeout = null)
+        TimeSpan? retryTimeout = null,
+        (string fileName, string contents)[]? additionalFiles = null)
     {
-        var document = CreateProjectAndRazorDocument(input.Text, fileKind);
+        var document = CreateProjectAndRazorDocument(input.Text, fileKind, additionalFiles: additionalFiles);
         var sourceText = await document.GetTextAsync(DisposalToken);
 
         ClientSettingsManager.Update(ClientAdvancedSettings.Default with { AutoInsertAttributeQuotes = autoInsertAttributeQuotes, CommitElementsWithSpace = commitElementsWithSpace });

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DefaultRazorCompletionFactsServiceTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DefaultRazorCompletionFactsServiceTest.cs
@@ -46,10 +46,10 @@ public class DefaultRazorCompletionFactsServiceTest(ITestOutputHelper testOutput
         var completionFactsService = new TestRazorCompletionFactsProvider(provider1, provider2);
 
         // Act
-        var (completionItems, _) = completionFactsService.GetCompletionItems(context);
+        var result = completionFactsService.GetCompletionItems(context);
 
         // Assert
-        Assert.Equal<RazorCompletionItem>([completionItem1, completionItem2], completionItems);
+        Assert.Equal<RazorCompletionItem>([completionItem1, completionItem2], result.Items);
     }
 
     private sealed class TestRazorCompletionFactsProvider(

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DefaultRazorCompletionFactsServiceTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DefaultRazorCompletionFactsServiceTest.cs
@@ -46,7 +46,7 @@ public class DefaultRazorCompletionFactsServiceTest(ITestOutputHelper testOutput
         var completionFactsService = new TestRazorCompletionFactsProvider(provider1, provider2);
 
         // Act
-        var completionItems = completionFactsService.GetCompletionItems(context);
+        var (completionItems, _) = completionFactsService.GetCompletionItems(context);
 
         // Assert
         Assert.Equal<RazorCompletionItem>([completionItem1, completionItem2], completionItems);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/RazorCompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/RazorCompletionListProviderTest.cs
@@ -456,11 +456,18 @@ public class RazorCompletionListProviderTest
     {
         // Arrange
         var documentPath = "C:/path/to/document.cshtml";
-        var builder = TagHelperDescriptorBuilder.CreateComponent("TestTagHelper", "TestAssembly");
-        builder.TypeName = "TestNamespace.TestTagHelper";
-        builder.TagMatchingRule(rule => rule.TagName = "Test");
-        var tagHelper = builder.Build();
-        var codeDocument = CreateCodeDocument("<", documentPath, [tagHelper]);
+        var componentBuilder = TagHelperDescriptorBuilder.CreateComponent("TestTagHelper", "TestAssembly");
+        componentBuilder.TypeName = "TestNamespace.TestTagHelper";
+        componentBuilder.TagMatchingRule(rule => rule.TagName = "Test");
+        var componentTagHelper = componentBuilder.Build();
+
+        // Add an HTML-targeting tag helper so NeedsHtmlCompletions returns true
+        // (pure component-only documents skip the HTML-dependent phase entirely).
+        var htmlBuilder = TagHelperDescriptorBuilder.Create("InputTagHelper", "TestAssembly");
+        htmlBuilder.TagMatchingRule(rule => rule.TagName = "input");
+        var htmlTagHelper = htmlBuilder.Build();
+
+        var codeDocument = CreateCodeDocument("<", documentPath, [componentTagHelper, htmlTagHelper]);
         var provider = new RazorCompletionListProvider(_completionFactsService, _completionListCache, _loggerFactory);
 
         // Act

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/RazorCompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/RazorCompletionListProviderTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
@@ -329,7 +329,7 @@ public class RazorCompletionListProviderTest
 
         // Act
         var completionList = provider.GetCompletionList(
-            codeDocument, absoluteIndex: cursorPosition, _defaultCompletionContext, _clientCapabilities, existingCompletions: null, _razorCompletionOptions);
+            codeDocument, absoluteIndex: cursorPosition, _defaultCompletionContext, _clientCapabilities, _razorCompletionOptions).CompletionList;
 
         // Assert
 
@@ -357,7 +357,7 @@ public class RazorCompletionListProviderTest
 
         // Act
         var completionList = provider.GetCompletionList(
-            codeDocument, absoluteIndex: 1, completionContext, _clientCapabilities, existingCompletions: null, _razorCompletionOptions);
+            codeDocument, absoluteIndex: 1, completionContext, _clientCapabilities, _razorCompletionOptions).CompletionList;
 
         // Assert
         Assert.NotNull(completionList);
@@ -387,7 +387,7 @@ public class RazorCompletionListProviderTest
 
         // Act
         var completionList = provider.GetCompletionList(
-            codeDocument, absoluteIndex: 1, completionContext, _clientCapabilities, existingCompletions: null, _razorCompletionOptions);
+            codeDocument, absoluteIndex: 1, completionContext, _clientCapabilities, _razorCompletionOptions).CompletionList;
 
         // Assert
         Assert.NotNull(completionList);
@@ -415,7 +415,7 @@ public class RazorCompletionListProviderTest
 
         // Act
         var completionList = provider.GetCompletionList(
-            codeDocument, absoluteIndex: 1, completionContext, _clientCapabilities, existingCompletions: null, _razorCompletionOptions);
+            codeDocument, absoluteIndex: 1, completionContext, _clientCapabilities, _razorCompletionOptions).CompletionList;
 
         // Assert
         Assert.Null(completionList);
@@ -440,7 +440,7 @@ public class RazorCompletionListProviderTest
 
         // Act
         var completionList = provider.GetCompletionList(
-            codeDocument, absoluteIndex: 1, completionContext, _clientCapabilities, existingCompletions: null, _razorCompletionOptions);
+            codeDocument, absoluteIndex: 1, completionContext, _clientCapabilities, _razorCompletionOptions).CompletionList;
 
         // Assert
         Assert.NotNull(completionList);
@@ -464,8 +464,8 @@ public class RazorCompletionListProviderTest
         var provider = new RazorCompletionListProvider(_completionFactsService, _completionListCache, _loggerFactory);
 
         // Act
-        var completionList = provider.GetCompletionList(
-            codeDocument, absoluteIndex: 1, _defaultCompletionContext, _clientCapabilities, existingCompletions: null, _razorCompletionOptions);
+        var completionList = provider.GetHtmlDependentCompletionList(
+            codeDocument, absoluteIndex: 1, _defaultCompletionContext, _clientCapabilities, _razorCompletionOptions, []);
 
         // Assert
         Assert.NotNull(completionList);
@@ -493,7 +493,7 @@ public class RazorCompletionListProviderTest
 
         // Act
         var completionList = provider.GetCompletionList(
-            codeDocument, absoluteIndex: 6, _defaultCompletionContext, _clientCapabilities, existingCompletions: null, _razorCompletionOptions);
+            codeDocument, absoluteIndex: 6, _defaultCompletionContext, _clientCapabilities, _razorCompletionOptions).CompletionList;
 
         // Assert
         Assert.NotNull(completionList);
@@ -525,7 +525,7 @@ public class RazorCompletionListProviderTest
 
         // Act
         var completionList = provider.GetCompletionList(
-            codeDocument, absoluteIndex: 6, _defaultCompletionContext, _clientCapabilities, existingCompletions: null, razorCompletionOptions);
+            codeDocument, absoluteIndex: 6, _defaultCompletionContext, _clientCapabilities, razorCompletionOptions).CompletionList;
 
         // Assert
         Assert.NotNull(completionList);

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadOnlyListExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadOnlyListExtensions.cs
@@ -188,36 +188,6 @@ internal static class ReadOnlyListExtensions
     }
 
     /// <summary>
-    ///  Returns the number of elements in a list that satisfy a condition.
-    /// </summary>
-    /// <param name="list">
-    ///  An <see cref="IReadOnlyList{T}"/> whose elements to apply the predicate to.
-    /// </param>
-    /// <param name="arg">
-    ///  An argument to pass to <paramref name="predicate"/>.
-    /// </param>
-    /// <param name="predicate">
-    ///  A function to test each element for a condition.
-    /// </param>
-    /// <returns>
-    ///  The number of elements in the list that satisfy the condition in the predicate.
-    /// </returns>
-    public static int Count<T, TArg>(this IReadOnlyList<T> list, TArg arg, Func<T, TArg, bool> predicate)
-    {
-        var count = 0;
-
-        foreach (var item in list.AsEnumerable())
-        {
-            if (predicate(item, arg))
-            {
-                count++;
-            }
-        }
-
-        return count;
-    }
-
-    /// <summary>
     ///  Determines whether all elements of a list satisfy a condition.
     /// </summary>
     /// <param name="list">

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadOnlyListExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadOnlyListExtensions.cs
@@ -188,6 +188,36 @@ internal static class ReadOnlyListExtensions
     }
 
     /// <summary>
+    ///  Returns the number of elements in a list that satisfy a condition.
+    /// </summary>
+    /// <param name="list">
+    ///  An <see cref="IReadOnlyList{T}"/> whose elements to apply the predicate to.
+    /// </param>
+    /// <param name="arg">
+    ///  An argument to pass to <paramref name="predicate"/>.
+    /// </param>
+    /// <param name="predicate">
+    ///  A function to test each element for a condition.
+    /// </param>
+    /// <returns>
+    ///  The number of elements in the list that satisfy the condition in the predicate.
+    /// </returns>
+    public static int Count<T, TArg>(this IReadOnlyList<T> list, TArg arg, Func<T, TArg, bool> predicate)
+    {
+        var count = 0;
+
+        foreach (var item in list.AsEnumerable())
+        {
+            if (predicate(item, arg))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    /// <summary>
     ///  Determines whether all elements of a list satisfy a condition.
     /// </summary>
     /// <param name="list">


### PR DESCRIPTION
Parallelize HTML and Razor completion with two-phase tag helper resolution

Problem

Razor completion in cohost mode runs HTML and Razor completion requests sequentially. The Razor call blocks on HTML completing first because tag helper element completions need HTML labels to determine which tag helpers to offer. This means total latency is always HTML + Razor, even though most Razor completions don't depend on HTML results.

Solution

Run HTML and Razor completion concurrently by splitting Razor completion into two phases:

Phase 1 (runs concurrently with HTML): Returns C# completions and all Razor completions except HTML-dependent providers. Also returns a NeedsHtmlDependentPhase flag indicating whether phase 2 is needed.

Phase 2 (runs after HTML completes, only when needed): Runs only IHtmlDependentCompletionItemProvider instances, passing HTML labels for context-aware tag helper filtering. Currently, only TagHelperCompletionProvider at element positions requires this phase — attribute positions and all other providers complete entirely in phase 1.

Total latency becomes max(HTML, Razor phase 1) + phase 2 instead of HTML + Razor. Phase 2 is skipped entirely for non-element positions and for pure Blazor/component projects where no tag helpers target HTML elements.

Key changes

 - CohostDocumentCompletionEndpoint: Launches Razor phase 1 and HTML concurrently via Task.WhenAll. After both complete, conditionally calls phase 2. Merges results via MergeCompletionLists, which uses two CompletionListMerger.Merge calls — first merging the two Razor phase lists, then merging the combined Razor list against HTML. This preserves list-level metadata (Data, ItemDefaults, CommitCharacters) and gives Razor commit characters precedence.
 - IHtmlDependentCompletionItemProvider: New interface deriving from IRazorCompletionItemProvider for providers that need HTML labels. Providers that don't need HTML labels require no changes.
 - RazorHtmlDependentCompletionContext: Derived completion context that adds HtmlLabels for phase 2, wrapping an existing RazorCompletionContext instead of duplicating context resolution. Replaces the old 
ExistingCompletions parameter on RazorCompletionContext.
 - CompletionResult: New record struct returned by phase 1 containing the completion list and NeedsHtmlDependentPhase flag, allowing the cohost to skip phase 2 when unnecessary.
 - CompletionItemsResult: New readonly record struct replacing the tuple return from IRazorCompletionFactsService.GetCompletionItems.
 - IRazorCompletionFactsService / RazorCompletionListProvider: Split into GetCompletionItems (phase 1) and GetHtmlDependentCompletionItems (phase 2). Phase 1 context creation is inlined; phase 2 reuses the same context with HtmlLabels added.
 - IRemoteCompletionService / RemoteCompletionService: Added GetHtmlDependentCompletionsAsync for the phase 2 remote call. Phase 1 no longer takes existingHtmlCompletions.
 - TagHelperCompletionProvider: NeedsHtmlCompletions inspects the document's tag helper descriptors to determine if phase 2 is actually needed. Directive attribute descriptors (e.g., @bind on <input>) are excluded, and only descriptors with TagOutputHint or HTML-targeting tag matching rules trigger phase 2. When phase 2 is not needed, element completions run in phase 1 with empty HTML labels (component completions are always included regardless).
 - TagHelperCompletionService: Lifted the IsDirectiveAttribute check from UpdateCompletions to the top of the GetElementCompletions foreach loop, filtering earlier and enabling the Blazor phase-skip optimization.
 - CompletionListMerger: Fixed inconsistent null/empty guard on second parameter; replaced LINQ Concat().ToArray() with collection expression spread for efficient codegen on both .NET Framework and .NET Core.

Testing

 - Two new cohost completion tests verify [OutputElementHint] behavior: a tag helper with [OutputElementHint("strong")] appears when HTML completions include "strong" and is absent when they don't.
 - Updated existing RazorCompletionListProviderTest element test to include an HTML-targeting tag helper alongside a component, exercising the phase-skip logic.

Observed timing improvements from I saw locally from bringing up completion in various locations:

| # | HTML | Razor | HtmlDependent | Overall | Saved |
 |---|------|-------|---------------|---------|-------|
 | 1 | 559 ms | 480 ms | 0 ms | 676 ms | 363 ms (35% ↓) |
 | 2 | 56 ms | 12 ms | 0 ms | 57 ms | 11 ms (16% ↓) |
 | 3 | 16 ms | 7 ms | 0 ms | 16 ms | 7 ms (30% ↓) |
 | 4 | 19 ms | 10 ms | 0 ms | 19 ms | 10 ms (34% ↓) |
 | 5 | 27 ms | 9 ms | 0 ms | 28 ms | 8 ms (22% ↓) |
 | 6 | 59 ms | 11 ms | 0 ms | 59 ms | 11 ms (16% ↓) |
 | 7 | 42 ms | 8 ms | 0 ms | 42 ms | 8 ms (16% ↓) |
 | 8 | 30 ms | 3 ms | 0 ms | 30 ms | 3 ms (9% ↓) |

Savings generally scale with Razor Phase 1 duration since it now overlaps with the HTML call rather than waiting for it to finish.

Speedometer results have come back on commit 3 and looked good for at least one test/scenario. Going to run again on commit 4 and am hoping to have the mudblazor element completion numbers improve too.

<img width="1232" height="750" alt="image" src="https://github.com/user-attachments/assets/22ca352a-33fc-41c3-92ef-2a54a239ffec" />