### PR TITLE
[release/dev17.12] Use repository NuGet config in tests

### DIFF
--- a/src/Analyzers/Razor.Diagnostics.Analyzers.Test/Razor.Diagnostics.Analyzers.Test.csproj
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers.Test/Razor.Diagnostics.Analyzers.Test.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Razor.Diagnostics.Analyzers\Razor.Diagnostics.Analyzers.csproj" />
+    <ProjectReference Include="..\..\Shared\Microsoft.AspNetCore.Razor.Test.Common\Microsoft.AspNetCore.Razor.Test.Common.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Analyzers/Razor.Diagnostics.Analyzers.Test/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers.Test/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.IO;
+using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
@@ -14,6 +16,9 @@ public static partial class CSharpAnalyzerVerifier<TAnalyzer>
     {
         public Test()
         {
+            ReferenceAssemblies = Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.Default.WithNuGetConfigFilePath(
+                Path.Combine(TestProject.GetRepoRoot(), "NuGet.config"));
+
             SolutionTransforms.Add((solution, projectId) =>
             {
                 var compilationOptions = solution.GetProject(projectId)!.CompilationOptions;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/CSharpTestLspServerHelpers.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/CSharpTestLspServerHelpers.cs
@@ -6,9 +6,11 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Test.Common.Mef;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.AspNetCore.Razor.Threading;
@@ -60,7 +62,10 @@ internal static class CSharpTestLspServerHelpers
         var csharpFiles = files.Select(f => new CSharpFile(f.Uri, f.SourceText));
 
         var exportProvider = TestComposition.Roslyn.ExportProviderFactory.CreateExportProvider();
-        var metadataReferences = (await ReferenceAssemblies.Default.ResolveAsync(language: LanguageNames.CSharp, cancellationToken))
+        var nugetConfigFilePath = Path.Combine(TestProject.GetRepoRoot(), "NuGet.config");
+        var metadataReferences = (await ReferenceAssemblies.Default
+            .WithNuGetConfigFilePath(nugetConfigFilePath)
+            .ResolveAsync(language: LanguageNames.CSharp, cancellationToken))
             // ComponentBase here comes from our ComponentShim project, not the real ASP.NET libraries. It's enough for the generated C#
             // in tests to at least compile better.
             .Add(ReferenceUtil.AspNetLatestComponents);


### PR DESCRIPTION
Backports the applicable parts of #13157 to `release/dev17.12`.

The Linux leg of [official build 3031693](https://dev.azure.com/dnceng/internal/_build/results?buildId=3031693&view=results) had 123 failures because Roslyn test infrastructure attempted to resolve reference assemblies from `api.nuget.org`, which is blocked in official builds. Configure both affected call sites to use the repository `NuGet.config` and its approved Azure feeds.

Unlike #13157, this does not update analyzer-testing packages: the version already used by this branch supports `WithNuGetConfigFilePath`. The source-generator change from that PR is also inapplicable because that test does not exist on this branch.

## Testing

- `./eng/common/build.sh --restore --build --test --configuration Release --projects <Razor.Diagnostics.Analyzers.Test.csproj>`
- `./eng/common/build.sh --restore --build --test --configuration Release --projects <Microsoft.AspNetCore.Razor.LanguageServer.Test.csproj>`
[Test Rum](https://dev.azure.com/dnceng/internal/_build/results?buildId=3049406&view=results)