### PR TITLE
[release/dev17.11] Migrate VS insertion authentication to WIF

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -18,7 +18,6 @@ variables:
 - name: _DevDivDropAccessToken
   value: $(dn-bot-devdiv-drop-rw-code-rw)
 
-- group: DotNet-Roslyn-Insertion-Variables
 - name: Razor.GitHubEmail
   value: dotnet-build-bot@microsoft.com
 - name: Razor.GitHubToken
@@ -424,10 +423,7 @@ extends:
             displayName: Get Branch Name
           - template: /eng/pipelines/insert.yml@self
             parameters:
-              buildUserName: "dn-bot@microsoft.com"
-              buildPassword: $(dn-bot-devdiv-build-e-code-full-release-e-packaging-r)
-              componentUserName: "dn-bot@microsoft.com"
-              componentPassword: $(dn-bot-dnceng-build-e-code-full-release-e-packaging-r)
+              dncEngAzureSubscription: 'DncEng Insertion: Roslyn and Razor'
               componentBuildProjectName: internal
               sourceBranch: "$(ComponentBranchName)"
               publishDataURI: "https://dev.azure.com/dnceng/internal/_apis/git/repositories/dotnet-razor/items?path=/eng/config/PublishData.json&api-version=6.0"

--- a/eng/pipelines/insert.yml
+++ b/eng/pipelines/insert.yml
@@ -12,14 +12,12 @@
     type: string
     default: 'true'
 
-  - name: buildUserName
+  - name: devDivAzdoToken
     type: string
-  - name: buildPassword
+    default: ''
+  - name: dncEngAzureSubscription
     type: string
-  - name: componentUserName
-    type: string
-  - name: componentPassword
-    type: string
+    default: 'DncEng Insertion: Roslyn and Razor'
 
   - name: publishDataURI
     type: string
@@ -47,11 +45,8 @@
 steps:
   - checkout: none
 
-  - task: NuGetCommand@2
-    displayName: 'Install RIT from Azure Artifacts'
-    inputs:
-      command: custom
-      arguments: 'install RoslynTools.VisualStudioInsertionTool -PreRelease -Source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
+  - script: dotnet tool install Microsoft.RoslynTools --tool-path .tools --prerelease --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json
+    displayName: 'Install roslyn-tools'
 
   - powershell: |
       $authorization = if ("" -ne $Env:PublishDataAccessToken) { "Bearer $Env:PublishDataAccessToken" } else { "" }
@@ -73,7 +68,7 @@ steps:
       Write-Host "##vso[task.setvariable variable=Template.TitleSuffix]$('')"
       Write-Host "##vso[task.setvariable variable=Template.ComponentAzdoUri]$('')"
       Write-Host "##vso[task.setvariable variable=Template.ComponentProjectName]$('')"
-      Write-Host "##vso[task.setvariable variable=Template.DropPath]$('(default)')"
+      Write-Host "##vso[task.setvariable variable=Template.DropPath]$('')"
 
       Write-Host "##vso[task.setvariable variable=Template.ComponentBranchName]$branchName"
       Write-Host "##vso[task.setvariable variable=Template.VSBranchName]$($branchData.vsBranch)"
@@ -99,15 +94,6 @@ steps:
       PublishDataAccessToken: ${{ parameters.publishDataAccessToken }}
 
   - powershell: |
