### PR TITLE
[release/dev17.12] Migrate DevDiv drop token to WIF

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -16,7 +16,7 @@ variables:
   value: false
 - group: DotNet-DevDiv-Insertion-Workflow-Variables
 - name: _DevDivDropAccessToken
-  value: $(dn-bot-devdiv-drop-rw-code-rw)
+  value: ''
 - name: Razor.GitHubEmail
   value: dotnet-build-bot@microsoft.com
 - name: Razor.GitHubToken
@@ -275,6 +275,17 @@ extends:
 
             - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)"
               displayName: Setting VisualStudio.DropName variable
+
+            - task: AzureCLI@2
+              displayName: Get DevDiv Drop Access Token
+              inputs:
+                azureSubscription: 'dnceng-devdiv-drop-rw-code-rw-wif'
+                scriptType: pscore
+                scriptLocation: inlineScript
+                inlineScript: |
+                  $token = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+                  Write-Host "##vso[task.setvariable variable=_DevDivDropAccessToken;issecret=true]$token"
+              condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
 
             # Publishes setup VSIXes to a drop.
             # Note: The insertion tool looks for the display name of this task in the logs.


### PR DESCRIPTION
Backport of #13225.

Acquires an Azure DevOps token at runtime through the existing `dnceng-devdiv-drop-rw-code-rw-wif` service connection and exposes it to `1ES.MicroBuildVstsDrop@1` as the secret `_DevDivDropAccessToken` variable. This removes the dependency on the expired `dn-bot-devdiv-drop-rw-code-rw` PAT.

## Customer Impact

Official builds can publish the VS insertion drop again.

## Regression

- [x] Yes

The static PAT expired.

## Testing

- Parsed `azure-pipelines-official.yml` with Ruby Psych.
- Confirmed the static PAT reference is removed and the Release drop task consumes the WIF-acquired secret variable.
- The end-to-end drop upload requires an official build after merge.