### PR TITLE
[PAT Migration] Replace devdiv/engineering SC with WIF (WI 10126) - release/stable

### DIFF
--- a/eng/restore-internal-tools.yml
+++ b/eng/restore-internal-tools.yml
@@ -1,8 +1,14 @@
 ﻿steps:
   - task: NuGetAuthenticate@1
     inputs:
-      nuGetServiceConnections: devdiv/dotnet-core-internal-tooling, devdiv/engineering
+      nuGetServiceConnections: devdiv/dotnet-core-internal-tooling
       forceReinstallCredentialProvider: true
+
+  - task: NuGetAuthenticate@1
+    displayName: Authenticate devdiv/Engineering feed (WIF)
+    inputs:
+      azureDevOpsServiceConnection: devdiv-engineering-feed-r-wif
+      feedUrl: https://devdiv.pkgs.visualstudio.com/_packaging/Engineering/nuget/v3/index.json
 
   # Needed for SBOM tool
   - task: UseDotNet@2


### PR DESCRIPTION
## Summary

Replace PAT-based \devdiv/engineering\ NuGet service connection with WIF-backed \devdiv-engineering-feed-r-wif\ in \ng/restore-internal-tools.yml\.

## Why a separate NuGetAuthenticate task?

\NuGetAuthenticate@1\'s \
uGetServiceConnections\ input only accepts \ExternalNuGetFeed\-type connections. The WIF SC (\devdiv-engineering-feed-r-wif\) is type \workloadidentityuser\, which requires the \zureDevOpsServiceConnection\ + \eedUrl\ input pair instead.

This is the same pattern used in dotnet/roslyn PR #83918 (which corrected the reverted #83723 that made this exact mistake).

## Context

PAT migration [WI 10126](https://dev.azure.com/dnceng/internal/_workitems/edit/10126). Identity: \dnceng-devdiv-engineering-feed-r-wif\ Entra app.

Note: PR validation may still use old YAML from \elease/stable\. Real verification happens on the first post-merge CI build.