-      # Set AzDO authorization template variables
-      Write-Host "Setting BuildUserName to $Env:BuildUserName"
-      Write-Host "##vso[task.setvariable variable=Template.BuildUserName]$Env:BuildUserName"
-      Write-Host "##vso[task.setvariable variable=Template.BuildPassword]$Env:BuildPassword"
-
-      Write-Host "Setting ComponentUserName to $Env:ComponentUserName"
-      Write-Host "##vso[task.setvariable variable=Template.ComponentUserName]$Env:ComponentUserName"
-      Write-Host "##vso[task.setvariable variable=Template.ComponentPassword]$Env:ComponentPassword"
-
       # Overwrite template variables with values passed into this template as parameters
       if ("" -ne $Env:CreateDraftPR)
       {
@@ -149,10 +135,6 @@ steps:
 
     displayName: Set Variables from Input Parameters
     env:
-      BuildUserName: ${{ parameters.buildUserName }}
-      BuildPassword: ${{ parameters.buildPassword }}
-      ComponentUserName: ${{ parameters.componentUserName }}
-      ComponentPassword: ${{ parameters.componentPassword }}
       CreateDraftPR: ${{ parameters.createDraftPR }}
       AutoComplete: ${{ parameters.autoComplete }}
       TitlePrefix: ${{ parameters.titlePrefix }}
@@ -161,40 +143,78 @@ steps:
       DropPath: ${{ parameters.dropPath }}
 
   # Now that everything is set, actually perform the insertion.
-  - powershell: |
-      mv RoslynTools.VisualStudioInsertionTool.* RIT
-      .\RIT\tools\net472\OneOffInsertion.ps1 `
-        -autoComplete "$(Template.AutoComplete)" `
-        -buildQueueName "$(Build.DefinitionName)" `
-        -cherryPick "(default)" `
-        -userName "$(Template.BuildUserName)" `
-        -password "$(Template.BuildPassword)" `
-        -componentUserName "$(Template.ComponentUserName)" `
-        -componentPassword "$(Template.ComponentPassword)" `
-        -componentAzdoUri "$(Template.ComponentAzdoUri)" `
-        -componentProjectName "$(Template.ComponentProjectName)" `
-        -componentName "Razor" `
-        -componentGitHubRepoName "dotnet/razor" `
-        -componentBranchName "$(Template.ComponentBranchName)" `
-        -createDraftPR "$(Template.CreateDraftPR)" `
-        -defaultValueSentinel "(default)" `
-        -dropPath "$(Template.DropPath)" `
-        -insertCore "false" `
-        -insertDevDiv "(default)" `
-        -insertionCount "1" `
-        -insertToolset "false" `
-        -titlePrefix "$(Template.TitlePrefix)" `
-        -titleSuffix "$(Template.TitleSuffix)" `
-        -queueValidation "true" `
-        -requiredValueSentinel "REQUIRED" `
-        -reviewerGUID "6c25b447-1d90-4840-8fde-d8b22cb8733e" `
-        -specificBuild "$(Build.BuildNumber)" `
-        -updateAssemblyVersions "true" `
-        -updateCoreXTLibraries "false" `
-        -visualStudioBranchName "$(Template.VSBranchName)" `
-        -writePullRequest "prid.txt" `
-        -queueSpeedometerValidation "${{ parameters.queueSpeedometerValidation }}"
-    displayName: 'Run OneOffInsertion.ps1'
+  # Uses AzureCLI@2 so that the WIF service connection's SP is logged in,
+  # then explicitly acquires an AzDO token via az CLI for dnceng auth.
+  - task: AzureCLI@2
+    displayName: 'Create VS Insertion PR'
+    inputs:
+      azureSubscription: ${{ parameters.dncEngAzureSubscription }}
+      scriptType: ps
+      scriptLocation: inlineScript
+      inlineScript: |
+        # Explicitly acquire an AzDO token from the logged-in WIF service principal.
+        # Do NOT rely on DefaultAzureCredential — it may pick up the agent's
+        # managed identity instead of the WIF SP.
+        $dncengToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($dncengToken)) {
+          Write-Error "Failed to acquire AzDO token for dnceng via az CLI"
+          exit 1
+        }
 
-  - script: 'echo. && echo. && type "prid.txt" && echo. && echo.'
-    displayName: 'Report PR URL'
+        # The WIF SP (Roslyn-Razor-Insertion-DncEng) is enrolled in both dnceng and
+        # devdiv, so a single token works for both orgs. Only fall back to a legacy
+        # PAT if one is explicitly provided via the devDivAzdoToken parameter.
+        $devDivToken = if ([string]::IsNullOrWhiteSpace($Env:DevDivToken)) { $dncengToken } else { $Env:DevDivToken }
+
+        $arguments = @(
+          "create-insertion"
+          "--insertion-name", "Razor"
+          "--vs-branch", "$(Template.VSBranchName)"
+          "--component-branch", "$(Template.ComponentBranchName)"
+          "--component-build-queue", "$(Build.DefinitionName)"
+          "--specific-build", "$(Build.BuildNumber)"
+          "--create-draft-pr", "$(Template.CreateDraftPR)"
+          "--set-auto-complete", "$(Template.AutoComplete)"
+          "--insert-corext-packages", "false"
+          "--update-assembly-versions"
+          "--run-speedometer-in-validation", "${{ parameters.queueSpeedometerValidation }}"
+          "--reviewer-guid", "6c25b447-1d90-4840-8fde-d8b22cb8733e"
+          "--devdiv-azdo-token", $devDivToken
+          "--dnceng-azdo-token", $dncengToken
+          "--ci"
+        )
+
+        $componentAzdoUri = "$(Template.ComponentAzdoUri)"
+        if ($componentAzdoUri -ne "")
+        {
+          $arguments += "--component-azdo-uri", $componentAzdoUri
+        }
+
+        $componentProjectName = "$(Template.ComponentProjectName)"
+        if ($componentProjectName -ne "")
+        {
+          $arguments += "--component-project", $componentProjectName
+        }
+
+        $dropPath = "$(Template.DropPath)"
+        if ($dropPath -ne "")
+        {
+          $arguments += "--build-drop-path", $dropPath
+        }
+
+        $titlePrefix = "$(Template.TitlePrefix)"
+        if ($titlePrefix -ne "")
+        {
+          $arguments += "--title-prefix", $titlePrefix
+        }
+
+        $titleSuffix = "$(Template.TitleSuffix)"
+        if ($titleSuffix -ne "")
+        {
+          $arguments += "--title-suffix", $titleSuffix
+        }
+
+        & ./.tools/roslyn-tools @arguments
+    env:
+      DevDivToken: ${{ parameters.devDivAzdoToken }}
+      DOTNET_ROLL_FORWARD: Major

