### PR TITLE
[release/insiders] Fix ArgumentOutOfRangeException when orphan end tag follows HTML text

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorTagHelperBinderPhaseTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorTagHelperBinderPhaseTest.cs
@@ -495,6 +495,45 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
         Assert.Equal<RazorDiagnostic>([initialError, expectedRewritingError], outputTree.Diagnostics);
     }
 
+    [Theory]
+    [InlineData("Hello</input>")]
+    [InlineData("Hello</input")]
+    [InlineData("text content</form>")]
+    [InlineData("foo</p>")]
+    public void Execute_OrphanEndTagAfterText_DoesNotThrow(string content)
+    {
+        var formTagHelper = CreateTagHelperDescriptor(
+            tagName: "form",
+            typeName: "TestFormTagHelper",
+            assemblyName: "TestAssembly");
+        var inputTagHelper = CreateTagHelperDescriptor(
+            tagName: "input",
+            typeName: "TestInputTagHelper",
+            assemblyName: "TestAssembly");
+        var pTagHelper = TagHelperDescriptorBuilder.CreateTagHelper("pTagHelper", "TestAssembly")
+            .TagMatchingRuleDescriptor(rule =>
+                rule
+                .RequireTagName("p")
+                .RequireAttributeDescriptor(attribute => attribute.Name("class")))
+            .Build();
+
+        var projectEngine = RazorProjectEngine.Create(builder =>
+        {
+            builder.SetTagHelpers(formTagHelper, inputTagHelper, pTagHelper);
+        });
+
+        var source = TestRazorSourceDocument.Create("@addTagHelper *, TestAssembly\r\n" + content, filePath: null);
+        var codeDocument = projectEngine.CreateCodeDocument(source);
+        var originalTree = RazorSyntaxTree.Parse(source);
+        codeDocument = codeDocument.WithSyntaxTree(originalTree);
+
+        codeDocument = projectEngine.ExecutePhase<DefaultRazorTagHelperContextDiscoveryPhase>(codeDocument);
+        codeDocument = projectEngine.ExecutePhase<DefaultRazorIntermediateNodeLoweringPhase>(codeDocument);
+        codeDocument = projectEngine.ExecutePhase<DefaultTagHelperResolutionPhase>(codeDocument);
+
+        Assert.NotNull(codeDocument.GetDocumentNode());
+    }
+
     private static string AssemblyA => "TestAssembly";
 
     private static string AssemblyB => "AnotherAssembly";

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultTagHelperResolutionPhase.LegacyTagHelperResolver.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultTagHelperResolutionPhase.LegacyTagHelperResolver.cs
@@ -942,6 +942,7 @@ internal partial class DefaultTagHelperResolutionPhase
             parent.Children.RemoveAt(index);
 
             var insertIndex = index;
+            IntermediateNode? firstInserted = null;
             foreach (var child in elementNode.Children)
             {
                 if (child is UnresolvedAttributeIntermediateNode unresolvedAttr)
@@ -952,23 +953,37 @@ internal partial class DefaultTagHelperResolutionPhase
                         foreach (var lowered in container.Children)
                         {
                             parent.Children.Insert(insertIndex++, lowered);
+                            firstInserted ??= lowered;
                         }
                     }
                     else if (unresolvedAttr.AsMarkupAttribute != null)
                     {
                         parent.Children.Insert(insertIndex++, unresolvedAttr.AsMarkupAttribute);
+                        firstInserted ??= unresolvedAttr.AsMarkupAttribute;
                     }
                     continue;
                 }
 
                 if (child is HtmlAttributeIntermediateNode htmlAttr)
                 {
+                    var beforeUnwrap = insertIndex;
                     insertIndex = UnwrapHtmlAttribute(parent, insertIndex, htmlAttr);
+                    if (firstInserted is null && insertIndex > beforeUnwrap)
+                    {
+                        firstInserted = parent.Children[beforeUnwrap];
+                    }
                     continue;
                 }
 
                 parent.Children.Insert(insertIndex++, child);
+                firstInserted ??= child;
             }
+
+            // Transfer element-level diagnostics onto the first inserted child *before*
+            // MergeAdjacentHtmlContent runs. The merge propagates diagnostics from a removed
+            // sibling into its merge target, so the diagnostics ride along even if
+            // firstInserted is consumed by a left-boundary merge into parent.Children[index - 1].
+            firstInserted?.AddDiagnosticsFromNode(elementNode);
 
             MergeAdjacentHtmlContent(parent, index, insertIndex);
         }
