### PR TITLE
Do not automatically trigger insertions

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -469,7 +469,7 @@ extends:
               -TsaPublish $True
 
       - stage: insert
-        dependsOn: publish_using_darc
+        trigger: manual
         displayName: Insert to VS
         jobs:
         - job: insert


### PR DESCRIPTION
Some servicing branches are only for the SDK and do not require a VS insertion.
