### PR TITLE
[release/dev17.12] Remove obsolete DevDiv variable group

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -14,7 +14,6 @@ variables:
   value: 'All'
 - name: RunIntegrationTests
   value: false
-- group: DotNet-DevDiv-Insertion-Workflow-Variables
 - name: _DevDivDropAccessToken
   value: ''
 - name: Razor.GitHubEmail


### PR DESCRIPTION
Follow-up to #13231.

The `DotNet-DevDiv-Insertion-Workflow-Variables` group only supplies the retired `dn-bot-devdiv-drop-rw-code-rw` PAT. The release pipeline now acquires the DevDiv drop token through the `dnceng-devdiv-drop-rw-code-rw-wif` service connection, so the group is unused and can be removed instead of retained or reauthorized.

This cleanup was identified while investigating [official build 3051290](https://dev.azure.com/dnceng/internal/_build/results?buildId=3051290&view=results). It is not expected to alter that build’s asset-validation checkpoint behavior.

Validation: `git diff --check`; confirmed there are no remaining references to the variable group or retired PAT.