--- a/src/Analyzers/Razor.Diagnostics.Analyzers.Test/Razor.Diagnostics.Analyzers.Test.csproj
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers.Test/Razor.Diagnostics.Analyzers.Test.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Razor.Diagnostics.Analyzers\Razor.Diagnostics.Analyzers.csproj" />
+    <ProjectReference Include="..\..\Shared\Microsoft.AspNetCore.Razor.Test.Common\Microsoft.AspNetCore.Razor.Test.Common.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Analyzers/Razor.Diagnostics.Analyzers.Test/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers.Test/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.IO;
+using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
@@ -14,6 +16,9 @@ public static partial class CSharpAnalyzerVerifier<TAnalyzer>
     {
         public Test()
         {
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Default.WithNuGetConfigFilePath(
+                Path.Combine(TestProject.GetRepoRoot(), "NuGet.config"));
+
             SolutionTransforms.Add((solution, projectId) =>
             {
                 var compilationOptions = solution.GetProject(projectId)!.CompilationOptions;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/CSharpTestLspServerHelpers.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/CSharpTestLspServerHelpers.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Test.Common.Mef;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.AspNetCore.Razor.Threading;
@@ -56,7 +57,10 @@ internal static class CSharpTestLspServerHelpers
         var csharpFiles = files.Select(f => new CSharpFile(f.Uri, f.SourceText));
 
         var exportProvider = TestComposition.Roslyn.ExportProviderFactory.CreateExportProvider();
-        var metadataReferences = (await ReferenceAssemblies.Default.ResolveAsync(language: LanguageNames.CSharp, cancellationToken))
+        var nugetConfigFilePath = Path.Combine(TestProject.GetRepoRoot(), "NuGet.config");
+        var metadataReferences = (await ReferenceAssemblies.Default
+            .WithNuGetConfigFilePath(nugetConfigFilePath)
+            .ResolveAsync(language: LanguageNames.CSharp, cancellationToken))
             // ComponentBase here comes from our ComponentShim project, not the real ASP.NET libraries. It's enough for the generated C#
             // in tests to at least compile better.
             .Add(ReferenceUtil.AspNetLatestComponents);

--- a/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/TestProject.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/TestProject.cs
@@ -50,6 +50,12 @@ public static class TestProject
         return projectDirectory;
     }
 
+    public static string GetRepoRoot(bool useCurrentDirectory = false)
+    {
+        var baseDir = useCurrentDirectory ? Directory.GetCurrentDirectory() : AppContext.BaseDirectory;
+        return SearchUp(baseDir, "global.json");
+    }
+
     public static string GetProjectDirectory(Type type, Layer layer, bool useCurrentDirectory = false)
     {
         var baseDir = useCurrentDirectory ? Directory.GetCurrentDirectory() : AppContext.BaseDirectory;


### PR DESCRIPTION
Backports the VS insertion authentication changes from #13010 and #13201.

Build [3031662](https://dev.azure.com/dnceng/internal/_build/results?buildId=3031662&view=results) failed during YAML validation because `DotNet-Roslyn-Insertion-Variables` no longer exists. That group supplied expired PAT credentials.

This change:
- migrates VS insertion from RIT/PAT authentication to `roslyn-tools` with the `DncEng Insertion: Roslyn and Razor` WIF service connection
- explicitly acquires the Azure DevOps token from the WIF-authenticated Azure CLI context
- reuses that token for both dnceng and devdiv
- removes only the obsolete `DotNet-Roslyn-Insertion-Variables` dependency
- preserves the monthly scheduled build
- preserves the manually triggered VS insertion stage

Validation: YAML syntax parsed successfully, `git diff --check` passed, and the release-only schedule and `trigger: manual` insertion configuration remain present.

[Test Run](https://dev.azure.com/dnceng/internal/_build/results?buildId=3049433&view=results)