### PR TITLE
Resolve consecutive WithoutEndTag tag helpers as siblings

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/TagHelpersIntegrationTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/TagHelpersIntegrationTest.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.AspNetCore.Razor.Language.Intermediate;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests;
@@ -180,11 +182,130 @@ public class TagHelpersIntegrationTest() : IntegrationTestBase(layer: TestProjec
         Assert.NotEmpty(contribution.ContributedTagHelpers);
     }
 
+    [Fact]
+    [WorkItem("https://github.com/dotnet/aspnetcore/issues/68193")]
+    public void ConsecutiveWithoutEndTagTagHelpers_AllBind()
+    {
+        // The HTML parser nests consecutive unclosed tags (`<alpha><beta><gamma>` becomes
+        // alpha > beta > gamma). Each of these is a WithoutEndTag tag helper, so all three
+        // must still bind as siblings rather than only the first.
+        TagHelperCollection tagHelpers =
+        [
+            CreateTagHelperDescriptor(
+                tagName: "alpha",
+                typeName: "AlphaTagHelper",
+                assemblyName: "TestAssembly",
+                tagStructure: TagStructure.WithoutEndTag),
+            CreateTagHelperDescriptor(
+                tagName: "beta",
+                typeName: "BetaTagHelper",
+                assemblyName: "TestAssembly",
+                tagStructure: TagStructure.WithoutEndTag),
+            CreateTagHelperDescriptor(
+                tagName: "gamma",
+                typeName: "GammaTagHelper",
+                assemblyName: "TestAssembly",
+                tagStructure: TagStructure.WithoutEndTag),
+        ];
+
+        var projectEngine = CreateProjectEngine(builder => builder.SetTagHelpers(tagHelpers));
+        var projectItem = AddProjectItemFromText("""
+            @addTagHelper *, TestAssembly
+            <head>
+            <alpha>
+            <beta>
+            <gamma>
+            </head>
+            """, filePath: "Index.cshtml");
+
+        // Act
+        var codeDocument = projectEngine.Process(projectItem);
+
+        // Assert
+        var documentNode = codeDocument.GetRequiredDocumentNode();
+        var tagHelperNodes = documentNode.FindDescendantNodes<TagHelperIntermediateNode>();
+        Assert.Collection(tagHelperNodes,
+            node => Assert.Equal("alpha", node.TagName),
+            node => Assert.Equal("beta", node.TagName),
+            node => Assert.Equal("gamma", node.TagName));
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/aspnetcore/issues/68193")]
+    public void MixedNestedStartTagOnlyAndHtmlTagHelpers_AllResolveCorrectly()
+    {
+        // A deliberately tangled mix: a nestable tag helper (wrapper) containing consecutive
+        // WithoutEndTag helpers (alpha, beta) and a normal one (bold), followed by a second
+        // WithoutEndTag helper whose parser-nested body wraps a real HTML element (<div>) and
+        // yet another WithoutEndTag helper. Every tag helper must bind, real HTML (<section>,
+        // <div>) must stay markup, and document order must be preserved.
+        // Note: custom (non-void) tag names are required -- the HTML parser self-terminates
+        // real void elements like <input>/<br>, which wouldn't exercise the nesting-promotion path.
+        TagHelperCollection tagHelpers =
+        [
+            CreateTagHelperDescriptor(
+                tagName: "wrapper",
+                typeName: "WrapperTagHelper",
+                assemblyName: "TestAssembly"),
+            CreateTagHelperDescriptor(
+                tagName: "bold",
+                typeName: "BoldTagHelper",
+                assemblyName: "TestAssembly"),
+            CreateTagHelperDescriptor(
+                tagName: "alpha",
+                typeName: "AlphaTagHelper",
+                assemblyName: "TestAssembly",
+                tagStructure: TagStructure.WithoutEndTag),
+            CreateTagHelperDescriptor(
+                tagName: "beta",
+                typeName: "BetaTagHelper",
+                assemblyName: "TestAssembly",
+                tagStructure: TagStructure.WithoutEndTag),
+        ];
+
+        var projectEngine = CreateProjectEngine(builder => builder.SetTagHelpers(tagHelpers));
+        var projectItem = AddProjectItemFromText("""
+            @addTagHelper *, TestAssembly
+            <section>
+            <wrapper>
+            <alpha>
+            <beta>
+            <bold>text</bold>
+            </wrapper>
+            <alpha>
+            <div>plain html</div>
+            <beta>
+            </section>
+            """, filePath: "Index.cshtml");
+
+        // Act
+        var codeDocument = projectEngine.Process(projectItem);
+
+        // Assert: every tag helper binds, in document order, with the WithoutEndTag helpers
+        // promoted to siblings rather than swallowing what follows them.
+        var documentNode = codeDocument.GetRequiredDocumentNode();
+        var tagHelperNodes = documentNode.FindDescendantNodes<TagHelperIntermediateNode>();
+        Assert.Collection(tagHelperNodes,
+            node => Assert.Equal("wrapper", node.TagName),
+            node => Assert.Equal("alpha", node.TagName),
+            node => Assert.Equal("beta", node.TagName),
+            node => Assert.Equal("bold", node.TagName),
+            node => Assert.Equal("alpha", node.TagName),
+            node => Assert.Equal("beta", node.TagName));
+
+        // The real HTML elements must survive as literal markup, never bound as tag helpers.
+        var generatedCode = codeDocument.GetRequiredCSharpDocument().Text.ToString();
+        Assert.Contains("<section>", generatedCode);
+        Assert.Contains("<div>", generatedCode);
+        Assert.Contains("plain html", generatedCode);
+    }
+
     private static TagHelperDescriptor CreateTagHelperDescriptor(
         string tagName,
         string typeName,
         string assemblyName,
-        IEnumerable<Action<BoundAttributeDescriptorBuilder>>? attributes = null)
+        IEnumerable<Action<BoundAttributeDescriptorBuilder>>? attributes = null,
+        TagStructure tagStructure = TagStructure.Unspecified)
     {
         var builder = TagHelperDescriptorBuilder.CreateTagHelper(typeName, assemblyName);
         builder.SetTypeName(typeName, typeNamespace: null, typeNameIdentifier: null);
@@ -197,7 +318,9 @@ public class TagHelpersIntegrationTest() : IntegrationTestBase(layer: TestProjec
             }
         }
 
