### PR TITLE
Log file kind and syntax tree in formatting logs

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/RazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/RazorFormattingService.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
@@ -92,10 +93,12 @@ internal class RazorFormattingService : IRazorFormattingService
         }
 
         var logger = _formattingLoggerFactory.CreateLogger(documentContext.Snapshot.FilePath, range is null ? "Full" : "Range");
+        logger?.LogObject("FileKind", documentContext.Snapshot.FileKind);
         logger?.LogObject("Options", options);
         logger?.LogObject("HtmlChanges", htmlChanges.SelectAsArray(e => e.ToRazorTextChange()));
         logger?.LogObject("Range", range);
         logger?.LogSourceText("InitialDocument", sourceText);
+        LogSyntaxTree(logger, codeDocument);
 
         var uri = documentContext.Uri;
         var documentSnapshot = documentContext.Snapshot;
@@ -285,10 +288,12 @@ internal class RazorFormattingService : IRazorFormattingService
         collapseChanges |= generatedDocumentChanges.Length == 1;
 
         var logger = _formattingLoggerFactory.CreateLogger(documentSnapshot.FilePath, formattingType);
+        logger?.LogObject("FileKind", documentSnapshot.FileKind);
         logger?.LogObject("Options", options);
         logger?.LogObject("Parameters", new { hostDocumentIndex, triggerCharacter, collapseChanges, includeCSharpLanguageFeatureEdits, validate });
         logger?.LogObject("GeneratedDocumentChanges", generatedDocumentChanges);
         logger?.LogSourceText("InitialDocument", codeDocument.Source.Text);
+        LogSyntaxTree(logger, codeDocument);
 
         var context = FormattingContext.CreateForOnTypeFormatting(
             documentSnapshot,
@@ -373,6 +378,18 @@ internal class RazorFormattingService : IRazorFormattingService
         }
 
         return changes;
+    }
+
+    private static void LogSyntaxTree(IFormattingLogger? logger, RazorCodeDocument codeDocument)
+    {
+        if (logger is null)
+        {
+            return;
+        }
+
+        var syntaxRoot = (RazorSyntaxNode)codeDocument.GetRequiredTagHelperRewrittenSyntaxTree().Root;
+        var serializedSyntaxTree = SyntaxSerializer.Default.Serialize(syntaxRoot);
+        logger.LogSourceText("SyntaxTree", SourceText.From(serializedSyntaxTree));
     }
 
     private static ImmutableArray<TextChange> ReplaceInChanges(ImmutableArray<TextChange> csharpChanges, string toFind, string replacement)

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/Formatting/FormattingLogTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/Formatting/FormattingLogTest.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -66,7 +67,7 @@ public class FormattingLogTest(ITestOutputHelper testOutput) : DocumentFormattin
     private async Task<TextEdit[]?> GetFormattingEditsAsync([CallerMemberName] string? testName = null)
     {
         var contents = GetResource(testName.AssumeNotNull(), "InitialDocument.txt").AssumeNotNull();
-        var document = CreateProjectAndRazorDocument(contents);
+        var document = CreateProjectAndRazorDocument(contents, fileKind: GetFileKind(testName));
         var sourceText = await document.GetTextAsync();
 
         var options = new RazorFormattingOptions() with
@@ -95,7 +96,60 @@ public class FormattingLogTest(ITestOutputHelper testOutput) : DocumentFormattin
         var formattingService = (RazorFormattingService)OOPExportProvider.GetExportedValue<IRazorFormattingService>();
         formattingService.GetTestAccessor().SetFormattingLoggerFactory(new TestFormattingLoggerFactory(TestOutputHelper));
 
-        return await GetFormattingEditsAsync(document, htmlEdits, span, options.CodeBlockBraceOnNextLine, options.AttributeIndentStyle, options.InsertSpaces, options.TabSize, options.CSharpSyntaxFormattingOptions.AssumeNotNull());
+        var edits = await GetFormattingEditsAsync(document, htmlEdits, span, options.CodeBlockBraceOnNextLine, options.AttributeIndentStyle, options.InsertSpaces, options.TabSize, options.CSharpSyntaxFormattingOptions.AssumeNotNull());
+
+        // If we have a FinalFormattedDocument from the user, then we want this test to fail until the bug is fixed, and the output changes
+        if (edits is not null && GetResource(testName, "FinalFormattedDocument.txt") is { } finalFormattedDocumentFile)
+        {
+            var finalFormattedDocument = finalFormattedDocumentFile.AssumeNotNull();
+            var formattedText = sourceText.WithChanges(edits.Select(sourceText.GetTextChange));
+
+            Assert.False(formattedText.ToString().Equals(finalFormattedDocument), "Formatted document should not match the expected final document, otherwise the bug has not been fixed. If this isn't true for this scenario, delete the FinalFormattedDocument test file.");
+        }
+
+        return edits;
+    }
+
+    private RazorFileKind? GetFileKind(string testName)
+    {
+        if (GetResource(testName, "FileKind.json") is { } fileKindFile)
+        {
+            return (RazorFileKind)JsonSerializer.Deserialize(fileKindFile, typeof(RazorFileKind), JsonHelpers.JsonSerializerOptions).AssumeNotNull();
+        }
+
+        // If we didn't get a file kind, see if we can get it from source mappings
+        if (GetResource(testName, "SourceMappings.json") is { } sourceMappings)
+        {
+            using var document = JsonDocument.Parse(sourceMappings);
+            if (document.RootElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var mapping in document.RootElement.EnumerateArray())
+                {
+                    if (mapping.TryGetProperty("OriginalSpan", out var originalSpan) &&
+                        originalSpan.TryGetProperty("FilePath", out var filePathProperty) &&
+                        filePathProperty.GetString() is { Length: > 0 } filePath)
+                    {
+                        return FileKinds.GetFileKindFromPath(filePath);
+                    }
+                }
+            }
+        }
+
+        // Last resort fallback, try getting the filetype out of the log messages
+        if (GetResource(testName, "Messages.txt") is { } messages)
+        {
+            const string marker = " formatting for ";
+            var index = messages.IndexOf(marker, StringComparison.Ordinal);
+            if (index >= 0)
+            {
+                var start = index + marker.Length;
+                var end = messages.IndexOfAny(['\r', '\n'], start);
+                var filePath = end >= 0 ? messages[start..end] : messages[start..];
+                return FileKinds.GetFileKindFromPath(filePath);
+            }
+        }
+
+        return null;
     }
 
     private string? GetResource(string testName, string name)


### PR DESCRIPTION
Fixes some issues found while investigating https://developercommunity.visualstudio.com/t/JavaScript-indentation-breaks-inside-Raz/11078750, namely:

* We weren't logging file kind, which means replaying in FormattingLogTest was getting different results due to different code-gen
* We could deduce from the logs that the issue was fixed by https://github.com/dotnet/razor/pull/12922 but if we had the SyntaxTree to confirm, it would have either proven it at best, or at worst the differences between the users syntax tree and our tests syntax tree would have given us a big head start for investigation.