### PR TITLE
Migrate DevDiv insertion token from PAT to WIF

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -19,8 +19,6 @@ variables:
 - group: DotNet-DevDiv-Insertion-Workflow-Variables
 - name: _DevDivDropAccessToken
   value: $(dn-bot-devdiv-drop-rw-code-rw)
-
-- group: DotNet-Roslyn-Insertion-Variables
 - name: Razor.GitHubEmail
   value: dotnet-build-bot@microsoft.com
 - name: Razor.GitHubToken
@@ -437,7 +435,6 @@ extends:
             displayName: Get Branch Name
           - template: /eng/pipelines/insert.yml@self
             parameters:
-              devDivAzdoToken: $(dn-bot-devdiv-build-e-code-full-release-e-packaging-r)
               dncEngAzureSubscription: 'DncEng Insertion: Roslyn and Razor'
               componentBuildProjectName: internal
               sourceBranch: "$(ComponentBranchName)"

--- a/eng/pipelines/insert.yml
+++ b/eng/pipelines/insert.yml
@@ -14,6 +14,7 @@
 
   - name: devDivAzdoToken
     type: string
+    default: ''
   - name: dncEngAzureSubscription
     type: string
     default: 'DncEng Insertion: Roslyn and Razor'
@@ -154,11 +155,16 @@ steps:
         # Explicitly acquire an AzDO token from the logged-in WIF service principal.
         # Do NOT rely on DefaultAzureCredential — it may pick up the agent's
         # managed identity instead of the WIF SP.
-        $dncengToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+        # The WIF SP (Roslyn-Razor-Insertion-DncEng) is enrolled in both dnceng and devdiv,
+        # so a single token works for both orgs.
+        $azdoToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
         if ($LASTEXITCODE -ne 0) {
-          Write-Error "Failed to acquire AzDO token for dnceng via az CLI"
+          Write-Error "Failed to acquire AzDO token via WIF service connection"
           exit 1
         }
+
+        # Use WIF token for DevDiv unless a legacy PAT is explicitly provided.
+        $devDivToken = if ([string]::IsNullOrWhiteSpace($Env:DevDivToken)) { $azdoToken } else { $Env:DevDivToken }
 
         $arguments = @(
           "create-insertion"
@@ -173,8 +179,8 @@ steps:
           "--update-assembly-versions"
           "--run-speedometer-in-validation", "${{ parameters.queueSpeedometerValidation }}"
           "--reviewer-guid", "6c25b447-1d90-4840-8fde-d8b22cb8733e"
-          "--devdiv-azdo-token", $Env:DevDivToken
-          "--dnceng-azdo-token", $dncengToken
+          "--devdiv-azdo-token", $devDivToken
+          "--dnceng-azdo-token", $azdoToken
           "--ci"
         )
 


### PR DESCRIPTION
## Summary
Migrate the `dn-bot-devdiv-build-e-code-full-release-e-packaging-r` PAT to WIF using the `Roslyn-Razor-Insertion-DncEng` SP.

## Changes
- `eng/pipelines/insert.yml`: Replace PAT-based auth with WIF token
- `azure-pipelines-official.yml`: Remove variable group and devDivAzdoToken parameter

Related: dnceng/internal WI 10089