### PR TITLE
[release/dev18.0] Backport auth and NuGet infrastructure fixes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,12 +31,12 @@
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.10.2" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="$(_MicrosoftBuildPackageVersion)" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="$(_MicrosoftBuildPackageVersion)" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="1.1.3-beta1.24423.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="1.1.3-beta1.26059.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="$(MicrosoftCodeAnalysisCommonPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer" Version="$(MicrosoftCodeAnalysisCSharpAnalyzerTestingPackageVersion)" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.3-beta1.24423.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.3-beta1.26059.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.EditorFeatures" Version="$(MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Features" Version="$(MicrosoftCodeAnalysisCSharpFeaturesPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" />

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -17,8 +17,6 @@ variables:
 - group: DotNet-DevDiv-Insertion-Workflow-Variables
 - name: _DevDivDropAccessToken
   value: $(dn-bot-devdiv-drop-rw-code-rw)
-
-- group: DotNet-Roslyn-Insertion-Variables
 - name: Razor.GitHubEmail
   value: dotnet-build-bot@microsoft.com
 - name: Razor.GitHubToken
@@ -431,7 +429,6 @@ extends:
             displayName: Get Branch Name
           - template: /eng/pipelines/insert.yml@self
             parameters:
-              devDivAzdoToken: $(dn-bot-devdiv-build-e-code-full-release-e-packaging-r)
               dncEngAzureSubscription: 'DncEng Insertion: Roslyn and Razor'
               componentBuildProjectName: internal
               sourceBranch: "$(ComponentBranchName)"

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -16,7 +16,7 @@ variables:
   value: false
 - group: DotNet-DevDiv-Insertion-Workflow-Variables
 - name: _DevDivDropAccessToken
-  value: $(dn-bot-devdiv-drop-rw-code-rw)
+  value: ''
 - name: Razor.GitHubEmail
   value: dotnet-build-bot@microsoft.com
 - name: Razor.GitHubToken
@@ -275,6 +275,17 @@ extends:
 
             - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)"
               displayName: Setting VisualStudio.DropName variable
+
+            - task: AzureCLI@2
+              displayName: Get DevDiv Drop Access Token
+              inputs:
+                azureSubscription: 'dnceng-devdiv-drop-rw-code-rw-wif'
+                scriptType: pscore
+                scriptLocation: inlineScript
+                inlineScript: |
+                  $token = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+                  Write-Host "##vso[task.setvariable variable=_DevDivDropAccessToken;issecret=true]$token"
+              condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
 
             # Publishes setup VSIXes to a drop.
             # Note: The insertion tool looks for the display name of this task in the logs.

--- a/eng/pipelines/insert.yml
+++ b/eng/pipelines/insert.yml
@@ -14,6 +14,7 @@
 
   - name: devDivAzdoToken
     type: string
+    default: ''
   - name: dncEngAzureSubscription
     type: string
     default: 'DncEng Insertion: Roslyn and Razor'
@@ -154,11 +155,16 @@ steps:
         # Explicitly acquire an AzDO token from the logged-in WIF service principal.
         # Do NOT rely on DefaultAzureCredential — it may pick up the agent's
         # managed identity instead of the WIF SP.
-        $dncengToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+        # The WIF SP (Roslyn-Razor-Insertion-DncEng) is enrolled in both dnceng and devdiv,
+        # so a single token works for both orgs.
+        $azdoToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
         if ($LASTEXITCODE -ne 0) {
-          Write-Error "Failed to acquire AzDO token for dnceng via az CLI"
+          Write-Error "Failed to acquire AzDO token via WIF service connection"
           exit 1
         }
+
+        # Use WIF token for DevDiv unless a legacy PAT is explicitly provided.
+        $devDivToken = if ([string]::IsNullOrWhiteSpace($Env:DevDivToken)) { $azdoToken } else { $Env:DevDivToken }
 
         $arguments = @(
           "create-insertion"
@@ -173,8 +179,8 @@ steps:
           "--update-assembly-versions"
           "--run-speedometer-in-validation", "${{ parameters.queueSpeedometerValidation }}"
           "--reviewer-guid", "6c25b447-1d90-4840-8fde-d8b22cb8733e"
-          "--devdiv-azdo-token", $Env:DevDivToken
-          "--dnceng-azdo-token", $dncengToken
+          "--devdiv-azdo-token", $devDivToken
+          "--dnceng-azdo-token", $azdoToken
           "--ci"
         )
 

