### PR TITLE
Fix dev17.8 official pipeline infrastructure

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -19,7 +19,6 @@ variables:
   - name: _DevDivDropAccessToken
     value: $(dn-bot-devdiv-drop-rw-code-rw)
 
-  - group: DotNet-Roslyn-Insertion-Variables
   - name: Razor.GitHubEmail
     value: dotnet-build-bot@microsoft.com
   - name: Razor.GitHubToken
@@ -55,18 +54,6 @@ pr:
     include:
       - '*'
 
-schedules:
-  - cron: "0 8 23-29 * 0" # Fourth Sunday of each month at 8:00 UTC
-    displayName: "Monthly smoke test"
-    branches:
-      include:
-        - main
-        - release/*
-      exclude:
-        - ""
-    always: true # Run even if there have been no source code changes since the last successful scheduled run
-    batch: false # Do not run the pipeline if the previously scheduled run is in-progress
-
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -77,6 +64,8 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive, CFSClean, CFSClean2
     featureFlags:
       autoBaseline: true
     sdl:
@@ -467,31 +456,3 @@ extends:
               -TsaRepositoryName "Razor-Tooling"
               -TsaCodebaseName "Razor-Tooling"
               -TsaPublish $True
-
-      - stage: insert
-        trigger: manual
-        displayName: Insert to VS
-        jobs:
-        - job: insert
-          displayName: Insert to VS
-          pool:
-            name: NetCore1ESPool-Svc-Internal
-            demands: ImageOverride -equals windows.vs2022.amd64
-          steps:
-          - download: current
-            artifact: VSSetup
-          - powershell: |
-              $branchName = "$(Build.SourceBranch)".Substring("refs/heads/".Length)
-              Write-Host "##vso[task.setvariable variable=ComponentBranchName]$branchName"
-            displayName: Get Branch Name
-          - template: /eng/pipelines/insert.yml@self
-            parameters:
-              buildUserName: "dn-bot@microsoft.com"
-              buildPassword: $(dn-bot-devdiv-build-e-code-full-release-e-packaging-r)
-              componentUserName: "dn-bot@microsoft.com"
-              componentPassword: $(dn-bot-dnceng-build-e-code-full-release-e-packaging-r)
-              componentBuildProjectName: internal
-              sourceBranch: "$(ComponentBranchName)"
-              publishDataURI: "https://dev.azure.com/dnceng/internal/_apis/git/repositories/dotnet-razor/items?path=/eng/config/PublishData.json&api-version=6.0"
-              publishDataAccessToken: "$(System.AccessToken)"
-              dropPath: '$(Pipeline.Workspace)\VSSetup'

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -54,6 +54,18 @@ pr:
     include:
       - '*'
 
+schedules:
+  - cron: "0 8 23-29 * 0" # Fourth Sunday of each month at 8:00 UTC
+    displayName: "Monthly smoke test"
+    branches:
+      include:
+        - main
+        - release/*
+      exclude:
+        - ""
+    always: true # Run even if there have been no source code changes since the last successful scheduled run
+    batch: false # Do not run the pipeline if the previously scheduled run is in-progress
+
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -456,3 +468,31 @@ extends:
               -TsaRepositoryName "Razor-Tooling"
               -TsaCodebaseName "Razor-Tooling"
               -TsaPublish $True
+
+      - stage: insert
+        trigger: manual
+        displayName: Insert to VS
+        jobs:
+        - job: insert
+          displayName: Insert to VS
+          pool:
+            name: NetCore1ESPool-Svc-Internal
+            demands: ImageOverride -equals windows.vs2022.amd64
+          steps:
+          - download: current
+            artifact: VSSetup
+          - powershell: |
+              $branchName = "$(Build.SourceBranch)".Substring("refs/heads/".Length)
+              Write-Host "##vso[task.setvariable variable=ComponentBranchName]$branchName"
+            displayName: Get Branch Name
+          - template: /eng/pipelines/insert.yml@self
+            parameters:
+              buildUserName: "dn-bot@microsoft.com"
+              buildPassword: $(dn-bot-devdiv-build-e-code-full-release-e-packaging-r)
+              componentUserName: "dn-bot@microsoft.com"
+              componentPassword: $(dn-bot-dnceng-build-e-code-full-release-e-packaging-r)
+              componentBuildProjectName: internal
+              sourceBranch: "$(ComponentBranchName)"
+              publishDataURI: "https://dev.azure.com/dnceng/internal/_apis/git/repositories/dotnet-razor/items?path=/eng/config/PublishData.json&api-version=6.0"
+              publishDataAccessToken: "$(System.AccessToken)"
+              dropPath: '$(Pipeline.Workspace)\VSSetup'

--- a/src/Analyzers/Razor.Diagnostics.Analyzers.Test/Razor.Diagnostics.Analyzers.Test.csproj
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers.Test/Razor.Diagnostics.Analyzers.Test.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Razor.Diagnostics.Analyzers\Razor.Diagnostics.Analyzers.csproj" />
+    <ProjectReference Include="..\..\Compiler\test\Microsoft.AspNetCore.Razor.Test.Common\Microsoft.AspNetCore.Razor.Test.Common.Compiler.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Analyzers/Razor.Diagnostics.Analyzers.Test/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers.Test/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.IO;
+using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
@@ -14,6 +16,9 @@ public static partial class CSharpAnalyzerVerifier<TAnalyzer>
     {
         public Test()
         {
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Default.WithNuGetConfigFilePath(
+                Path.Combine(TestProject.GetRepoRoot(), "NuGet.config"));
+
             SolutionTransforms.Add((solution, projectId) =>
             {
                 var compilationOptions = solution.GetProject(projectId)!.CompilationOptions;

--- a/src/Compiler/test/Microsoft.AspNetCore.Razor.Test.Common/Language/TestProject.cs
+++ b/src/Compiler/test/Microsoft.AspNetCore.Razor.Test.Common/Language/TestProject.cs
@@ -32,6 +32,8 @@ public static class TestProject
         return projectDirectory;
     }
 
+    public static string GetRepoRoot() => SearchUp(AppContext.BaseDirectory, "global.json");
+
     public static string GetProjectDirectory(Type type)
     {
         var repoRoot = SearchUp(AppContext.BaseDirectory, "global.json");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/CSharpTestLspServerHelpers.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/CSharpTestLspServerHelpers.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -54,7 +55,10 @@ internal class CSharpTestLspServerHelpers
         var cSharpFiles = files.Select(f => new CSharpFile(f.Uri, f.SourceText));
 
         var exportProvider = RoslynTestCompositions.Roslyn.ExportProviderFactory.CreateExportProvider();
-        var metadataReferences = await ReferenceAssemblies.Default.ResolveAsync(language: LanguageNames.CSharp, cancellationToken);
+        var nugetConfigFilePath = Path.Combine(TestProject.GetRepoRoot(), "NuGet.config");
+        var metadataReferences = await ReferenceAssemblies.Default
+            .WithNuGetConfigFilePath(nugetConfigFilePath)
+            .ResolveAsync(language: LanguageNames.CSharp, cancellationToken);
         var workspace = CreateCSharpTestWorkspace(cSharpFiles, exportProvider, metadataReferences, razorSpanMappingService);
         var clientCapabilities = new VSInternalClientCapabilities
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/TestProject.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/TestProject.cs
@@ -10,6 +10,12 @@ namespace Microsoft.AspNetCore.Razor.Language;
 
 public static class TestProject
 {
+    public static string GetRepoRoot(bool useCurrentDirectory = false)
+    {
+        var baseDir = useCurrentDirectory ? Directory.GetCurrentDirectory() : AppContext.BaseDirectory;
+        return SearchUp(baseDir, "global.json");
+    }
+
     public static string GetProjectDirectory(Type type, bool useCurrentDirectory = false)
     {
         var baseDir = useCurrentDirectory ? Directory.GetCurrentDirectory() : AppContext.BaseDirectory;


### PR DESCRIPTION
Fixes the infrastructure failures in [official build 3031672](https://dev.azure.com/dnceng/internal/_build/results?buildId=3031672&view=results).

- Removes the reference to the deleted `DotNet-Roslyn-Insertion-Variables` group and the obsolete manual PAT-based VS insertion stage
- Enables the current 1ES network isolation policies, matching #12955, to allow analyzer tests to resolve packages

The YAML parses locally. Azure pipeline preview could not be run because the current user lacks `EditBuild` permission on pipeline 262.

[Test Run](https://dev.azure.com/dnceng/internal/_build/results?buildId=3049432&view=results)