@@ -1132,6 +1147,11 @@ internal partial class DefaultTagHelperResolutionPhase
                 {
                     // Merge next into current.
                     current.Children.AddRange(next.Children);
+
+                    // Preserve any diagnostics on the removed sibling (e.g. orphan-tag
+                    // diagnostics attached to the first inserted child by ConvertToPlainElement)
+                    // so they aren't silently dropped.
+                    current.AddDiagnosticsFromNode(next);
                     if (current.Source is SourceSpan currentSource && next.Source is SourceSpan nextSource)
                     {
                         current.Source = MergeSourceSpans(currentSource, nextSource);

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultTagHelperResolutionPhase.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultTagHelperResolutionPhase.cs
@@ -160,11 +160,6 @@ internal partial class DefaultTagHelperResolutionPhase : RazorEnginePhaseBase
             TryAddMalformedEndTagDiagnostic(elementNode, tagName, binder, attributes, parent, tagHelperParent);
 
             _resolver.ConvertToPlainElement(parent, index, elementNode);
-
-            // Transfer element diagnostics to the converted/unwrapped node.
-            // ConvertToMarkupElement already copies diagnostics, but UnwrapElement does not,
-            // so this is needed for the legacy path.
-            parent.Children[index].AddDiagnosticsFromNode(elementNode);
             return;
         }
 
@@ -418,8 +413,8 @@ internal partial class DefaultTagHelperResolutionPhase : RazorEnginePhaseBase
 
     /// <summary>
     /// Post-pass that consolidates adjacent <see cref="HtmlContentIntermediateNode"/> children.
-    /// Merges tokens and extends source spans. Called after element unwrapping to clean up
-    /// fragmented content.
+    /// Merges tokens, extends source spans, and preserves diagnostics. Called after element
+    /// unwrapping to clean up fragmented content.
     /// </summary>
     private static void MergeAdjacentHtmlContent(IntermediateNode parent)
     {
@@ -429,6 +424,9 @@ internal partial class DefaultTagHelperResolutionPhase : RazorEnginePhaseBase
                 parent.Children[i + 1] is HtmlContentIntermediateNode next)
             {
                 current.Children.AddRange(next.Children);
+
+                // Preserve diagnostics from the removed sibling so they aren't silently dropped.
+                current.AddDiagnosticsFromNode(next);
                 if (current.Source is SourceSpan cs && next.Source is SourceSpan ns)
                 {
                     // Adjacent nodes are sequential, so next always ends after current.


### PR DESCRIPTION
Backport of dotnet/roslyn#83574 to `release/insiders`.

Fixes an `ArgumentOutOfRangeException` in `DefaultTagHelperResolutionPhase` when an orphan end tag (e.g. `&lt;/input&gt;` with no matching start tag) immediately follows HTML text content and the tag name matches a legacy tag helper.

Same class of bug as #13120, in a different code path.

## Repro

```razor
@addTagHelper *, MyAssembly
Hello</input>
```

## Root cause

The legacy resolver's `ConvertToPlainElement` removes the wrapper at `parent.Children[index]`, inserts the lowered HTML for the orphan end tag, then runs `MergeAdjacentHtmlContent` which absorbs the inserted HTML into the preceding text sibling and removes one item from `parent.Children`. The caller then indexed `parent.Children[index]` using the now-stale index, throwing `ArgumentOutOfRangeException`.

## Fix

Move the diagnostic transfer entirely into the legacy resolver (matching what the component resolver already does internally):

- `ConvertToPlainElement` tracks the first inserted child by reference and attaches `elementNode`'s diagnostics to it **before** `MergeAdjacentHtmlContent` runs.
- `MergeAdjacentHtmlContent` (both copies) now calls `current.AddDiagnosticsFromNode(next)` before removing the merged-away sibling, so any diagnostics ride along.
- The buggy `parent.Children[index].AddDiagnosticsFromNode(...)` call at the orphan-end-tag callsite is removed; the resolver now owns the transfer end-to-end. This also incidentally removes a pre-existing duplicate-diagnostic on the component orphan path.

Net diff is +27/-7 across 2 files. No API changes.