-        builder.TagMatchingRuleDescriptor(ruleBuilder => ruleBuilder.RequireTagName(tagName));
+        builder.TagMatchingRuleDescriptor(ruleBuilder => ruleBuilder
+            .RequireTagName(tagName)
+            .RequireTagStructure(tagStructure));
 
         var descriptor = builder.Build();
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultTagHelperResolutionPhase.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultTagHelperResolutionPhase.cs
@@ -202,6 +202,27 @@ internal partial class DefaultTagHelperResolutionPhase : RazorEnginePhaseBase
                 {
                     parent.Children.Insert(insertIdx++, elementNode.Children[i]);
                 }
+
+                // The promoted nodes were parsed as body children of this element because the
+                // HTML parser nests unclosed tags (e.g. `<a><b><c>` becomes a > b > c). Now that
+                // this element is bound as StartTagOnly, they are siblings that may themselves be
+                // tag helpers. The outer walker iterates in reverse and won't revisit these
+                // newly inserted positions, so resolve them here (in reverse, since resolving a
+                // promoted StartTagOnly sibling can insert further siblings after it).
+                for (var j = insertIdx - 1; j > index; j--)
+                {
+                    if (j < parent.Children.Count)
+                    {
+                        if (parent.Children[j] is UnresolvedElementIntermediateNode promotedElement)
+                        {
+                            ResolveElement(parent, j, promotedElement, binder, prefix, usedHelpers, in context);
+                        }
+                        else
+                        {
+                            ResolveElements(parent.Children[j], binder, prefix, usedHelpers, in context);
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Consecutive tag helpers declared with `TagStructure.WithoutEndTag` and written without a self-closing slash (e.g. `<meta-description><meta-keywords><head-custom>`) only bind the **first** helper. The rest are emitted as literal, unprocessed markup.

This is a regression from the deferred tag helper lowering work (#12957), which moved tag helper resolution after IR lowering. It was reported downstream as [dotnet/razor#13212](https://github.com/dotnet/razor/issues/13212), where a GrandNode app rendered a blank page (`Uncaught ReferenceError: Vue is not defined`) because the `<head>` script-registration tag helpers silently stopped running and the Vue bundle was never emitted.

## Root cause

The HTML parser nests consecutive unclosed tags, so `<a><b><c>` parses as `a > b > c`. When `DefaultTagHelperResolutionPhase.ResolveElement` binds `a` as a `StartTagOnly` helper, it promotes `a`'s parser-nested body children to be **siblings** inserted *after* `a`. But the element walker `ResolveElements` iterates children in reverse, so it has already moved past that position and never resolves the promoted siblings. They remain `UnresolvedElementIntermediateNode`s and are later unwrapped to literal HTML.

The `ConvertToPlainElement` path already re-resolves its promoted siblings; the direct `ResolveElement` `StartTagOnly` path was missing the equivalent step.

## Fix

After promoting the `StartTagOnly` element's children to siblings, resolve them in place (in reverse, since resolving a promoted `StartTagOnly` sibling can itself insert further siblings). This mirrors the existing pattern in `ConvertToPlainElementAndResolve`.

## Testing

Two new integration tests in `TagHelpersIntegrationTest`:

- `ConsecutiveWithoutEndTagTagHelpers_AllBind` — three consecutive `WithoutEndTag` helpers all bind.
- `MixedNestedStartTagOnlyAndHtmlTagHelpers_AllResolveCorrectly` — a tangled mix of a nestable helper, consecutive `WithoutEndTag` helpers, a normal helper, and real HTML (`<section>`, `<div>`); asserts every helper binds in document order and real markup is preserved.

Both fail without the fix (only the first helper binds) and pass with it. The existing tag helper suites remain green (Language `~TagHelper`: 953 pass; MVC extensions codegen/baseline: 178 pass).

> Note: this regression is also present in the shipping .NET 10 GA Razor compiler, so a servicing backport to `release/10.0.3xx` (and any 11 preview line) is likely warranted.
