### PR TITLE
Migrate DevDiv insertion token from PAT to WIF on main

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -20,7 +20,6 @@ variables:
 - name: _DevDivDropAccessToken
   value: $(dn-bot-devdiv-drop-rw-code-rw)
 
-- group: DotNet-Roslyn-Insertion-Variables
 - name: Razor.GitHubEmail
   value: dotnet-build-bot@microsoft.com
 - name: Razor.GitHubToken
@@ -425,7 +424,6 @@ extends:
             displayName: Get Branch Name
           - template: /eng/pipelines/insert.yml@self
             parameters:
-              devDivAzdoToken: $(dn-bot-devdiv-build-e-code-full-release-e-packaging-r)
               dncEngAzureSubscription: 'DncEng Insertion: Roslyn and Razor'
               componentBuildProjectName: internal
               sourceBranch: "$(ComponentBranchName)"

--- a/eng/pipelines/insert.yml
+++ b/eng/pipelines/insert.yml
@@ -14,6 +14,7 @@
 
   - name: devDivAzdoToken
     type: string
+    default: ''
   - name: dncEngAzureSubscription
     type: string
     default: 'DncEng Insertion: Roslyn and Razor'
@@ -155,10 +156,15 @@ steps:
         # Do NOT rely on DefaultAzureCredential — it may pick up the agent's
         # managed identity instead of the WIF SP.
         $dncengToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
-        if ($LASTEXITCODE -ne 0) {
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($dncengToken)) {
           Write-Error "Failed to acquire AzDO token for dnceng via az CLI"
           exit 1
         }
+
+        # The WIF SP (Roslyn-Razor-Insertion-DncEng) is enrolled in both dnceng and
+        # devdiv, so a single token works for both orgs. Only fall back to a legacy
+        # PAT if one is explicitly provided via the devDivAzdoToken parameter.
+        $devDivToken = if ([string]::IsNullOrWhiteSpace($Env:DevDivToken)) { $dncengToken } else { $Env:DevDivToken }
 
         $arguments = @(
           "create-insertion"
@@ -173,7 +179,7 @@ steps:
           "--update-assembly-versions"
           "--run-speedometer-in-validation", "${{ parameters.queueSpeedometerValidation }}"
           "--reviewer-guid", "6c25b447-1d90-4840-8fde-d8b22cb8733e"
-          "--devdiv-azdo-token", $Env:DevDivToken
+          "--devdiv-azdo-token", $devDivToken
           "--dnceng-azdo-token", $dncengToken
           "--ci"
         )


### PR DESCRIPTION
Ports the WIF insertion pattern (already merged to the `release/*` branches) to `main`, so the last remaining consumer of the expired DevDiv insertion PAT is removed.

## Background

`main`'s official pipeline still authenticated the DevDiv side of the VS insertion with the PAT `dn-bot-devdiv-build-e-code-full-release-e-packaging-r`:
- It **expired 2026-05-18** and its Key Vault secret was **deleted 2026-07-11**.
- The release branches (`release/dev17.14`, `release/dev17.12`, `release/stable`, `release/insiders`) were already migrated to WIF and no longer reference it.
- `main` was only partially migrated: the dnceng token uses WIF via `AzureCLI@2`, but `--devdiv-azdo-token` was still fed the PAT via variable group `DotNet-Roslyn-Insertion-Variables` (VG 154), whose **only** variable is that expired PAT.

`main` rarely runs the insertion stage (last official insert was 2026-05-11), so this has been latent rather than an active outage — but it blocks deletion of VG 154.

## Changes

**`eng/pipelines/insert.yml`**
- Make `devDivAzdoToken` optional (`default: ''`).
- Fall back to the WIF-acquired dnceng token for `--devdiv-azdo-token` when no PAT is supplied. The insertion service principal (`Roslyn-Razor-Insertion-DncEng`) is enrolled in both `dnceng` and `devdiv`, so a single WIF token authenticates to both orgs. This matches the roslyn-tools reference `insert.yml`.

**`azure-pipelines-official.yml`**
- Remove the `DotNet-Roslyn-Insertion-Variables` variable group reference (only supplied the expired PAT).
- Remove the `devDivAzdoToken: $(dn-bot-devdiv-build-e-code-full-release-e-packaging-r)` template argument.

The `Razor.*` insertion variables were already defined inline and are unaffected (confirmed against the release branches, which build and insert without this variable group).

## Follow-up

After this merges and a green `main` official build confirms the "Insert to VS" stage authenticates to DevDiv via WIF, variable group 154 (`DotNet-Roslyn-Insertion-Variables`) can be deleted.

Tracked by [AB#11018](https://dnceng.visualstudio.com/internal/_workitems/edit/11018) (cleanup of migration [AB#10089](https://dnceng.visualstudio.com/internal/_workitems/edit/10089)).
