### PR TITLE
[PAT Migration] Replace devdiv/engineering SC with WIF (WI 10126)

### DIFF
--- a/eng/restore-internal-tools.yml
+++ b/eng/restore-internal-tools.yml
@@ -1,7 +1,7 @@
 ﻿steps:
   - task: NuGetAuthenticate@1
     inputs:
-      nuGetServiceConnections: devdiv/dotnet-core-internal-tooling, devdiv/engineering
+      nuGetServiceConnections: devdiv/dotnet-core-internal-tooling, devdiv-engineering-feed-r-wif
       forceReinstallCredentialProvider: true
 
   # Needed for SBOM tool


### PR DESCRIPTION
Replace PAT-based `devdiv/engineering` NuGet service connection with WIF-backed `devdiv-engineering-feed-r-wif` in `NuGetAuthenticate@1`.

**Background:** PAT migration [WI 10126](https://dev.azure.com/dnceng/internal/_workitems/edit/10126). The old `devdiv/engineering` SC uses a PAT (dn-bot) for cross-org feed access. The new `devdiv-engineering-feed-r-wif` SC uses Workload Identity Federation backed by Entra app `dnceng-devdiv-engineering-feed-r-wif`.

**Change:** `eng/restore-internal-tools.yml`: `devdiv/engineering` → `devdiv-engineering-feed-r-wif`

**Note:** PR validation may still use the old YAML from `main`. The real verification happens on the first post-merge CI build.