--- a/src/Analyzers/Razor.Diagnostics.Analyzers.Test/Razor.Diagnostics.Analyzers.Test.csproj
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers.Test/Razor.Diagnostics.Analyzers.Test.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Razor.Diagnostics.Analyzers\Razor.Diagnostics.Analyzers.csproj" />
+    <ProjectReference Include="..\..\Shared\Microsoft.AspNetCore.Razor.Test.Common\Microsoft.AspNetCore.Razor.Test.Common.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Analyzers/Razor.Diagnostics.Analyzers.Test/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
+++ b/src/Analyzers/Razor.Diagnostics.Analyzers.Test/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO;
+using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
@@ -14,6 +16,9 @@ public static partial class CSharpAnalyzerVerifier<TAnalyzer>
     {
         public Test()
         {
+            ReferenceAssemblies = ReferenceAssemblies.Default.WithNuGetConfigFilePath(
+                Path.Combine(TestProject.GetRepoRoot(), "NuGet.config"));
+
             SolutionTransforms.Add((solution, projectId) =>
             {
                 var compilationOptions = solution.GetProject(projectId)!.CompilationOptions;

--- a/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/ComponentParameterNullableWarningSuppressorTests.cs
+++ b/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/ComponentParameterNullableWarningSuppressorTests.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using System.IO;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Razor.Compiler.Analyzers;
 using Microsoft.CodeAnalysis.Testing;
@@ -407,7 +409,8 @@ namespace Microsoft.CodeAnalysis.Razor.Analyzers.Tests
             var test = new CSharpAnalyzerTest<ComponentParameterNullableWarningSuppressor, DefaultVerifier>
             {
                 TestCode = source,
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net80.WithNuGetConfigFilePath(
+                    Path.Combine(TestProject.GetRepoRoot(), "NuGet.config")),
                 CompilerDiagnostics = CompilerDiagnostics.Warnings,
                 DisabledDiagnostics = { "CS1591" }, // Missing XML comment for publicly visible type or member
             };

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/CSharpTestLspServerHelpers.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/CSharpTestLspServerHelpers.cs
@@ -6,9 +6,11 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Test.Common.Mef;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.AspNetCore.Razor.Threading;
@@ -70,7 +72,10 @@ internal static class CSharpTestLspServerHelpers
             .AddParts(typeof(RazorTestLanguageServerFactory))
             .ExportProviderFactory.CreateExportProvider();
 
-        var metadataReferences = await ReferenceAssemblies.Default.ResolveAsync(language: LanguageNames.CSharp, cancellationToken);
+        var nugetConfigFilePath = Path.Combine(TestProject.GetRepoRoot(), "NuGet.config");
+        var metadataReferences = await ReferenceAssemblies.Default
+            .WithNuGetConfigFilePath(nugetConfigFilePath)
+            .ResolveAsync(language: LanguageNames.CSharp, cancellationToken);
         metadataReferences = metadataReferences.Add(ReferenceUtil.AspNetLatestComponents);
 
         var workspace = CreateCSharpTestWorkspace(csharpFiles, exportProvider, metadataReferences, razorMappingService, multiTargetProject);


### PR DESCRIPTION
Backports build authentication and NuGet infrastructure fixes from `release/dev17.14`.

- Remove the retired `DotNet-Roslyn-Insertion-Variables` variable group, which prevents [official build 3048997](https://dev.azure.com/dnceng/internal/_build/results?buildId=3048997&view=results) from loading its YAML.
- Acquire the insertion token through the existing WIF service connection instead of the retired PAT.
- Acquire the VS drop upload token through `dnceng-devdiv-drop-rw-code-rw-wif` instead of the expired `dn-bot-devdiv-drop-rw-code-rw` PAT.
- Resolve test reference assemblies through the repository NuGet configuration so internal feeds are available.

Backports dotnet/razor#13146, dotnet/razor#13225, and dotnet/razor#13157.

[Test Run](https://dev.azure.com/dnceng/internal/_build/results?buildId=3050799&view=results)